### PR TITLE
Fix the bug when entity has uninitialized fields

### DIFF
--- a/src/Abp.Web.Api.OData/WebApi/OData/Controllers/AbpODataEntityController.cs
+++ b/src/Abp.Web.Api.OData/WebApi/OData/Controllers/AbpODataEntityController.cs
@@ -68,9 +68,9 @@ namespace Abp.WebApi.OData.Controllers
                 return BadRequest(ModelState);
             }
 
-            await Repository.InsertAndGetIdAsync(entity);
+            var createdEntity = await Repository.InsertAsync(entity);
 
-            return Created(entity);
+            return Created(createdEntity);
         }
 
         public virtual async Task<IHttpActionResult> Patch([FromODataUri] TPrimaryKey key, Delta<TEntity> entity)


### PR DESCRIPTION
Using only `InsertAndGetIdAsync()` method doesn't fixes the bug when the retured entity has { Id: 0, TenantId: 0} and so on.