### PR TITLE
Add DatabaseId configuration support for AbpRedisCache

### DIFF
--- a/src/Abp.RedisCache/AbpRedisCacheConfig.cs
+++ b/src/Abp.RedisCache/AbpRedisCacheConfig.cs
@@ -11,5 +11,13 @@ namespace Abp
             get { return connectionStringKey; }
             set { connectionStringKey = value; }
         }
+
+        private string databaseIdAppSetting = "Abp.Redis.Cache.DatabaseId";
+
+        public string DatabaseIdAppSetting
+        {
+            get { return databaseIdAppSetting; }
+            set { databaseIdAppSetting = value; }
+        }
     }
 }

--- a/src/Abp.RedisCache/RedisCache/AbpRedisCache.cs
+++ b/src/Abp.RedisCache/RedisCache/AbpRedisCache.cs
@@ -16,9 +16,11 @@ namespace Abp.RedisCache
         {
             get
             {
-                return _connectionMultiplexer.GetDatabase();
+                return _connectionMultiplexer.GetDatabase(DatabaseId);
             }
         }
+
+        public int DatabaseId { get; private set; } = -1;
 
         /// <summary>
         /// Constructor.
@@ -28,6 +30,7 @@ namespace Abp.RedisCache
         {
             _config = config;
             var connectionString = redisConnectionProvider.GetConnectionString(_config.ConnectionStringKey);
+            DatabaseId = redisConnectionProvider.GetDatabaseId(_config.DatabaseIdAppSetting);
             _connectionMultiplexer = redisConnectionProvider.GetConnection(connectionString);
         }
         public override object GetOrDefault(string key)

--- a/src/Abp.RedisCache/RedisCache/Configuration/IRedisConnectionProvider.cs
+++ b/src/Abp.RedisCache/RedisCache/Configuration/IRedisConnectionProvider.cs
@@ -7,5 +7,6 @@ namespace Abp.RedisCache.Configuration
         ConnectionMultiplexer GetConnection(string connectionString);
 
         string GetConnectionString(string name);
+        int GetDatabaseId(string name);
     }
 }

--- a/src/Abp.RedisCache/RedisCache/Configuration/RedisConnectionProvider.cs
+++ b/src/Abp.RedisCache/RedisCache/Configuration/RedisConnectionProvider.cs
@@ -17,7 +17,7 @@ namespace Abp.RedisCache.Configuration
             {
                 return "localhost";
             }
-
+            
             return connStr.ConnectionString;
         }
 
@@ -37,6 +37,17 @@ namespace Abp.RedisCache.Configuration
                 connectionString,
                 new Lazy<ConnectionMultiplexer>(() => ConnectionMultiplexer.Connect(connectionString))
                 ).Value;
+        }
+
+        public int GetDatabaseId(string databaseIdAppSettingName)
+        {
+            int databaseId = -1;
+
+            var appSetting = ConfigurationManager.AppSettings[databaseIdAppSettingName];
+
+            int.TryParse(appSetting, out databaseId);
+
+            return databaseId;
         }
     }
 }

--- a/src/Tests/Abp.RedisCache.Tests/Abp.RedisCache.Tests.csproj
+++ b/src/Tests/Abp.RedisCache.Tests/Abp.RedisCache.Tests.csproj
@@ -86,6 +86,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tests/Abp.RedisCache.Tests/App.config
+++ b/src/Tests/Abp.RedisCache.Tests/App.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="Abp.Redis.Cache.DatabaseId" value="1"/>
+  </appSettings>
+  <connectionStrings>
+    <add name="Abp.Redis.Cache" connectionString="...redis.cache.windows.net,abortConnect=false,ssl=true,password=.." />
+  </connectionStrings>
+</configuration>

--- a/src/Tests/Abp.RedisCache.Tests/RedisCacheManager_Test.cs
+++ b/src/Tests/Abp.RedisCache.Tests/RedisCacheManager_Test.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Dynamic;
 using Abp.RedisCache.Configuration;
 using Abp.Runtime.Caching;
 using Abp.Runtime.Caching.Configuration;
@@ -47,5 +48,17 @@ namespace Abp.RedisCache.Tests
         {
             public int Value { get; set; }
         }
+
+        [Fact]
+        public void DatabaseId_Test()
+        {
+            var dbIdAppSettingName = LocalIocManager.Resolve<AbpRedisCacheConfig>().DatabaseIdAppSetting;
+
+            var dbIdInConfig = LocalIocManager.Resolve<IAbpRedisConnectionProvider>().GetDatabaseId(dbIdAppSettingName);
+
+            ((AbpRedisCache)_cache.InternalCache).DatabaseId.ShouldBe(dbIdInConfig);
+        }
+
+
     }
 }


### PR DESCRIPTION
By default the stackexchange.redis uses the first database (DatabaseId  = 0) for the default connection string. the AbpRedisCache didn't make it configurable and this pull request makes it support to set Abp.Redis.Cache.DatabaseId in app settings.