### PR TITLE
Soft Delete with custom names using Attribute

### DIFF
--- a/src/Abp.EntityFramework/Abp.EntityFramework.csproj
+++ b/src/Abp.EntityFramework/Abp.EntityFramework.csproj
@@ -72,6 +72,7 @@
     <Compile Include="EntityFramework\Repositories\EfRepositoryBase.cs" />
     <Compile Include="EntityFramework\Repositories\EfRepositoryBaseOfTEntityAndTPrimaryKey.cs" />
     <Compile Include="EntityFramework\IDbContextProvider.cs" />
+    <Compile Include="EntityFramework\SoftDeleting\SoftDeleteAttribute.cs" />
     <Compile Include="EntityFramework\SoftDeleting\SoftDeleteInterceptor.cs" />
     <Compile Include="EntityFramework\SoftDeleting\SoftDeleteQueryVisitor.cs" />
     <Compile Include="EntityFramework\Uow\EfUnitOfWork.cs" />

--- a/src/Abp.EntityFramework/EntityFramework/AbpDbContext.cs
+++ b/src/Abp.EntityFramework/EntityFramework/AbpDbContext.cs
@@ -3,9 +3,13 @@ using System.Data.Common;
 using System.Data.Entity;
 using System.Data.Entity.Core.Objects;
 using System.Data.Entity.Infrastructure;
+using System.Data.Entity.ModelConfiguration.Conventions;
+using System.Linq;
+
 using Abp.Configuration.Startup;
 using Abp.Domain.Entities;
 using Abp.Domain.Entities.Auditing;
+using Abp.EntityFramework.SoftDeleting;
 using Abp.Runtime.Session;
 
 namespace Abp.EntityFramework
@@ -87,6 +91,13 @@ namespace Abp.EntityFramework
         {
             base.OnModelCreating(modelBuilder);
             modelBuilder.Types<ISoftDelete>().Configure(c => c.HasTableAnnotation(AbpEfConsts.SoftDeleteCustomAnnotationName, true));
+
+            // Using SoftDelete Attribute
+            modelBuilder.Conventions.Add(
+                new AttributeToTableAnnotationConvention<SoftDeleteAttribute, string>(
+                    AbpEfConsts.SoftDeleteCustomAnnotationName,
+                    (type, attributes) => attributes.Single().ColumnName)
+                );
         }
 
         public override int SaveChanges()
@@ -158,7 +169,7 @@ namespace Abp.EntityFramework
 
                 softDeleteEntry.State = EntityState.Unchanged;
                 softDeleteEntry.Entity.IsDeleted = true;
-                
+
                 if (entry.Entity is IDeletionAudited)
                 {
                     var deletionAuditedEntry = entry.Cast<IDeletionAudited>();

--- a/src/Abp.EntityFramework/EntityFramework/SoftDeleting/SoftDeleteAttribute.cs
+++ b/src/Abp.EntityFramework/EntityFramework/SoftDeleting/SoftDeleteAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Abp.EntityFramework.SoftDeleting
+{
+    /// <summary>
+    ///     Attribute for soft delete.
+    /// </summary>
+    /// <remarks>
+    ///     usage : [SoftDelete("YourColumnName")]
+    /// </remarks>
+    public class SoftDeleteAttribute : Attribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the Abp.EntityFramework.SoftDeleting.SoftDeleteAttribute
+        ///     class.
+        /// </summary>
+        /// <param name="column">The column.</param>
+        public SoftDeleteAttribute(string column)
+        {
+            this.ColumnName = column;
+        }
+
+        /// <summary>
+        ///     Gets or sets the name of the column.
+        /// </summary>
+        /// <value>
+        ///     The name of the column.
+        /// </value>
+        public string ColumnName { get; set; }
+    }
+}

--- a/src/Abp.EntityFramework/EntityFramework/SoftDeleting/SoftDeleteInterceptor.cs
+++ b/src/Abp.EntityFramework/EntityFramework/SoftDeleting/SoftDeleteInterceptor.cs
@@ -1,11 +1,27 @@
-﻿using System.Data.Entity.Core.Common.CommandTrees;
+﻿using System.Collections.Generic;
+using System.Data.Entity.Core.Common.CommandTrees;
+using System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder;
 using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Infrastructure.Interception;
+using System.Linq;
 
 namespace Abp.EntityFramework.SoftDeleting
 {
+    /// <summary>
+    ///     A soft delete interceptor.
+    /// </summary>
+    /// <seealso cref="T:System.Data.Entity.Infrastructure.Interception.IDbCommandTreeInterceptor"/>
     internal class SoftDeleteInterceptor : IDbCommandTreeInterceptor
     {
+        /// <summary>
+        ///     This method is called after a new
+        ///     <see cref="T:System.Data.Entity.Core.Common.CommandTrees.DbCommandTree"/> has been
+        ///     created. The tree that is used after interception can be changed by setting
+        ///     <see cref="P:System.Data.Entity.Infrastructure.Interception.DbCommandTreeInterceptionContext.Result"/>
+        ///     while intercepting.
+        /// </summary>
+        /// <param name="interceptionContext">Contextual information associated with the call.</param>
+        /// <seealso cref="M:System.Data.Entity.Infrastructure.Interception.IDbCommandTreeInterceptor.TreeCreated(DbCommandTreeInterceptionContext)"/>
         public void TreeCreated(DbCommandTreeInterceptionContext interceptionContext)
         {
             if (interceptionContext.OriginalResult.DataSpace == DataSpace.SSpace)
@@ -15,6 +31,37 @@ namespace Abp.EntityFramework.SoftDeleting
                 {
                     var newQuery = queryCommand.Query.Accept(new SoftDeleteQueryVisitor());
                     interceptionContext.Result = new DbQueryCommandTree(queryCommand.MetadataWorkspace, queryCommand.DataSpace, newQuery);
+                }
+
+                var deleteCommand = interceptionContext.OriginalResult as DbDeleteCommandTree;
+                if (deleteCommand != null)
+                {
+                    MetadataProperty annotation = deleteCommand.Target.VariableType.EdmType.MetadataProperties
+                                .SingleOrDefault(p => p.Name.EndsWith("customannotation:" + AbpEfConsts.SoftDeleteCustomAnnotationName));
+
+                    if (annotation != null)
+                    {
+                        string column = annotation.Value is bool ? "IsDeleted" : annotation.Value.ToString();
+
+                        var setClauses = new List<DbModificationClause>();
+                        var table = (EntityType)deleteCommand.Target.VariableType.EdmType;
+                        if (table.Properties.Any(p => p.Name == column))
+                        {
+                            setClauses.Add(DbExpressionBuilder.SetClause(
+                                    deleteCommand.Target.VariableType.Variable(deleteCommand.Target.VariableName).Property(column),
+                                    DbExpression.FromBoolean(true)));
+                        }
+
+                        var update = new DbUpdateCommandTree(
+                            deleteCommand.MetadataWorkspace,
+                            deleteCommand.DataSpace,
+                            deleteCommand.Target,
+                            deleteCommand.Predicate,
+                            setClauses.AsReadOnly(),
+                            null);
+
+                        interceptionContext.Result = update;
+                    }
                 }
             }
         }


### PR DESCRIPTION
usage :

````c#
[SoftDelete("YourPropertyName")]
public class Test : Entity
{
    public bool YourPropertyName { get; set; }
}
````

No conflicts with the old way (ISoftDelete inteface) 
It uses IsDeleted property if the entity implements ISoftDelete inteface