### PR TITLE
SearchOption

### DIFF
--- a/src/Abp.Web/Web/WebAssemblyFinder.cs
+++ b/src/Abp.Web/Web/WebAssemblyFinder.cs
@@ -14,6 +14,11 @@ namespace Abp.Web
     public class WebAssemblyFinder : IAssemblyFinder
     {
         /// <summary>
+        /// The search option used to find assemblies in bin folder.
+        /// </summary>
+        public static SearchOption FindAssembliesSearchOption = SearchOption.TopDirectoryOnly;
+        
+        /// <summary>
         /// This return all assemblies in bin folder of the web application.
         /// </summary>
         /// <returns>List of assemblies</returns>
@@ -22,7 +27,7 @@ namespace Abp.Web
             var assembliesInBinFolder = new List<Assembly>();
 
             var allReferencedAssemblies = BuildManager.GetReferencedAssemblies().Cast<Assembly>().ToList();
-            var dllFiles = Directory.GetFiles(HttpRuntime.AppDomainAppPath + "bin\\", "*.dll", SearchOption.TopDirectoryOnly).ToList();
+            var dllFiles = Directory.GetFiles(HttpRuntime.AppDomainAppPath + "bin\\", "*.dll", FindAssembliesSearchOption).ToList();
 
             foreach (string dllFile in dllFiles)
             {


### PR DESCRIPTION
The search option used to find assemblies in bin folder was hardcoded and now can be set by all web applications inheriting AbpWebApplication. We can now find assemblies in the the bin folder and all subfolders (my application has modules in subfolders like portable areas).

Thank you.