### PR TITLE
Resolved #866: Non-entity DbSets ignored by EF repository registrar.

### DIFF
--- a/src/Abp.EntityFramework/EntityFramework/Extensions/DbContextExtensions.cs
+++ b/src/Abp.EntityFramework/EntityFramework/Extensions/DbContextExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using System.Reflection;
+using Abp.Domain.Entities;
 using Abp.Reflection;
 
 namespace Abp.EntityFramework.Extensions
@@ -14,8 +15,9 @@ namespace Abp.EntityFramework.Extensions
             return
                 from property in dbContextType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 where
-                    ReflectionHelper.IsAssignableToGenericType(property.PropertyType, typeof(IDbSet<>)) ||
-                    ReflectionHelper.IsAssignableToGenericType(property.PropertyType, typeof(DbSet<>))
+                    (ReflectionHelper.IsAssignableToGenericType(property.PropertyType, typeof(IDbSet<>)) ||
+                    ReflectionHelper.IsAssignableToGenericType(property.PropertyType, typeof(DbSet<>))) &&
+                    ReflectionHelper.IsAssignableToGenericType(property.PropertyType.GenericTypeArguments[0], typeof(IEntity<>))
                 select property.PropertyType.GenericTypeArguments[0];
         }
     }

--- a/src/Tests/Abp.EntityFramework.Tests/Repositories/EntityFrameworkGenericRepositoryRegistrar_Tests.cs
+++ b/src/Tests/Abp.EntityFramework.Tests/Repositories/EntityFrameworkGenericRepositoryRegistrar_Tests.cs
@@ -53,6 +53,8 @@ namespace Abp.EntityFramework.Tests.Repositories
         public class MyMainDbContext : MyBaseDbContext
         {
             public virtual DbSet<MyEntity2> MyEntities2 { get; set; }
+
+            public virtual DbSet<MyNonEntity> MyNonEntities { get; set; }
         }
 
         [AutoRepositoryTypes(
@@ -82,6 +84,11 @@ namespace Abp.EntityFramework.Tests.Repositories
         }
 
         public class MyEntity3 : Entity<Guid>
+        {
+
+        }
+
+        public class MyNonEntity
         {
 
         }


### PR DESCRIPTION
Hi @hikalkan, 

I made the change in DbContextExtensions as you've suggested.