### PR TITLE
add  abp.log4net   project  to  support  log4net 2.0.5

### DIFF
--- a/Abp.sln
+++ b/Abp.sln
@@ -94,6 +94,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Abp.AspNetCore.TestBase", "
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AbpAspNetCoreDemo", "test\aspnet-core-demo\AbpAspNetCoreDemo\AbpAspNetCoreDemo.xproj", "{26172FE6-890F-4D45-83B2-3F28193843AF}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Abp.Log4Net", "src\Abp.Log4Net\Abp.Log4Net.xproj", "{FB797CC0-A394-4977-86B0-47F16672DDE8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -260,6 +262,10 @@ Global
 		{26172FE6-890F-4D45-83B2-3F28193843AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26172FE6-890F-4D45-83B2-3F28193843AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26172FE6-890F-4D45-83B2-3F28193843AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB797CC0-A394-4977-86B0-47F16672DDE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB797CC0-A394-4977-86B0-47F16672DDE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB797CC0-A394-4977-86B0-47F16672DDE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB797CC0-A394-4977-86B0-47F16672DDE8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -306,5 +312,6 @@ Global
 		{47279576-BA2A-4941-96BD-E4B913B50B4A} = {1E6B9E8D-D5C1-4AD7-89F9-7179FEFD7C01}
 		{B21CDFC5-81C3-4E29-B7FF-C11B5EC43456} = {DFF0464B-5402-4DD6-86F5-2AEC1163B232}
 		{26172FE6-890F-4D45-83B2-3F28193843AF} = {1C5D3B56-8C59-4ABC-8E66-CBE971633FA7}
+		{FB797CC0-A394-4977-86B0-47F16672DDE8} = {DFF0464B-5402-4DD6-86F5-2AEC1163B232}
 	EndGlobalSection
 EndGlobal

--- a/src/Abp.Log4Net/Abp.Log4Net.xproj
+++ b/src/Abp.Log4Net/Abp.Log4Net.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>fb797cc0-a394-4977-86b0-47f16672dde8</ProjectGuid>
+    <RootNamespace>Abp</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Abp.Log4Net/Log4NetBootstrapper.cs
+++ b/src/Abp.Log4Net/Log4NetBootstrapper.cs
@@ -1,0 +1,15 @@
+﻿using Castle.Facilities.Logging;
+using Abp.Dependency;
+namespace Abp
+{
+    public static class Log4NetBootstrapper
+    {
+        public static void Start()
+        {
+            IocManager.Instance.IocContainer
+                .AddFacility<LoggingFacility>(f => f.LogUsing<Log4NetFactory>()
+              .WithConfig("log4net.config"));
+        }
+        
+    }
+}

--- a/src/Abp.Log4Net/Log4NetFactory.cs
+++ b/src/Abp.Log4Net/Log4NetFactory.cs
@@ -1,0 +1,39 @@
+﻿
+using System;
+
+using log4net;
+using Castle.Core.Logging;
+using log4net.Config;
+
+namespace Abp
+{
+    public class Log4NetFactory
+        : AbstractLoggerFactory
+    {
+        internal const string DefaultConfigFileName = "log4net.config";
+
+        public Log4NetFactory()
+            : this(DefaultConfigFileName)
+        {
+        }
+
+        public Log4NetFactory(string configFile)
+        {
+            var file = GetConfigFile(configFile);
+            XmlConfigurator.ConfigureAndWatch(file);
+        }
+
+        public override ILogger Create(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException("name");
+            var log = LogManager.GetLogger(name);
+            return new Log4NetLogger(log, this);
+        }
+
+        public override ILogger Create(string name, LoggerLevel level)
+        {
+            throw new NotSupportedException("Logger levels cannot be set at runtime. Please review your configuration file.");
+        }
+    }
+}

--- a/src/Abp.Log4Net/Log4NetModule.cs
+++ b/src/Abp.Log4Net/Log4NetModule.cs
@@ -1,0 +1,19 @@
+﻿using Abp.Modules;
+using System.Reflection;
+
+namespace Abp
+{
+    [DependsOn(typeof(AbpKernelModule))]
+    public class Log4NetModule:AbpModule
+    {
+        public override void PreInitialize()
+        {
+
+        }
+
+        public override void Initialize()
+        {
+            this.IocManager.RegisterAssemblyByConvention(Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/src/Abp.Log4Net/Log4netLogger.cs
+++ b/src/Abp.Log4Net/Log4netLogger.cs
@@ -1,0 +1,349 @@
+
+using log4net;
+using log4net.Core;
+using log4net.Util;
+using System;
+using System.Globalization;
+
+namespace Abp
+{
+    [Serializable]
+    public class Log4NetLogger : MarshalByRefObject, Castle.Core.Logging.ILogger
+    {
+        private static readonly Type DeclaringType = typeof(Log4NetLogger);
+
+        public Log4NetLogger(ILogger logger, Log4NetFactory factory)
+        {
+            this.Logger = logger;
+            this.Factory = factory;
+        }
+
+        internal Log4NetLogger()
+        {
+        }
+
+        internal Log4NetLogger(ILog log, Log4NetFactory factory)
+            : this(log.Logger, factory)
+        {
+        }
+
+        public bool IsDebugEnabled
+        {
+            get { return this.Logger.IsEnabledFor(Level.Debug); }
+        }
+
+        public bool IsErrorEnabled
+        {
+            get { return this.Logger.IsEnabledFor(Level.Error); }
+        }
+
+        public bool IsFatalEnabled
+        {
+            get { return this.Logger.IsEnabledFor(Level.Fatal); }
+        }
+
+        public bool IsInfoEnabled
+        {
+            get { return this.Logger.IsEnabledFor(Level.Info); }
+        }
+
+        public bool IsWarnEnabled
+        {
+            get { return this.Logger.IsEnabledFor(Level.Warn); }
+        }
+
+        protected internal Log4NetFactory Factory { get; set; }
+
+        protected internal ILogger Logger { get; set; }
+
+        public override string ToString()
+        {
+            return this.Logger.ToString();
+        }
+
+        public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name)
+        {
+            return this.Factory.Create(this.Logger.Name + "." + name);
+        }
+
+        public void Debug(string message)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Debug, message, null);
+            }
+        }
+
+        public void Debug(Func<string> messageFactory)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Debug, messageFactory.Invoke(), null);
+            }
+        }
+
+        public void Debug(string message, Exception exception)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Debug, message, exception);
+            }
+        }
+
+        public void DebugFormat(string format, params Object[] args)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Debug, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            }
+        }
+
+        public void DebugFormat(Exception exception, string format, params Object[] args)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Debug, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), exception);
+            }
+        }
+
+        public void DebugFormat(IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Debug, new SystemStringFormat(formatProvider, format, args), null);
+            }
+        }
+
+        public void DebugFormat(Exception exception, IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsDebugEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Debug, new SystemStringFormat(formatProvider, format, args), exception);
+            }
+        }
+
+        public void Error(string message)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Error, message, null);
+            }
+        }
+
+        public void Error(Func<string> messageFactory)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Error, messageFactory.Invoke(), null);
+            }
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Error, message, exception);
+            }
+        }
+
+        public void ErrorFormat(string format, params Object[] args)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Error, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            }
+        }
+
+        public void ErrorFormat(Exception exception, string format, params Object[] args)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Error, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), exception);
+            }
+        }
+
+        public void ErrorFormat(IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Error, new SystemStringFormat(formatProvider, format, args), null);
+            }
+        }
+
+        public void ErrorFormat(Exception exception, IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsErrorEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Error, new SystemStringFormat(formatProvider, format, args), exception);
+            }
+        }
+
+        public void Fatal(string message)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Fatal, message, null);
+            }
+        }
+
+        public void Fatal(Func<string> messageFactory)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Fatal, messageFactory.Invoke(), null);
+            }
+        }
+
+        public void Fatal(string message, Exception exception)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Fatal, message, exception);
+            }
+        }
+
+        public void FatalFormat(string format, params Object[] args)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Fatal, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            }
+        }
+
+        public void FatalFormat(Exception exception, string format, params Object[] args)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Fatal, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), exception);
+            }
+        }
+
+        public void FatalFormat(IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Fatal, new SystemStringFormat(formatProvider, format, args), null);
+            }
+        }
+
+        public void FatalFormat(Exception exception, IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsFatalEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Fatal, new SystemStringFormat(formatProvider, format, args), exception);
+            }
+        }
+
+        public void Info(string message)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Info, message, null);
+            }
+        }
+
+        public void Info(Func<string> messageFactory)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Info, messageFactory.Invoke(), null);
+            }
+        }
+
+        public void Info(string message, Exception exception)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Info, message, exception);
+            }
+        }
+
+        public void InfoFormat(string format, params Object[] args)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Info, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            }
+        }
+
+        public void InfoFormat(Exception exception, string format, params Object[] args)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Info, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), exception);
+            }
+        }
+
+        public void InfoFormat(IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Info, new SystemStringFormat(formatProvider, format, args), null);
+            }
+        }
+
+        public void InfoFormat(Exception exception, IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsInfoEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Info, new SystemStringFormat(formatProvider, format, args), exception);
+            }
+        }
+
+        public void Warn(string message)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Warn, message, null);
+            }
+        }
+
+        public void Warn(Func<string> messageFactory)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Warn, messageFactory.Invoke(), null);
+            }
+        }
+
+        public void Warn(string message, Exception exception)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Warn, message, exception);
+            }
+        }
+
+        public void WarnFormat(string format, params Object[] args)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Warn, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            }
+        }
+
+        public void WarnFormat(Exception exception, string format, params Object[] args)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Warn, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), exception);
+            }
+        }
+
+        public void WarnFormat(IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Warn, new SystemStringFormat(formatProvider, format, args), null);
+            }
+        }
+
+        public void WarnFormat(Exception exception, IFormatProvider formatProvider, string format, params Object[] args)
+        {
+            if (this.IsWarnEnabled)
+            {
+                this.Logger.Log(DeclaringType, Level.Warn, new SystemStringFormat(formatProvider, format, args), exception);
+            }
+        }
+    }
+}

