### PR TITLE
feat(app-services): Introduced CacheResultAttribute to allow response cache control

### DIFF
--- a/src/Abp.AspNetCore/Abp.AspNetCore.csproj
+++ b/src/Abp.AspNetCore/Abp.AspNetCore.csproj
@@ -45,4 +45,8 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="AspNetCore\Mvc\Results\Caching\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
@@ -10,6 +10,8 @@ namespace Abp.AspNetCore.Configuration
     {
         public WrapResultAttribute DefaultWrapResultAttribute { get; }
 
+        public CacheResultAttribute DefaultCacheResultAttribute { get; }
+
         public UnitOfWorkAttribute DefaultUnitOfWorkAttribute { get; }
 
         public List<Type> FormBodyBindingIgnoredTypes { get; }
@@ -25,6 +27,7 @@ namespace Abp.AspNetCore.Configuration
         public AbpAspNetCoreConfiguration()
         {
             DefaultWrapResultAttribute = new WrapResultAttribute();
+            DefaultCacheResultAttribute = new CacheResultAttribute();
             DefaultUnitOfWorkAttribute = new UnitOfWorkAttribute();
             ControllerAssemblySettings = new ControllerAssemblySettingList();
             FormBodyBindingIgnoredTypes = new List<Type>();

--- a/src/Abp.AspNetCore/AspNetCore/Configuration/IAbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/IAbpAspNetCoreConfiguration.cs
@@ -10,6 +10,8 @@ namespace Abp.AspNetCore.Configuration
     {
         WrapResultAttribute DefaultWrapResultAttribute { get; }
 
+        CacheResultAttribute DefaultCacheResultAttribute { get; }
+
         UnitOfWorkAttribute DefaultUnitOfWorkAttribute { get; }
 
         List<Type> FormBodyBindingIgnoredTypes { get; }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultFilter.cs
@@ -1,4 +1,5 @@
-﻿using Abp.AspNetCore.Configuration;
+﻿using System;
+using Abp.AspNetCore.Configuration;
 using Abp.AspNetCore.Mvc.Extensions;
 using Abp.AspNetCore.Mvc.Results.Wrapping;
 using Abp.Dependency;
@@ -18,12 +19,27 @@ namespace Abp.AspNetCore.Mvc.Results
 
         public virtual void OnResultExecuting(ResultExecutingContext context)
         {
-            if (_configuration.SetNoCacheForAjaxResponses && context.HttpContext.Request.IsAjaxRequest())
+            var methodInfo = context.ActionDescriptor.GetMethodInfo();
+
+            var cacheResultAttribute =
+            ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
+                methodInfo,
+                _configuration.DefaultCacheResultAttribute
+            );
+
+            if (!cacheResultAttribute.NoCache)
+            {
+                SetCache(context,
+                    cacheResultAttribute.MustRevalidate,
+                    cacheResultAttribute.PrivateOnly,
+                    cacheResultAttribute.MaxAge);
+            }
+            else if (cacheResultAttribute.NoCache || 
+                (_configuration.SetNoCacheForAjaxResponses && context.HttpContext.Request.IsAjaxRequest()))
             {
                 SetNoCache(context);
             }
 
-            var methodInfo = context.ActionDescriptor.GetMethodInfo();
             var wrapResultAttribute =
                 ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
                     methodInfo,
@@ -40,11 +56,22 @@ namespace Abp.AspNetCore.Mvc.Results
                 .Wrap(context);
         }
 
+        private void SetCache(ResultExecutingContext context, bool mustRevalidate, bool privateOnly, int maxAge)
+        {
+            if (maxAge > 0)
+            {
+                context.HttpContext.Response.Headers["Cache-Control"] =
+                    (privateOnly ? "private, " : "public, ") +
+                    (mustRevalidate ? "must-revalidate, " : "") +
+                    ("max-age=" + maxAge);
+            }
+        }
+
         public virtual void OnResultExecuted(ResultExecutedContext context)
         {
             //no action
         }
-        
+
         protected virtual void SetNoCache(ResultExecutingContext context)
         {
             //Based on http://stackoverflow.com/questions/49547/making-sure-a-web-page-is-not-cached-across-all-browsers

--- a/src/Abp/Web/Models/CacheResultAttribute.cs
+++ b/src/Abp/Web/Models/CacheResultAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Abp.Web.Models
+{
+    /// <summary>
+    /// Used to determine how response should be cached
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Method)]
+    public class CacheResultAttribute : Attribute
+    {
+        public CacheResultAttribute()
+        {
+        }
+        CacheResultAttribute(int maxAge, bool privateOnly = false, bool mustRevalidate = true)
+            : this(maxAge)
+        {
+            PrivateOnly = privateOnly;
+            MustRevalidate = mustRevalidate;
+        }
+        public CacheResultAttribute(int maxAge)
+        {
+            NoCache = maxAge > 0;
+            MaxAge = maxAge;
+        }
+
+        public bool NoCache { get; set; } = true;
+        public int MaxAge { get; set; } = 0;
+        public bool MustRevalidate { get; set; } = true;
+        public bool PrivateOnly { get; set; } = true;
+    }
+}


### PR DESCRIPTION
I introduced a CacheResult attribute to allow control of the response cache headers