### PR TITLE
replace "Assembly.LoadFile" with "file => Assembly.Load(AssemblyName.GetAssemblyName(file))"

### DIFF
--- a/src/Abp/PlugIns/AssemblyFileListPlugInSource.cs
+++ b/src/Abp/PlugIns/AssemblyFileListPlugInSource.cs
@@ -54,7 +54,7 @@ namespace Abp.PlugIns
         private List<Assembly> LoadAssemblies()
         {
             return FilePaths.Select(
-                Assembly.LoadFile //TODO: Use AssemblyLoadContext.Default.LoadFromAssemblyPath instead?
+                 file => Assembly.Load(AssemblyName.GetAssemblyName(file))
             ).ToList();
         }
     }

--- a/src/Abp/Reflection/AssemblyHelper.cs
+++ b/src/Abp/Reflection/AssemblyHelper.cs
@@ -15,7 +15,7 @@ namespace Abp.Reflection
                 .Where(s => s.EndsWith(".dll") || s.EndsWith(".exe"));
 
             return assemblyFiles.Select(
-                Assembly.LoadFile
+                file => Assembly.Load(AssemblyName.GetAssemblyName(file))
             ).ToList();
         }
     }


### PR DESCRIPTION
#2580: I still think `file => Assembly.Load(AssemblyName.GetAssemblyName(file))` is a good choice.It works well. 
### Two reasons:
1.  `Assembly.LoadFile` may be cause exception when you use both "**DependsOn**" and "**AssemblyFileListPlugInSource**" to load the same module.
2.  `AssemblyLoadContext.Default.LoadFromAssemblyPath` is not supported net461.