--- a/src/Abp.Log4Net/Properties/AssemblyInfo.cs
+++ b/src/Abp.Log4Net/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Abp.Log4Net")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fb797cc0-a394-4977-86b0-47f16672dde8")]

--- a/src/Abp.Log4Net/log4net.config
+++ b/src/Abp.Log4Net/log4net.config
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender" >
+    <file value="Logs/Logs.txt" />
+    <encoding value="utf-8" />
+    <appendToFile value="true" />
+    <rollingStyle value="Size" />
+    <maxSizeRollBackups value="10" />
+    <maximumFileSize value="10000KB" />
+    <staticLogFileName value="true" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-5level %date [%-5.5thread] %-40.40logger - %message%newline" />
+    </layout>
+  </appender>
+  <root>
+    <appender-ref ref="RollingFileAppender" />
+    <level value="DEBUG" />
+  </root>
+  <logger name="NHibernate">
+    <level value="WARN" />
+  </logger>
+</log4net>

--- a/src/Abp.Log4Net/project.json
+++ b/src/Abp.Log4Net/project.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "Abp": "0.10.3",
+    "Castle.LoggingFacility": "3.3.0",
+    "Castle.Windsor": "3.3.0",
+    "log4net": "2.0.5"
+  },
+
+  "frameworks": {
+    "net452": {
+      "frameworkAssemblies": {
+        "System.Configuration": "",
+        "System.Data": "",
+        "System.Transactions": "",
+        "System.Runtime": {
+          "type": "build"
+        },
+        "System.Runtime.Caching": "",
+        "System.ComponentModel.DataAnnotations": "",
+        "System.Threading.Tasks": {
+          "type": "build"
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Abp  is  use  log4net with  1.2.10 .  if  the  version  is  1.2.13 or   the  lasted  like 2.0.5 ,  abp  don't  support.  So  I  google  one  solution,  the  detail code  in   the  abp.log4net .
Thanks!