### PR TITLE
Addition of IRedisCacheSerializer and implementation of ProtoBuf serializer....

### DIFF
--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCache.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCache.cs
@@ -11,14 +11,16 @@ namespace Abp.Runtime.Caching.Redis
     public class AbpRedisCache : CacheBase
     {
         private readonly IDatabase _database;
+        private IRedisCacheSerializer _serializer;
 
         /// <summary>
         /// Constructor.
         /// </summary>
-        public AbpRedisCache(string name, IAbpRedisCacheDatabaseProvider redisCacheDatabaseProvider)
+        public AbpRedisCache(string name, IAbpRedisCacheDatabaseProvider redisCacheDatabaseProvider, IRedisCacheSerializer redisCacheSerializer)
             : base(name)
         {
             _database = redisCacheDatabaseProvider.GetDatabase();
+            _serializer = redisCacheSerializer;
         }
 
         public override object GetOrDefault(string key)
@@ -61,12 +63,12 @@ namespace Abp.Runtime.Caching.Redis
 
         protected virtual string Serialize(object value, Type type)
         {
-            return JsonSerializationHelper.SerializeWithType(value, type);
+            return _serializer.Serialize(value, type);
         }
 
         protected virtual object Deserialize(RedisValue objbyte)
         {
-            return JsonSerializationHelper.DeserializeWithType(objbyte);
+            return _serializer.Deserialize(objbyte);
         }
 
         protected virtual string GetLocalizedKey(string key)

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/DefaultRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/DefaultRedisCacheSerializer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Abp.Json;
+using StackExchange.Redis;
+
+namespace Abp.Runtime.Caching.Redis
+{
+    /// <summary>
+    ///     Default implementation uses JSON as the underlying persistence mechanism.
+    /// </summary>
+    public class DefaultRedisCacheSerializer : IRedisCacheSerialization
+    {
+        /// <summary>
+        ///     Creates an instance of the object from its serialized string representation.
+        /// </summary>
+        /// <param name="objbyte">String representation of the object from the Redis server.</param>
+        /// <returns>Returns a newly constructed object.</returns>
+        /// <seealso cref="IRedisCacheSerialization.Serialize" />
+        public object Deserialize(RedisValue objbyte)
+        {
+            return JsonSerializationHelper.DeserializeWithType(objbyte);
+        }
+
+        /// <summary>
+        ///     Produce a string representation of the supplied object.
+        /// </summary>
+        /// <param name="value">Instance to serialize.</param>
+        /// <param name="type">Type of the object.</param>
+        /// <returns>Returns a string representing the object instance that can be placed into the Redis cache.</returns>
+        /// <seealso cref="IRedisCacheSerialization.Deserialize" />
+        public string Serialize(object value, Type type)
+        {
+            return JsonSerializationHelper.SerializeWithType(value, type);
+        }
+    }
+}

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/DefaultRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/DefaultRedisCacheSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Abp.Dependency;
 using Abp.Json;
 using StackExchange.Redis;
 
@@ -7,14 +8,14 @@ namespace Abp.Runtime.Caching.Redis
     /// <summary>
     ///     Default implementation uses JSON as the underlying persistence mechanism.
     /// </summary>
-    public class DefaultRedisCacheSerializer : IRedisCacheSerialization
+    public class DefaultRedisCacheSerializer : IRedisCacheSerializer
     {
         /// <summary>
         ///     Creates an instance of the object from its serialized string representation.
         /// </summary>
         /// <param name="objbyte">String representation of the object from the Redis server.</param>
         /// <returns>Returns a newly constructed object.</returns>
-        /// <seealso cref="IRedisCacheSerialization.Serialize" />
+        /// <seealso cref="IRedisCacheSerializer.Serialize" />
         public object Deserialize(RedisValue objbyte)
         {
             return JsonSerializationHelper.DeserializeWithType(objbyte);
@@ -26,7 +27,7 @@ namespace Abp.Runtime.Caching.Redis
         /// <param name="value">Instance to serialize.</param>
         /// <param name="type">Type of the object.</param>
         /// <returns>Returns a string representing the object instance that can be placed into the Redis cache.</returns>
-        /// <seealso cref="IRedisCacheSerialization.Deserialize" />
+        /// <seealso cref="IRedisCacheSerializer.Deserialize" />
         public string Serialize(object value, Type type)
         {
             return JsonSerializationHelper.SerializeWithType(value, type);

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/IRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/IRedisCacheSerializer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using StackExchange.Redis;
+
+namespace Abp.Runtime.Caching.Redis
+{
+    /// <summary>
+    ///     Interface to be implemented by all custom (de)serialization methods used when persisting and retrieving
+    ///     objects from the Redis cache.
+    /// </summary>
+    public interface IRedisCacheSerialization
+    {
+        /// <summary>
+        ///     Creates an instance of the object from its serialized string representation.
+        /// </summary>
+        /// <param name="objbyte">String representation of the object from the Redis server.</param>
+        /// <returns>Returns a newly constructed object.</returns>
+        /// <seealso cref="Serialize" />
+        object Deserialize(RedisValue objbyte);
+
+        /// <summary>
+        ///     Produce a string representation of the supplied object.
+        /// </summary>
+        /// <param name="value">Instance to serialize.</param>
+        /// <param name="type">Type of the object.</param>
+        /// <returns>Returns a string representing the object instance that can be placed into the Redis cache.</returns>
+        /// <seealso cref="Deserialize" />
+        string Serialize(object value, Type type);
+    }
+}

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/IRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/IRedisCacheSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Abp.Dependency;
 using StackExchange.Redis;
 
 namespace Abp.Runtime.Caching.Redis
@@ -7,7 +8,7 @@ namespace Abp.Runtime.Caching.Redis
     ///     Interface to be implemented by all custom (de)serialization methods used when persisting and retrieving
     ///     objects from the Redis cache.
     /// </summary>
-    public interface IRedisCacheSerialization
+    public interface IRedisCacheSerializer
     {
         /// <summary>
         ///     Creates an instance of the object from its serialized string representation.

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/ProtoBufRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/ProtoBufRedisCacheSerializer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using ProtoBuf;
+using StackExchange.Redis;
+
+namespace Abp.Runtime.Caching.Redis
+{
+    public class ProtoBufRedisCacheSerializer : IRedisCacheSerialization
+    {
+        private const string TypeSeperator = "|";
+
+        /// <summary>
+        ///     Creates an instance of the object from its serialized string representation.
+        /// </summary>
+        /// <param name="objbyte">String representation of the object from the Redis server.</param>
+        /// <returns>Returns a newly constructed object.</returns>
+        /// <seealso cref="IRedisCacheSerialization.Serialize" />
+        public object Deserialize(RedisValue objbyte)
+        {
+            string serializedObj = objbyte;
+
+            int typeSeperatorIndex = serializedObj.IndexOf(TypeSeperator);
+            Type type = Type.GetType(serializedObj.Substring(0, typeSeperatorIndex));
+            string serialized = serializedObj.Substring(typeSeperatorIndex + 1);
+
+            byte[] byteAfter64 = Convert.FromBase64String(serialized);
+            MemoryStream afterStream = new MemoryStream(byteAfter64);
+
+            return Serializer.Deserialize(type, afterStream);
+
+            //MethodInfo method = typeof(Serializer).GetMethod(nameof(Serializer.Deserialize));
+            //MethodInfo generic = method.MakeGenericMethod(type);
+            //return generic.Invoke(null, new object[]{afterStream});
+        }
+
+        /// <summary>
+        ///     Produce a string representation of the supplied object.
+        /// </summary>
+        /// <param name="value">Instance to serialize.</param>
+        /// <param name="type">Type of the object.</param>
+        /// <returns>Returns a string representing the object instance that can be placed into the Redis cache.</returns>
+        /// <seealso cref="IRedisCacheSerialization.Deserialize" />
+        public string Serialize(object value, Type type)
+        {
+            MemoryStream msTestString = new MemoryStream();
+            Serializer.Serialize(msTestString, value);
+            string serialized = Convert.ToBase64String(msTestString.GetBuffer(), 0, (int) msTestString.Length);
+
+            return $"{type.AssemblyQualifiedName}{TypeSeperator}{serialized}";
+        }
+    }
+}

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/ProtoBufRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/ProtoBufRedisCacheSerializer.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.IO;
+using Abp.Dependency;
 using ProtoBuf;
 using StackExchange.Redis;
 
 namespace Abp.Runtime.Caching.Redis
 {
-    public class ProtoBufRedisCacheSerializer : IRedisCacheSerialization
+    public class ProtoBufRedisCacheSerializer : IRedisCacheSerializer, ITransientDependency
     {
         private const string TypeSeperator = "|";
 
@@ -14,7 +15,7 @@ namespace Abp.Runtime.Caching.Redis
         /// </summary>
         /// <param name="objbyte">String representation of the object from the Redis server.</param>
         /// <returns>Returns a newly constructed object.</returns>
-        /// <seealso cref="IRedisCacheSerialization.Serialize" />
+        /// <seealso cref="IRedisCacheSerializer.Serialize" />
         public object Deserialize(RedisValue objbyte)
         {
             string serializedObj = objbyte;
@@ -39,7 +40,7 @@ namespace Abp.Runtime.Caching.Redis
         /// <param name="value">Instance to serialize.</param>
         /// <param name="type">Type of the object.</param>
         /// <returns>Returns a string representing the object instance that can be placed into the Redis cache.</returns>
-        /// <seealso cref="IRedisCacheSerialization.Deserialize" />
+        /// <seealso cref="IRedisCacheSerializer.Deserialize" />
         public string Serialize(object value, Type type)
         {
             MemoryStream msTestString = new MemoryStream();

--- a/src/Abp.RedisCache/project.json
+++ b/src/Abp.RedisCache/project.json
@@ -1,10 +1,11 @@
 {
   "version": "1.0.0.0-*",
 
-  "dependencies": {
-    "Abp": "1.0.0.0-*",
-    "StackExchange.Redis": "1.1.605"
-  },
+    "dependencies": {
+        "Abp": "1.0.0.0-*",
+        "protobuf-net": "2.1.0",
+        "StackExchange.Redis": "1.1.605"
+    },
 
   "frameworks": {
     "net452": {

--- a/test/Abp.RedisCache.Tests/ProtoBufRedisCacheSerializer_Test.cs
+++ b/test/Abp.RedisCache.Tests/ProtoBufRedisCacheSerializer_Test.cs
@@ -1,0 +1,39 @@
+﻿using Abp.Runtime.Caching.Redis;
+using Abp.Tests;
+using ProtoBuf;
+using Shouldly;
+using Xunit;
+
+namespace Abp.RedisCache.Tests
+{
+    [ProtoContract]
+    public class ClassToSerialize
+    {
+        [ProtoMember(2)]
+        public int Age { get; set; }
+
+        [ProtoMember(1)]
+        public string Name { get; set; }
+    }
+
+    public class ProtoBufRedisCacheSerializer_Test : TestBaseWithLocalIocManager
+    {
+        [Fact]
+        public void Simple_Serialize_Deserialize_Test()
+        {
+            //Arrange
+            ProtoBufRedisCacheSerializer protoBufSerializer = new ProtoBufRedisCacheSerializer();
+            ClassToSerialize objectToSerialize = new ClassToSerialize {Age = 10, Name = "John"};
+
+            //Act
+            string classSerializedString = protoBufSerializer.Serialize(objectToSerialize, typeof(ClassToSerialize));
+            object classUnSerialized = protoBufSerializer.Deserialize(classSerializedString);
+
+            //Assert
+            classUnSerialized.ShouldBeOfType<ClassToSerialize>();
+            ClassToSerialize classUnSerializedTyped = classUnSerialized as ClassToSerialize;
+            classUnSerializedTyped.Age.ShouldBe(10);
+            classUnSerializedTyped.Name.ShouldBe("John");
+        }
+    }
+}

--- a/test/Abp.RedisCache.Tests/project.json
+++ b/test/Abp.RedisCache.Tests/project.json
@@ -1,12 +1,13 @@
-﻿{
+{
   "version": "1.0.0-*",
 
   "testRunner": "xunit",
 
-  "dependencies": {
-    "Abp.RedisCache": "1.0.0.0-*",
-    "Abp.Tests": "1.0.0-*"
-  },
+    "dependencies": {
+        "Abp.RedisCache": "1.0.0.0-*",
+        "Abp.Tests": "1.0.0-*",
+        "Shouldly": "2.8.2"
+    },
 
   "frameworks": {
     "net452": {


### PR DESCRIPTION
Hi Halil,

I have not modified AbpRedisCache to make use of the new IRedisCacheSerializer. Figured you could do that once you were happy with the PR.

Implementation wise I am reasonably happy with the outcome. Serializing a simple class of:

```c#
public class ClassToSerialize
{
    public int Age { get; set; }
    public string Name { get; set; }
}
```

yields the following when done with the default and proto-buf serializers:

```
Abp.RedisCache.Tests.ClassToSerialize, Abp.RedisCache.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null|{"Age":10,"Name":"John"}
Abp.RedisCache.Tests.ClassToSerialize, Abp.RedisCache.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null|CgRKb2huEAo=
```

so even though we have to Base64 encode the proto-buf it still works out smaller even with potential [size increases](https://www.google.com.au/search?q=base64+size+increase). I did not do any comparison of performance between the two serializers.

Areas for improvement:

1) Supply binary data (byte arrays) to Redis instead of strings (Aleviates the need for Base64 encoding of data for instance)
2) Find a better encoding scheme for Type.AssemblyQualifiedName as practically this takes up unecessary space 

I don't know enough about Redis and the StackOverflow implementation to answer 1) but a common space efficient encoding could defined for 2) and used for all the serializers.
