### PR TITLE
Skip attributing FormBody to IFormFile type input to the application service project

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Conventions/AbpAppServiceConvention.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Conventions/AbpAppServiceConvention.cs
@@ -80,7 +80,7 @@ namespace Abp.AspNetCore.Mvc.Conventions
             ConfigureParameters(controller);
         }
 
-        private void ConfigureParameters(ControllerModel controller)
+       private void ConfigureParameters(ControllerModel controller)
         {
             foreach (var action in controller.Actions)
             {
@@ -93,14 +93,19 @@ namespace Abp.AspNetCore.Mvc.Conventions
 
                     if (!TypeHelper.IsPrimitiveExtendedIncludingNullable(prm.ParameterInfo.ParameterType))
                     {
-                        if (CanUseFormBodyBinding(action))
+                        if (!TypeHelper.IsFormBodyProhibited(prm.ParameterInfo.ParameterType))
                         {
-                            prm.BindingInfo = BindingInfo.GetBindingInfo(new[] { new FromBodyAttribute() });
+                            if (CanUseFormBodyBinding(action))
+                            {
+                                prm.BindingInfo = BindingInfo.GetBindingInfo(new[] { new FromBodyAttribute() });
+                            }
                         }
+
                     }
                 }
             }
         }
+		
 
         private static bool CanUseFormBodyBinding(ActionModel action)
         {

--- a/src/Abp/Reflection/TypeHelper.cs
+++ b/src/Abp/Reflection/TypeHelper.cs
@@ -57,5 +57,15 @@ namespace Abp.Reflection
                    type == typeof (TimeSpan) ||
                    type == typeof (Guid);
         }
+
+        public static bool IsFormBodyProhibited(Type type)
+        {
+            if (type.ToString() == "Microsoft.AspNetCore.Http.IFormFile")
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Skip attributing FormBody to IFormFile type input to the application service project. Without this change we cannot have an upload method in application services since FormBody does not works with multidata input such as IFormFile.