### PR TITLE
.To<Guid>() object extension method throws Invalid cast from 'System.String' to 'System.Guid' exception.

### DIFF
--- a/src/Abp/Extensions/ObjectExtensions.cs
+++ b/src/Abp/Extensions/ObjectExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+using System.ComponentModel;
 
 namespace Abp.Extensions
 {
@@ -30,6 +31,11 @@ namespace Abp.Extensions
         public static T To<T>(this object obj)
             where T : struct
         {
+            if (typeof(T) == typeof(Guid))
+            {
+                return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFromInvariantString(obj.ToString());
+            }
+
             return (T)Convert.ChangeType(obj, typeof(T), CultureInfo.InvariantCulture);
         }
 

--- a/test/Abp.Tests/Extensions/ObjectExtension_Test.cs
+++ b/test/Abp.Tests/Extensions/ObjectExtension_Test.cs
@@ -32,7 +32,9 @@ namespace Abp.Tests.Extensions
 
             "false".To<bool>().ShouldBeOfType<bool>().ShouldBe(false);
             "True".To<bool>().ShouldBeOfType<bool>().ShouldBe(true);
-            
+
+            "2260afec-bbfd-42d4-a91a-dcb11e09b17f".To<Guid>().ShouldBeOfType<Guid>().ShouldBe(new Guid("2260afec-bbfd-42d4-a91a-dcb11e09b17f"));
+
             Assert.Throws<FormatException>(() => "test".To<bool>());
             Assert.Throws<FormatException>(() => "test".To<int>());
         }


### PR DESCRIPTION
The following exception is thrown when the extension method is called like 
`var x = value.To<Guid>();`

> Invalid cast from 'System.String' to 'System.Guid'

This PR uses a different method to convert to a Guid. An example has been added to an existing unit test to cover the changes.