### PR TITLE
Update IBackgroundJobManager.EnqueueAsync to return the Id of the Job…

### DIFF
--- a/src/Abp.HangFire/Hangfire/HangfireBackgroundJobManager.cs
+++ b/src/Abp.HangFire/Hangfire/HangfireBackgroundJobManager.cs
@@ -48,14 +48,32 @@ namespace Abp.Hangfire
             base.WaitToStop();
         }
 
-        public Task EnqueueAsync<TJob, TArgs>(TArgs args, BackgroundJobPriority priority = BackgroundJobPriority.Normal,
+        public Task<string> EnqueueAsync<TJob, TArgs>(TArgs args, BackgroundJobPriority priority = BackgroundJobPriority.Normal,
             TimeSpan? delay = null) where TJob : IBackgroundJob<TArgs>
         {
+            string jobUniqueIdentifier = string.Empty;
+
             if (!delay.HasValue)
-                HangfireBackgroundJob.Enqueue<TJob>(job => job.Execute(args));
+            { 
+                jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => job.Execute(args));
+            }
             else
-                HangfireBackgroundJob.Schedule<TJob>(job => job.Execute(args), delay.Value);
-            return Task.FromResult(0);
+            {
+                jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => job.Execute(args), delay.Value);
+            }
+
+            return Task.FromResult(jobUniqueIdentifier);
+        }
+
+        public Task<bool> DeleteAsync(string jobId)
+        {
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentNullException(nameof(jobId));
+            }
+
+            bool successfulDeletion = HangfireBackgroundJob.Delete(jobId);
+            return Task.FromResult(successfulDeletion);
         }
     }
 }

--- a/src/Abp.Zero.Common/BackgroundJobs/BackgroundJobStore.cs
+++ b/src/Abp.Zero.Common/BackgroundJobs/BackgroundJobStore.cs
@@ -20,6 +20,11 @@ namespace Abp.BackgroundJobs
             _backgroundJobRepository = backgroundJobRepository;
         }
 
+        public Task<BackgroundJobInfo> GetAsync(long jobId)
+        {
+            return _backgroundJobRepository.GetAsync(jobId);
+        }
+
         public Task InsertAsync(BackgroundJobInfo jobInfo)
         {
             return _backgroundJobRepository.InsertAsync(jobInfo);

--- a/src/Abp/BackgroundJobs/IBackgroundJobManager.cs
+++ b/src/Abp/BackgroundJobs/IBackgroundJobManager.cs
@@ -18,7 +18,15 @@ namespace Abp.BackgroundJobs
         /// <param name="args">Job arguments.</param>
         /// <param name="priority">Job priority.</param>
         /// <param name="delay">Job delay (wait duration before first try).</param>
-        Task EnqueueAsync<TJob, TArgs>(TArgs args, BackgroundJobPriority priority = BackgroundJobPriority.Normal, TimeSpan? delay = null)
+        /// <returns>Unique identifier of a background job.</returns>
+        Task<string> EnqueueAsync<TJob, TArgs>(TArgs args, BackgroundJobPriority priority = BackgroundJobPriority.Normal, TimeSpan? delay = null)
             where TJob : IBackgroundJob<TArgs>;
+
+        /// <summary>
+        /// Deletes a job with the specified jobId.
+        /// </summary>
+        /// <param name="jobId">The Job Unique Identifier.</param>
+        /// <returns><c>True</c> on a successfull state transition, <c>false</c> otherwise.</returns>
+        Task<bool> DeleteAsync(string jobId);
     }
 }

--- a/src/Abp/BackgroundJobs/IBackgroundJobStore.cs
+++ b/src/Abp/BackgroundJobs/IBackgroundJobStore.cs
@@ -9,6 +9,13 @@ namespace Abp.BackgroundJobs
     public interface IBackgroundJobStore
     {
         /// <summary>
+        /// Gets a BackgroundJobInfo based on the given jobId.
+        /// </summary>
+        /// <param name="jobId">The Job Unique Identifier.</param>
+        /// <returns>The BackgroundJobInfo object.</returns>
+        Task<BackgroundJobInfo> GetAsync(long jobId);
+
+        /// <summary>
         /// Inserts a background job.
         /// </summary>
         /// <param name="jobInfo">Job information.</param>

--- a/src/Abp/BackgroundJobs/InMemoryBackgroundJobStore.cs
+++ b/src/Abp/BackgroundJobs/InMemoryBackgroundJobStore.cs
@@ -24,6 +24,11 @@ namespace Abp.BackgroundJobs
             _jobs = new Dictionary<long, BackgroundJobInfo>();
         }
 
+        public Task<BackgroundJobInfo> GetAsync(long jobId)
+        {
+            return Task.FromResult(_jobs[jobId]);
+        }
+
         public Task InsertAsync(BackgroundJobInfo jobInfo)
         {
             jobInfo.Id = Interlocked.Increment(ref _lastId);

--- a/src/Abp/BackgroundJobs/NullBackgroundJobStore.cs
+++ b/src/Abp/BackgroundJobs/NullBackgroundJobStore.cs
@@ -10,6 +10,11 @@ namespace Abp.BackgroundJobs
     /// </summary>
     public class NullBackgroundJobStore : IBackgroundJobStore
     {
+        public Task<BackgroundJobInfo> GetAsync(long jobId)
+        {
+            return Task.FromResult(new BackgroundJobInfo());
+        }
+
         public Task InsertAsync(BackgroundJobInfo jobInfo)
         {
             return Task.FromResult(0);

--- a/test/Abp.Tests/BackgroundJobs/InMemoryBackgroundJobStore_Tests.cs
+++ b/test/Abp.Tests/BackgroundJobs/InMemoryBackgroundJobStore_Tests.cs
@@ -25,6 +25,12 @@ namespace Abp.Tests.BackgroundJobs
             
             await _store.InsertAsync(jobInfo);
             (await _store.GetWaitingJobsAsync(1000)).Count.ShouldBe(1);
+
+            var jobInfoFromStore = await _store.GetAsync(1);
+            jobInfoFromStore.ShouldNotBeNull();
+            jobInfoFromStore.JobType.ShouldBeSameAs(jobInfo.JobType);
+            jobInfoFromStore.JobArgs.ShouldBeSameAs(jobInfo.JobArgs);
+
             await _store.DeleteAsync(jobInfo);
             (await _store.GetWaitingJobsAsync(1000)).Count.ShouldBe(0);
         }


### PR DESCRIPTION
This PR contains the following changes (related to #2645):

- Update IBackgroundJobManager.EnqueueAsync to return the Id of the Job returned. 
- Add IBackgroundJobManager.DeleteAsync.

I would like to be able to keep track of a job created. In order to achieve that, I need to get the JobId created by Hangfire. In some specific cases, it may be required to delete a job which is no longer required.

Essentially, I am enhancing the IBackgroundJobManager interface to return the JobId and allow deletion.

Thank you for taking this change in consideration.

Martin
