### PR TITLE
fix define is not defined

### DIFF
--- a/src/Abp.Web.Api/WebApi/Controllers/Dynamic/Scripting/jQuery/JQueryProxyGenerator.cs
+++ b/src/Abp.Web.Api/WebApi/Controllers/Dynamic/Scripting/jQuery/JQueryProxyGenerator.cs
@@ -33,7 +33,7 @@ namespace Abp.WebApi.Controllers.Dynamic.Scripting.jQuery
             //generate amd module definition
             if (_defineAmdModule)
             {
-                script.AppendLine("    if(define && typeof define === 'function' && define.amd){");
+                script.AppendLine("    if(typeof define === 'function' && define.amd){");
                 script.AppendLine("        define(function (require, exports, module) {");
                 script.AppendLine("            return {");
 


### PR DESCRIPTION
#1741  ReferenceError: define is not defined

[jquery judgment define the way](https://github.com/jquery/jquery/blob/ee2e377494a882f043e6d8abc67ac6370ee83d9c/dist/jquery.js#L10179)

```
if (typeof define === "function" && define.amd) {
	define("jquery", [], function(){
		return jQuery;
	});
}
```