### PR TITLE
Cache all types to avoid load all assemblies in the TypeFinder

### DIFF
--- a/src/Abp/Reflection/TypeFinder.cs
+++ b/src/Abp/Reflection/TypeFinder.cs
@@ -13,6 +13,8 @@ namespace Abp.Reflection
 
         public IAssemblyFinder AssemblyFinder { get; set; }
 
+        private static Dictionary<TypeFinder, List<Type>> _typeCache = new Dictionary<TypeFinder, List<Type>>();
+
         public TypeFinder()
         {
             AssemblyFinder = CurrentDomainAssemblyFinder.Instance;
@@ -31,7 +33,14 @@ namespace Abp.Reflection
 
         private List<Type> GetAllTypes()
         {
-            var allTypes = new List<Type>();
+            List<Type> allTypes;
+
+            if (_typeCache.TryGetValue(this, out allTypes))
+            {
+                return allTypes;
+            }
+
+            allTypes = new List<Type>();
 
             foreach (var assembly in AssemblyFinder.GetAllAssemblies().Distinct())
             {
@@ -61,6 +70,7 @@ namespace Abp.Reflection
                 }
             }
 
+            _typeCache[this] = allTypes;
             return allTypes;
         }
     }


### PR DESCRIPTION
TypeFinder would be used multi times when the web application first start. TypeFinder load all assemblies and get all types, It's very slow. So i think it need to cache the Types use Dictionary