### PR TITLE
Modify DapperExpressionVisitor.cs

### DIFF
--- a/src/Abp.Dapper/Dapper/Expressions/DapperExpressionVisitor.cs
+++ b/src/Abp.Dapper/Dapper/Expressions/DapperExpressionVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -48,51 +48,6 @@ namespace Abp.Dapper.Expressions
             return _pg.Predicates.Count == 1 ? _pg.Predicates[0] : _pg;
         }
 
-        private static PredicateGroup GetLastPredicateGroup(PredicateGroup grp)
-        {
-            IList<IPredicate> groups = grp.Predicates;
-
-            if (!groups.Any())
-            {
-                return grp;
-            }
-
-            IPredicate last = groups.Last();
-
-            if (last is PredicateGroup)
-            {
-                return GetLastPredicateGroup(last as PredicateGroup);
-            }
-
-            return grp;
-        }
-
-        private IFieldPredicate GetLastField()
-        {
-            PredicateGroup lastGrp = GetLastPredicateGroup(_pg);
-
-            IPredicate last = lastGrp.Predicates.Last();
-
-            return last as IFieldPredicate;
-        }
-
-        private IFieldPredicate GetCurrentField()
-        {
-            //IPredicate last =_currentGroup.Predicates.Last();
-
-            //return last as IFieldPredicate;
-
-            return GetCurrentField(_currentGroup);
-        }
-        private IFieldPredicate GetCurrentField(IPredicateGroup group)
-        {
-            IPredicate last = group.Predicates.Last();
-            if (last is IPredicateGroup)
-            {
-                return GetCurrentField(last as IPredicateGroup);
-            }
-            return last as IFieldPredicate;
-        }
         private static Operator DetermineOperator(Expression binaryExpression)
         {
             switch (binaryExpression.NodeType)
@@ -112,6 +67,21 @@ namespace Abp.Dapper.Expressions
             }
         }
 
+        private IFieldPredicate GetCurrentField()
+        {
+            return GetCurrentField(_currentGroup);
+        }
+
+        private IFieldPredicate GetCurrentField(IPredicateGroup group)
+        {
+            IPredicate last = group.Predicates.Last();
+            if (last is IPredicateGroup)
+            {
+                return GetCurrentField(last as IPredicateGroup);
+            }
+            return last as IFieldPredicate;
+        }
+
         private void AddField(MemberExpression exp, Operator op = Operator.Eq, object value = null, bool not = false)
         {
             PredicateGroup pg = _currentGroup;
@@ -123,6 +93,8 @@ namespace Abp.Dapper.Expressions
             pg.Predicates.Add(field);
         }
 
+
+        #region The visit methods override
         protected override Expression VisitBinary(BinaryExpression node)
         {
             Expressions.Add(node);
@@ -240,5 +212,6 @@ namespace Abp.Dapper.Expressions
 
             return base.VisitUnary(node); // returning base because we want to continue further processing - ie subsequent call to VisitMethodCall
         }
+        #endregion
     }
 }

--- a/src/Abp.Dapper/Dapper/Expressions/DapperExpressionVisitor.cs
+++ b/src/Abp.Dapper/Dapper/Expressions/DapperExpressionVisitor.cs
@@ -20,10 +20,12 @@ namespace Abp.Dapper.Expressions
         private PredicateGroup _pg;
         private Expression _processedProperty;
         private bool _unarySpecified;
-
+        private Stack<PredicateGroup> _predicateGroupStack;
+        public PredicateGroup _currentGroup { get; set; }
         public DapperExpressionVisitor()
         {
             Expressions = new HashSet<Expression>();
+            _predicateGroupStack = new Stack<PredicateGroup>();
         }
 
         /// <summary>
@@ -34,6 +36,7 @@ namespace Abp.Dapper.Expressions
         public IPredicate Process(Expression exp)
         {
             _pg = new PredicateGroup { Predicates = new List<IPredicate>() };
+            _currentGroup = _pg;
             Visit(Evaluator.PartialEval(exp));
 
             // the 1st expression determines root group operator
@@ -73,6 +76,23 @@ namespace Abp.Dapper.Expressions
             return last as IFieldPredicate;
         }
 
+        private IFieldPredicate GetCurrentField()
+        {
+            //IPredicate last =_currentGroup.Predicates.Last();
+
+            //return last as IFieldPredicate;
+
+            return GetCurrentField(_currentGroup);
+        }
+        private IFieldPredicate GetCurrentField(IPredicateGroup group)
+        {
+            IPredicate last = group.Predicates.Last();
+            if (last is IPredicateGroup)
+            {
+                return GetCurrentField(last as IPredicateGroup);
+            }
+            return last as IFieldPredicate;
+        }
         private static Operator DetermineOperator(Expression binaryExpression)
         {
             switch (binaryExpression.NodeType)
@@ -94,7 +114,7 @@ namespace Abp.Dapper.Expressions
 
         private void AddField(MemberExpression exp, Operator op = Operator.Eq, object value = null, bool not = false)
         {
-            PredicateGroup pg = GetLastPredicateGroup(_pg);
+            PredicateGroup pg = _currentGroup;
 
             // need convert from Expression<Func<T, bool>> to Expression<Func<T, object>> as this is what Predicates.Field() requires
             Expression<Func<TEntity, object>> fieldExp = Expression.Lambda<Func<TEntity, object>>(Expression.Convert(exp, typeof(object)), exp.Expression as ParameterExpression);
@@ -116,15 +136,17 @@ namespace Abp.Dapper.Expressions
                     Predicates = new List<IPredicate>(),
                     Operator = nt == ExpressionType.OrElse ? GroupOperator.Or : GroupOperator.And
                 };
+                _currentGroup.Predicates.Add(pg);
+                _predicateGroupStack.Push(_currentGroup);
+                _currentGroup = pg;
 
-                _pg.Predicates.Add(pg);
             }
 
             Visit(node.Left);
 
             if (node.Left is MemberExpression)
             {
-                IFieldPredicate field = GetLastField();
+                IFieldPredicate field = GetCurrentField();
                 field.Operator = DetermineOperator(node);
 
                 if (nt == ExpressionType.NotEqual)
@@ -134,7 +156,10 @@ namespace Abp.Dapper.Expressions
             }
 
             Visit(node.Right);
-
+            if (nt == ExpressionType.OrElse || nt == ExpressionType.AndAlso)
+            {
+                _currentGroup = _predicateGroupStack.Pop();
+            }
             return node;
         }
 
@@ -159,9 +184,8 @@ namespace Abp.Dapper.Expressions
 
         protected override Expression VisitConstant(ConstantExpression node)
         {
-            IFieldPredicate field = GetLastField();
+            IFieldPredicate field = GetCurrentField();
             field.Value = node.Value;
-
             return node;
         }
 


### PR DESCRIPTION
Fixed the bug when used '&&' and '||' together in Lamba Expression,just like this, 'x => x.CarId == 1 && x.IsActive|| x.PersonId == 1'.