### PR TITLE
Implemented AbpValidationException validation error list narrative to ErrorInfo.Detail

### DIFF
--- a/src/Abp.Web.Resources/Localization/AbpWeb/AbpWeb.tr.xml
+++ b/src/Abp.Web.Resources/Localization/AbpWeb/AbpWeb.tr.xml
@@ -3,6 +3,7 @@
   <texts>
     <text name="InternalServerError" value="Sayfa işlenirken sunucu tarafında beklenmedik bir hata oluştu!" />
     <text name="ValidationError" value="İşleminiz geçerli değil!" />
+    <text name="ValidationNarrative" value="Aşağıdaki hatalar doğrulama sırasında tespit edilmiştir." />
     <text name="AreYouSure" value="Emin misiniz?" />
     <text name="Cancel" value="İptal" />
     <text name="Yes" value="Evet" />

--- a/src/Abp.Web.Resources/Localization/AbpWeb/AbpWeb.xml
+++ b/src/Abp.Web.Resources/Localization/AbpWeb/AbpWeb.xml
@@ -3,6 +3,7 @@
   <texts>
     <text name="InternalServerError" value="An internal error occured during your request!" />
     <text name="ValidationError" value="Your request is not valid!" />
+    <text name="ValidationNarrative" value="The following errors were detected during validation." />
     <text name="AreYouSure" value="Are you sure?" />
     <text name="Cancel" value="Cancel" />
     <text name="Yes" value="Yes" />

--- a/src/Abp.Web/Web/Localization/AbpWebLocalizedMessages.cs
+++ b/src/Abp.Web/Web/Localization/AbpWebLocalizedMessages.cs
@@ -14,6 +14,8 @@ namespace Abp.Web.Localization
         public static string InternalServerError { get { return L("InternalServerError"); } }
 
         public static string ValidationError { get { return L("ValidationError"); } }
+
+        public static string ValidationNarrative { get { return L("ValidationNarrative"); } }
         
         private static readonly ILocalizationSource Source;
 

--- a/src/Abp.Web/Web/Models/DefaultErrorInfoConverter.cs
+++ b/src/Abp.Web/Web/Models/DefaultErrorInfoConverter.cs
@@ -56,7 +56,8 @@ namespace Abp.Web.Models
             {
                 return new ErrorInfo(AbpWebLocalizedMessages.ValidationError)
                        {
-                           ValidationErrors = GetValidationErrorInfos(exception as AbpValidationException)
+                           ValidationErrors = GetValidationErrorInfos(exception as AbpValidationException),
+                           Details = GetValidationErrorNarrative(exception as AbpValidationException)
                        };
             }
 
@@ -100,6 +101,16 @@ namespace Abp.Web.Models
                 }
             }
 
+            //Additional info for AbpValidationException
+            if (exception is AbpValidationException)
+            {
+                var validationException = exception as AbpValidationException;
+                if (validationException.ValidationErrors.Count > 0)
+                {
+                    detailBuilder.AppendLine(GetValidationErrorNarrative(validationException));
+                }
+            }
+
             //Exception StackTrace
             if (!string.IsNullOrEmpty(exception.StackTrace))
             {
@@ -126,6 +137,19 @@ namespace Abp.Web.Models
                     AddExceptionToDetails(innerException, detailBuilder);
                 }
             }
+        }
+
+        private static string GetValidationErrorNarrative(AbpValidationException validationException)
+        {
+            StringBuilder detailBuilder = new StringBuilder();
+            detailBuilder.AppendLine(AbpWebLocalizedMessages.ValidationNarrative);
+            foreach (var validationResult in validationException.ValidationErrors)
+            {
+                detailBuilder.AppendFormat(" - {0}", validationResult.ErrorMessage);
+                detailBuilder.AppendLine();
+            }
+
+            return detailBuilder.ToString();
         }
 
         private static ValidationErrorInfo[] GetValidationErrorInfos(AbpValidationException validationException)


### PR DESCRIPTION
Updated the DefaultErrorInfoConverter to include the validation errors in a narrative format in ErrorInfo.Details so any messages run through the abp.message.error function may be more user friendly.  

The root message can be customized.  By default, the detail will provide a string such as 

    The following errors were detected during validation.
     - The FirstName field is required.
     - The LastName field is required.

The messages are also included if SendAllExceptionsToClients is enabled.