### PR TITLE
Prevent IE11 caching GET call in Angular 2

### DIFF
--- a/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.jquery.js
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.jquery.js
@@ -13,6 +13,17 @@
         userOptions = userOptions || {};
 
         var options = $.extend(true, {}, abp.ajax.defaultOpts, userOptions);
+        var oldBeforeSendOption = options.beforeSend;		
+        options.beforeSend = function(xhr) {
+            if (oldBeforeSendOption) {
+                 oldBeforeSendOption(xhr);
+            }
+
+            xhr.setRequestHeader("Pragma", "no-cache");
+            xhr.setRequestHeader("Cache-Control", "no-cache");
+            xhr.setRequestHeader("Expires", "Sat, 01 Jan 2000 00:00:00 GMT");
+        };
+
         options.success = undefined;
         options.error = undefined;
 


### PR DESCRIPTION
Replaces 
https://github.com/aspnetboilerplate/bower-abp-resources/pull/5
as changes to abp.jquery.js should be made here and not in https://github.com/aspnetboilerplate/bower-abp-resources