### PR TITLE
Fixed incorrect parameter name

### DIFF
--- a/src/Abp/Authorization/SimplePermissionDependency.cs
+++ b/src/Abp/Authorization/SimplePermissionDependency.cs
@@ -23,7 +23,7 @@ namespace Abp.Authorization
         /// <summary>
         /// Initializes a new instance of the <see cref="SimplePermissionDependency"/> class.
         /// </summary>
-        /// <param name="permissions">The features.</param>
+        /// <param name="permissions">The permissions.</param>
         public SimplePermissionDependency(params string[] permissions)
         {
             Permissions = permissions;
@@ -36,9 +36,9 @@ namespace Abp.Authorization
         /// If this is set to true, all of the <see cref="Permissions"/> must be granted.
         /// If it's false, at least one of the <see cref="Permissions"/> must be granted.
         /// </param>
-        /// <param name="features">The features.</param>
-        public SimplePermissionDependency(bool requiresAll, params string[] features)
-            : this(features)
+        /// <param name="permissions">The permissions.</param>
+        public SimplePermissionDependency(bool requiresAll, params string[] permissions)
+            : this(permissions)
         {
             RequiresAll = requiresAll;
         }


### PR DESCRIPTION
Fixed incorrect parameter name ```features``` in SimplePermissionDependency.cs