### PR TITLE
SimpleStringCipher Decrypt method Exception

### DIFF
--- a/src/Abp/Runtime/Security/SimpleStringCipher.cs
+++ b/src/Abp/Runtime/Security/SimpleStringCipher.cs
@@ -70,7 +70,7 @@ namespace Abp.Runtime.Security
 
         public string Decrypt(string cipherText, string passPhrase = DefaultPassPhrase)
         {
-            if (cipherText == null)
+            if (string.IsNullOrEmpty(cipherText))
             {
                 return null;
             }


### PR DESCRIPTION
if cipherText is empty, is exception