### PR TITLE
Force specific .NET Core SDK - Remove unwanted type defeinitions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 ﻿{
-  "projects": [ "src", "test" ]
+  "projects": [ "src", "test" ],
+  "sdk": {
+    "version": "1.0.0-preview2-003131" //force specific .NET Core SDK Version when we have multiple
+  }
 }

--- a/src/Abp.Web.Api/WebApi/Controllers/Dynamic/Scripting/TypeScript/TypeScriptDefinitionGenerator.cs
+++ b/src/Abp.Web.Api/WebApi/Controllers/Dynamic/Scripting/TypeScript/TypeScriptDefinitionGenerator.cs
@@ -49,43 +49,6 @@ namespace Abp.WebApi.Controllers.Dynamic.Scripting.TypeScript
                 script.AppendLine();
             }
             script.AppendLine("}");
-            #region Create Script for Abp common objects
-
-            script.AppendLine("declare module abp {");
-            script.AppendLine("class ui {");
-            script.AppendLine("static setBusy(element, IPromise);");
-            script.AppendLine("}");
-            script.AppendLine("class nav {");
-            script.AppendLine("static menus: any;");
-            script.AppendLine("}");
-            script.AppendLine("class message{");
-            script.AppendLine("static info(message: string, title: string);");
-            script.AppendLine("static success(message: string, title: string);");
-            script.AppendLine("static warn(message: string, title: string);");
-            script.AppendLine("static error(message: string, title: string);");
-            script.AppendLine("}");
-            script.AppendLine("class notify {");
-            script.AppendLine("static info(message: string, title?: string);");
-            script.AppendLine("static success(message: string, title?: string);");
-            script.AppendLine("static warn(message: string, title?: string);");
-            script.AppendLine("static error(message: string, title?: string);");
-            script.AppendLine("}");
-            script.AppendLine("class localization{");
-            script.AppendLine("static languages: any;");
-            script.AppendLine("static currentLanguage: any;");
-            script.AppendLine("}");
-            script.AppendLine("interface IGenericPromise<T> {");
-            script.AppendLine("success(successCallback: (promiseValue: T) => any) : any;");
-            script.AppendLine("error(errorCallback: () => any) : any;");
-            script.AppendLine("}");
-            script.AppendLine("interface IPromise {");
-            script.AppendLine("success(successCallback: () => any) : any;");
-            script.AppendLine("error(errorCallback: () => any) : any;");
-            script.AppendLine("}");
-            script.AppendLine("}");
-
-            #endregion
-
             return script.ToString();
         }
 


### PR DESCRIPTION
Force specific .NET Core SDK. It is helpful when you have multiple versions installed.
Remove unwanted type definitions.