### PR TITLE
Replaced ContinueWith with async/await in ResultWrapperHandler

### DIFF
--- a/src/Abp.Web.Api/WebApi/Controllers/ResultWrapperHandler.cs
+++ b/src/Abp.Web.Api/WebApi/Controllers/ResultWrapperHandler.cs
@@ -24,14 +24,11 @@ namespace Abp.WebApi.Controllers
             _configuration = configuration;
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return base.SendAsync(request, cancellationToken).ContinueWith(
-                task =>
-                {
-                    WrapResultIfNeeded(request, task.Result);
-                    return task.Result;
-                }, cancellationToken);
+            var result = await base.SendAsync(request, cancellationToken);
+            WrapResultIfNeeded(request, result);
+            return result;
         }
 
         protected virtual void WrapResultIfNeeded(HttpRequestMessage request, HttpResponseMessage response)


### PR DESCRIPTION
This fixes an issue in `ResultWrapperHandler` that prevents aborted requests from being completed.
To reproduce this issue you can add this code to an API controller ( and use the old `ResultWrapperHandler` with `ContinueWith`):
```
private static int s_counter;    

public async Task<IHttpActionResult> Submit()
{
    Interlocked.Increment(ref s_counter);
    await Task.Delay(30 * 1000);
    Interlocked.Decrement(ref s_counter);

    Debug.WriteLine($"Counter {s_counter}");

    return Ok(_counter);
}
```

and call it from browser. If you close the tab during the 30 seconds delay the request is aborted and `Interlocked.Decrement(ref s_counter);` will never be called.

This is problematic when you manually call `SaveChangesAsync` and the request is aborted before `uow.CompleteAsync` is called by `AbpApiUowFilter`. In this case the transaction will remain uncommitted and the acquired locks will never be released, blocking further updates.