### PR TITLE
Implemented the unAuthorizedRequest property of the AjaxResponse

### DIFF
--- a/src/Abp.Web.Api/WebApi/Controllers/Filters/AbpExceptionFilterAttribute.cs
+++ b/src/Abp.Web.Api/WebApi/Controllers/Filters/AbpExceptionFilterAttribute.cs
@@ -23,7 +23,9 @@ namespace Abp.WebApi.Controllers.Filters
 
             context.Response = context.Request.CreateResponse(
                 HttpStatusCode.OK,
-                new AjaxResponse(ErrorInfoBuilder.Instance.BuildForException(context.Exception))
+                new AjaxResponse(
+                    ErrorInfoBuilder.Instance.BuildForException(context.Exception),
+                    context.Exception is Abp.Authorization.AbpAuthorizationException)
                 );
 
             EventBus.Default.Trigger(this, new AbpHandledExceptionData(context.Exception));

--- a/src/Abp.Web.Mvc/Web/Mvc/Controllers/AbpHandleErrorAttribute.cs
+++ b/src/Abp.Web.Mvc/Web/Mvc/Controllers/AbpHandleErrorAttribute.cs
@@ -83,7 +83,10 @@ namespace Abp.Web.Mvc.Controllers
         private ActionResult GenerateAjaxResult(ExceptionContext context)
         {
             context.HttpContext.Response.StatusCode = 200;
-            return new AbpJsonResult(new MvcAjaxResponse(ErrorInfoBuilder.Instance.BuildForException(context.Exception)));
+            return new AbpJsonResult(
+                new MvcAjaxResponse(
+                    ErrorInfoBuilder.Instance.BuildForException(context.Exception),
+                    context.Exception is Abp.Authorization.AbpAuthorizationException));
         }
 
         private ActionResult GenerateNonAjaxResult(ExceptionContext context)

--- a/src/Abp.Web/Web/Models/DefaultErrorInfoConverter.cs
+++ b/src/Abp.Web/Web/Models/DefaultErrorInfoConverter.cs
@@ -60,6 +60,12 @@ namespace Abp.Web.Models
                        };
             }
 
+            if (exception is Abp.Authorization.AbpAuthorizationException)
+            {
+                var authorizationException = exception as Abp.Authorization.AbpAuthorizationException;
+                return new ErrorInfo(authorizationException.Message);
+            }
+
             return new ErrorInfo(AbpWebLocalizedMessages.InternalServerError);
         }
 


### PR DESCRIPTION
Implemented the unAuthorizedRequest property of the AjaxResponse when an AbpAuthorizationException is thrown.  Also passed the AbpAuthorizationException message along to the caller in the DefaultErrorInfoConverter.

Similar Issue: https://github.com/aspnetboilerplate/aspnetboilerplate/issues/196
