### PR TITLE
Fix JavaScript string encoding

### DIFF
--- a/src/Abp.Web.Common/Web/Settings/SettingScriptManager.cs
+++ b/src/Abp.Web.Common/Web/Settings/SettingScriptManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using Abp.Configuration;
 using Abp.Dependency;
 
@@ -48,7 +49,7 @@ namespace Abp.Web.Settings
 
                 script.Append("        '" +
                               settingDefinition.Name .Replace("'", @"\'") + "': " +
-                              (settingValue == null ? "null" : "'" + settingValue.Replace(@"\", @"\\").Replace("'", @"\'") + "'"));
+                              (settingValue == null ? "null" : "'" + HttpUtility.JavaScriptStringEncode(settingValue) + "'"));
 
                 ++added;
             }


### PR DESCRIPTION
SettingScriptManager does not adequately escape a number of important characters in settings, notably newline and carriage return characters, which break the GetScripts controller action (Unterminated string literal). Applying the enclosed change fixed this, but I had to implement a new class make it the default resolution in my IocContainer.

It does require a reference to the core assembly System.Web.
