### PR TITLE
Bugfix #1059 (GraphDiff compatability)

### DIFF
--- a/src/Abp.EntityFramework/EntityFramework/AbpDbContext.cs
+++ b/src/Abp.EntityFramework/EntityFramework/AbpDbContext.cs
@@ -212,6 +212,10 @@ namespace Abp.EntityFramework
                 switch (entry.State)
                 {
                     case EntityState.Added:
+                        //Following 3 lines are required to support the compatability with GraphDiff library
+                        CheckAndSetId(entry.Entity);
+                        CheckAndSetMustHaveTenantIdProperty(entry.Entity);
+                        SetCreationAuditProperties(entry.Entity, GetAuditUserId());
                         EntityChangeEventHelper.TriggerEntityCreatingEvent(entry.Entity);
                         EntityChangeEventHelper.TriggerEntityCreatedEventOnUowCompleted(entry.Entity);
                         break;


### PR DESCRIPTION
Duplicating lines 216-218 is required to support GraphDiff.
In most cases, checks, made inside of these methods will discover that entity fields are already set and these is no need to change anything.
While using GraphDiff, these 3 methods discover that that entity's fields have their default state and need to be updated.
I run Unit-test session and It seems to work fine with all of the cases.