### PR TITLE
Managed decimal CLR type in typescript helper

### DIFF
--- a/src/Abp.Web.Api/WebApi/Controllers/Dynamic/Scripting/TypeScript/TypeScriptHelper.cs
+++ b/src/Abp.Web.Api/WebApi/Controllers/Dynamic/Scripting/TypeScript/TypeScriptHelper.cs
@@ -14,7 +14,7 @@ namespace Abp.WebApi.Controllers.Dynamic.Scripting.TypeScript
         private static readonly string[] _basicTypes =
         {
             "guid", "string", "bool",
-            "datetime", "int16", "int32", "int64", "single", "double", "boolean", "void","byte"
+            "datetime", "int16", "int32", "int64", "single", "double", "decimal", "boolean", "void","byte"
         };
 
         private static readonly string[] _typesToIgnore =
@@ -88,6 +88,7 @@ namespace Abp.WebApi.Controllers.Dynamic.Scripting.TypeScript
                 case "int64":
                 case "single":
                 case "double":
+                case "decimal":
                 case "byte":
                     return "number";
                 case "boolean":


### PR DESCRIPTION
Hi,

TypescriptHelper does not manage decimal types, so when i have a .NET decimal type property in a dto , it doesn't have been converted to typescript number type