### PR TITLE
Default value should clear the setting

### DIFF
--- a/src/Abp/Configuration/SettingManager.cs
+++ b/src/Abp/Configuration/SettingManager.cs
@@ -290,7 +290,7 @@ namespace Abp.Configuration
             }
 
             //No need to store on database if the value is the default value
-            if (value == defaultValue)
+            if (value == defaultValue || value == settingDefinition.DefaultValue)
             {
                 if (settingValue != null)
                 {


### PR DESCRIPTION
Consider the following scenario:

Setting Default: "Default"
AppSetting : "Default"
TenantSetting: "TenantOverride"
UserSetting: "UserOverride"

If I do a ChangeSettingForUser with the value "Default", I expected the user value to be removed from storage and the "TenantOverride" value to become the active one. A workaround (in the calling code) is to check if the value being set is "Default" and then specifically get the tenant setting and use that value to set the user setting, but this seems unefficient and untidy. 
