### PR TITLE
Fixed AbpXmlSource translation files: TimeZoneAllOfThesePermissionsMustBeGranted

### DIFF
--- a/src/Abp/Localization/Sources/AbpXmlSource/Abp-tr.xml
+++ b/src/Abp/Localization/Sources/AbpXmlSource/Abp-tr.xml
@@ -14,7 +14,7 @@
     <text name="ReceiveNotifications">Bildirimleri al</text>
     <text name="CurrentUserDidNotLoginToTheApplication">Kullanıcı girişi yapılmamış!</text>
     <text name="TimeZone">Zaman dilimi</text>
-    <text name="TimeZoneAllOfThesePermissionsMustBeGranted">Gereken izinler sağlanamadı. Şu izinlerin tamamı sağlanmış olmalı: {0}</text>
+    <text name="AllOfThesePermissionsMustBeGranted">Gereken izinler sağlanamadı. Şu izinlerin tamamı sağlanmış olmalı: {0}</text>
     <text name="AtLeastOneOfThesePermissionsMustBeGranted">Gereken izinler sağlanamadı. Şu izinlerin en az birisi sağlanmış olmalı: {0}</text>
   </texts>
 </localizationDictionary>

--- a/src/Abp/Localization/Sources/AbpXmlSource/Abp-zh-CN.xml
+++ b/src/Abp/Localization/Sources/AbpXmlSource/Abp-zh-CN.xml
@@ -14,7 +14,7 @@
     <text name="ReceiveNotifications">接收通知</text>
     <text name="CurrentUserDidNotLoginToTheApplication">当前用户没有登录到系统！</text>
     <text name="TimeZone">时区</text>
-    <text name="TimeZoneAllOfThesePermissionsMustBeGranted">您没有权限进行此操作,您需要以下权限: {0}</text>
+    <text name="AllOfThesePermissionsMustBeGranted">您没有权限进行此操作,您需要以下权限: {0}</text>
     <text name="AtLeastOneOfThesePermissionsMustBeGranted">您没有权限进行此操作,您至少需要下列权限的其中一项: {0}</text>
   </texts>
 </localizationDictionary>

--- a/src/Abp/Localization/Sources/AbpXmlSource/Abp.xml
+++ b/src/Abp/Localization/Sources/AbpXmlSource/Abp.xml
@@ -14,7 +14,7 @@
     <text name="ReceiveNotifications">Receive notifications</text>
     <text name="CurrentUserDidNotLoginToTheApplication">Current user did not login to the application!</text>
     <text name="TimeZone">Timezone</text>
-    <text name="TimeZoneAllOfThesePermissionsMustBeGranted">Required permissions are not granted. All of these permissions must be granted: {0}</text>
+    <text name="AllOfThesePermissionsMustBeGranted">Required permissions are not granted. All of these permissions must be granted: {0}</text>
     <text name="AtLeastOneOfThesePermissionsMustBeGranted">Required permissions are not granted. At least one of these permissions must be granted: {0}</text>
   </texts>
 </localizationDictionary>


### PR DESCRIPTION
TimeZoneAllOfThesePermissionsMustBeGranted changed to AllOfThesePermissionsMustBeGranted. There must have been some kind of spelling mistake.