### PR TITLE
Update AutoMapExtensions.cs

### DIFF
--- a/src/Abp.AutoMapper/AutoMapper/AutoMapExtensions.cs
+++ b/src/Abp.AutoMapper/AutoMapper/AutoMapExtensions.cs
@@ -12,7 +12,7 @@ namespace Abp.AutoMapper
         /// <param name="source">Source object</param>
         public static TDestination MapTo<TDestination>(this object source)
         {
-            return Mapper.Map<TDestination>(source);
+            return Mapper.Map<TDestination>(source, opts => opts.CreateMissingTypeMaps = true);
         }
 
         /// <summary>


### PR DESCRIPTION
When we map entities to dtos in runtime we have "Missing type map configuration or unsupported mapping" exception if entity is EF Proxy. But we can't create map from proxy class to dto so we need AutoMapper to do this. So we should use option CreateMissingTypeMaps when Map.