### PR TITLE
add a new AbpSession class to get userid from asp. net core

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/AbpAspNetCoreModule.cs
+++ b/src/Abp.AspNetCore/AspNetCore/AbpAspNetCoreModule.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using Abp.AspNetCore.Configuration;
+using Abp.Dependency;
 using Abp.Modules;
+using Abp.Runtime.Session;
 using Abp.Web;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 
@@ -17,6 +19,8 @@ namespace Abp.AspNetCore
         public override void Initialize()
         {
             IocManager.RegisterAssemblyByConvention(Assembly.GetExecutingAssembly());
+            IocManager.Register<IAbpSession,Runtime.Session.AspNetCoreClaimsAbpSession>(DependencyLifeStyle.Singleton);
+
         }
 
         public override void PostInitialize()

--- a/src/Abp.AspNetCore/AspNetCore/Runtime/Session/AspNetCoreClaimsAbpSession.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Runtime/Session/AspNetCoreClaimsAbpSession.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using Abp.Configuration.Startup;
+using Abp.MultiTenancy;
+using Abp.Runtime.Security;
+using Abp.Runtime.Session;
+using Microsoft.AspNetCore.Http;
+
+namespace Abp.AspNetCore.Runtime.Session
+{
+    public class AspNetCoreClaimsAbpSession : IAbpSession
+    {
+        private const int DefaultTenantId = 1;
+
+        public IHttpContextAccessor HttpContextAccessor { get; set; }
+
+        public AspNetCoreClaimsAbpSession(IMultiTenancyConfig multiTenancy)
+        {
+            _multiTenancy = multiTenancy;
+        }
+        private readonly IMultiTenancyConfig _multiTenancy;
+
+        public ClaimsIdentity Identity => Principal?.Identity as ClaimsIdentity;
+
+        public ClaimsPrincipal Principal => HttpContextAccessor?.HttpContext?.User;
+
+        public virtual string UserIdClaimType { get; set; } = ClaimTypes.NameIdentifier;
+
+        public long? UserId
+        {
+            get
+            {
+
+                var userIdClaim = Identity?.Claims.FirstOrDefault(c =>
+                    c.Type == UserIdClaimType);
+                if (string.IsNullOrEmpty(userIdClaim?.Value))
+                {
+                    return null;
+                }
+
+                long userId;
+                if (!long.TryParse(userIdClaim.Value, out userId))
+                {
+                    return null;
+                }
+
+                return userId;
+            }
+        }
+
+        public virtual int? TenantId
+        {
+            get
+            {
+                if (!_multiTenancy.IsEnabled)
+                {
+                    return DefaultTenantId;
+                }
+
+
+                var tenantIdClaim = Principal.Claims.FirstOrDefault(c =>
+                    c.Type == AbpClaimTypes.TenantId);
+                if (string.IsNullOrEmpty(tenantIdClaim?.Value))
+                {
+                    return null;
+                }
+
+                return Convert.ToInt32(tenantIdClaim.Value);
+            }
+        }
+
+        public virtual MultiTenancySides MultiTenancySide =>
+            _multiTenancy.IsEnabled && !TenantId.HasValue
+            ? MultiTenancySides.Host
+            : MultiTenancySides.Tenant;
+
+        public virtual long? ImpersonatorUserId
+        {
+            get
+            {
+                var impersonatorUserIdClaim = Principal.Claims.FirstOrDefault(c =>
+                    c.Type == AbpClaimTypes.ImpersonatorUserId);
+                if (string.IsNullOrEmpty(impersonatorUserIdClaim?.Value))
+                {
+                    return null;
+                }
+
+                return Convert.ToInt64(impersonatorUserIdClaim.Value);
+            }
+        }
+
+        public virtual int? ImpersonatorTenantId
+        {
+            get
+            {
+                if (!_multiTenancy.IsEnabled)
+                {
+                    return DefaultTenantId;
+                }
+
+                var impersonatorTenantIdClaim = Principal.Claims.FirstOrDefault(c =>
+                    c.Type == AbpClaimTypes.ImpersonatorTenantId);
+                if (string.IsNullOrEmpty(impersonatorTenantIdClaim?.Value))
+                {
+                    return null;
+                }
+
+                return Convert.ToInt32(impersonatorTenantIdClaim.Value);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Because asp .net core do not relay ClaimsPrincipal by Thread.CurrentPrincipal anymore, we need to inject HttpContextAccessor.

For unit test friendly, I made HttpContextAccessor as property injection.