### PR TITLE
Improved UnitOfWork Error Handling

### DIFF
--- a/src/Abp/Domain/Uow/IActiveUnitOfWork.cs
+++ b/src/Abp/Domain/Uow/IActiveUnitOfWork.cs
@@ -24,7 +24,15 @@ namespace Abp.Domain.Uow
         /// This event is raised when this UOW is disposed.
         /// </summary>
         event EventHandler Disposed;
-        
+
+        /// <summary>
+        /// Called when an error occurs while executing a dynamic 
+        /// function in the context of this UnitOfWork so that the 
+        /// UnitOfWork may know about it and better error handling
+        /// may be implemented.
+        /// </summary>
+        void OnRuntimeError(Exception e);
+
         /// <summary>
         /// Gets if this unit of work is transactional.
         /// </summary>

--- a/src/Abp/Domain/Uow/UnitOfWorkBase.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkBase.cs
@@ -46,6 +46,19 @@ namespace Abp.Domain.Uow
         /// </summary>
         private Exception _exception;
 
+        /// <summary>
+        /// Allows callers to set the exception if there was an error
+        /// that occurred while performing the unit of work.
+        /// </summary>
+        internal void SetException(Exception exc)
+        {
+            // Only save the first exception
+            if (_exception == null)
+            {
+                _exception = exc;
+            }
+        }
+
         /// <inheritdoc/>
         public void Begin(UnitOfWorkOptions options)
         {
@@ -77,7 +90,7 @@ namespace Abp.Domain.Uow
             }
             catch (Exception ex)
             {
-                _exception = ex;
+                SetException(ex);
                 throw;
             }
         }
@@ -94,7 +107,7 @@ namespace Abp.Domain.Uow
             }
             catch (Exception ex)
             {
-                _exception = ex;
+                SetException(ex);
                 throw;
             }
         }

--- a/src/Abp/Domain/Uow/UnitOfWorkBase.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkBase.cs
@@ -195,5 +195,11 @@ namespace Abp.Domain.Uow
 
             _isCompleteCalledBefore = true;
         }
+
+        /// <inheritdoc/>
+        public virtual void OnRuntimeError(Exception e)
+        {
+            SetException(e);
+        }
     }
 }

--- a/src/Abp/Domain/Uow/UnitOfWorkInterceptor.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkInterceptor.cs
@@ -65,10 +65,9 @@ namespace Abp.Domain.Uow
                 catch (System.Exception ex)
                 {
                     // Save to unit of work so the error will propagate to the failed handler correctly
-                    UnitOfWorkBase unitOfWorkBase = _unitOfWorkManager.Current as UnitOfWorkBase;
-                    if (unitOfWorkBase != null)
+                    if (_unitOfWorkManager.Current != null)
                     {
-                        unitOfWorkBase.SetException(ex);
+                        _unitOfWorkManager.Current.OnRuntimeError(ex);
                     }
                     // rethrow
                     throw;
@@ -87,10 +86,9 @@ namespace Abp.Domain.Uow
             catch (System.Exception ex)
             {
                 // Save to unit of work so the error will propagate to the failed handler correctly
-                UnitOfWorkBase unitOfWorkBase = _unitOfWorkManager.Current as UnitOfWorkBase;
-                if (unitOfWorkBase != null)
+                if (_unitOfWorkManager.Current != null)
                 {
-                    unitOfWorkBase.SetException(ex);
+                    _unitOfWorkManager.Current.OnRuntimeError(ex);
                 }
                 // rethrow
                 throw;


### PR DESCRIPTION
I was running into a problem detecting error states when an error would occur during the initialization of the UnitOfWork.  I had previously tied into the Failed event, but noticed that the exception was sometimes null.  Upon inspection, I realized that the only time the exception would be set was when it was captured on Complete or CompleteAsync.  I investigated further and found the issue to be occurring in the UnitOfWorkInterceptor during PerformUow.  I captured the error there and set it through an internal SetException function on UnitOfWorkBase to allow us to propagate the exception to the Failed event handler.