### PR TITLE
FirstOrDefault instead of Get in CrudAppService

### DIFF
--- a/src/Abp/Application/Services/AsyncCrudAppService.cs
+++ b/src/Abp/Application/Services/AsyncCrudAppService.cs
@@ -151,7 +151,7 @@ namespace Abp.Application.Services
 
         protected virtual Task<TEntity> GetEntityByIdAsync(TPrimaryKey id)
         {
-            return Repository.GetAsync(id);
+            return Repository.FirstOrDefaultAsync(id);
         }
     }
 }

--- a/src/Abp/Application/Services/CrudAppService.cs
+++ b/src/Abp/Application/Services/CrudAppService.cs
@@ -146,7 +146,7 @@ namespace Abp.Application.Services
 
         protected virtual TEntity GetEntityById(TPrimaryKey id)
         {
-            return Repository.Get(id);
+            return Repository.FirstOrDefault(id);
         }
     }
 }


### PR DESCRIPTION
Calling Repository.Get will throw exception if id doesn't exist, we should use FirstOrDefault for more flexibility