### PR TITLE
DapperExtensions 1.5.0 referenced for .net targeted projects

### DIFF
--- a/src/Abp.Dapper/Abp.Dapper.csproj
+++ b/src/Abp.Dapper/Abp.Dapper.csproj
@@ -29,17 +29,18 @@
     <ProjectReference Include="..\Abp\Abp.csproj" />
     <PackageReference Include="Dapper" Version="1.50.2" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <PackageReference Include="DapperExtensions.DotnetCore" Version="1.0.1" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="DapperExtensions" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="DapperExtensions.DotnetCore" Version="1.0.1" />
   </ItemGroup>
   
 </Project>

--- a/test/Abp.Dapper.NHibernate.Tests/Abp.Dapper.NHibernate.Tests.csproj
+++ b/test/Abp.Dapper.NHibernate.Tests/Abp.Dapper.NHibernate.Tests.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DapperExtensions.DotnetCore" Version="1.0.1" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.105.1" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
DapperExtensions 1.5.0 referenced for .net targeted projects, others are DapperExtensions.DotnetCore.
Fix for #2209