### PR TITLE
Clone ErrorInfo for AjaxResponse and tweak the member names if necessary

### DIFF
--- a/src/Abp.Web/Web/Models/AjaxResponseOfTResult.cs
+++ b/src/Abp.Web/Web/Models/AjaxResponseOfTResult.cs
@@ -67,7 +67,7 @@ namespace Abp.Web.Models
         /// <param name="unAuthorizedRequest">Used to indicate that the current user has no privilege to perform this request</param>
         public AjaxResponse(ErrorInfo error, bool unAuthorizedRequest = false)
         {
-            Error = error;
+            Error = new ErrorInfo(error, forAjax: true);
             UnAuthorizedRequest = unAuthorizedRequest;
             Success = false;
         }

--- a/src/Abp.Web/Web/Models/ErrorInfo.cs
+++ b/src/Abp.Web/Web/Models/ErrorInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace Abp.Web.Models
 {
@@ -86,6 +87,20 @@ namespace Abp.Web.Models
             : this(message, details)
         {
             Code = code;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ErrorInfo"/>.
+        /// </summary>
+        /// <param name="instanceToClone">Instance to clone</param>
+        /// <param name="forAjax">Indicates whether the resultant instance is to be returned in AJAX response</param>
+        public ErrorInfo(ErrorInfo instanceToClone, bool forAjax = false)
+            : this(instanceToClone.Code, instanceToClone.Message, instanceToClone.Details)
+        {
+            ValidationErrors =
+                (instanceToClone.ValidationErrors != null)
+                ? instanceToClone.ValidationErrors.Select(ve => new ValidationErrorInfo(ve, forAjax: forAjax)).ToArray()
+                : null;
         }
     }
 }

--- a/src/Abp.Web/Web/Models/ValidationErrorInfo.cs
+++ b/src/Abp.Web/Web/Models/ValidationErrorInfo.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using Abp.Extensions;
 
 namespace Abp.Web.Models
 {
@@ -53,6 +55,22 @@ namespace Abp.Web.Models
         /// <param name="member">Related invalid member</param>
         public ValidationErrorInfo(string message, string member)
             : this(message, new[] { member })
+        {
+
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ValidationErrorInfo"/>.
+        /// </summary>
+        /// <param name="instanceToClone">Instance to clone</param>
+        /// <param name="forAjax">Indicates whether the resultant instance is to be returned in AJAX response</param>
+        public ValidationErrorInfo(ValidationErrorInfo instanceToClone, bool forAjax = false)
+            : this(
+                instanceToClone.Message,
+                (instanceToClone.Members != null)
+                    ? instanceToClone.Members.Select(m => (!forAjax) ? m : m.ToCamelCase()).ToArray()
+                    : null
+            )
         {
 
         }


### PR DESCRIPTION
It seems I'm too late with my PR which is supposed to fix #599. I send it anyway for your consideration. Instead of modifying `DefaultErrorInfoConverter` as in your fix, I changed the `AjaxResponse` ctor. That approach might be preferable if `DefaultErrorInfoConverter` is supposed to be used in non-AJAX scenarios - your change made it AJAX-only.