### PR TITLE
Check user lockout for user log in from LDAP

### DIFF
--- a/src/Abp.Zero/Authorization/AbpLoginManager.cs
+++ b/src/Abp.Zero/Authorization/AbpLoginManager.cs
@@ -164,24 +164,14 @@ namespace Abp.Authorization
                     return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.InvalidUserNameOrEmailAddress, tenant);
                 }
 
-                var fromLdap = user.AuthenticationSource == "LDAP";
-                if (fromLdap)
+                if (await UserManager.IsLockedOutAsync(user.Id))
                 {
-                    if (await UserManager.IsLockedOutAsync(user.Id))
-                    {
-                        return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.LockedOut, tenant, user);
-                    }
+                    return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.LockedOut, tenant, user);
                 }
 
                 if (!loggedInFromExternalSource)
                 {
                     UserManager.InitializeLockoutSettings(tenantId);
-
-                    if (await UserManager.IsLockedOutAsync(user.Id))
-                    {
-                        return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.LockedOut, tenant, user);
-                    }
-
                     var verificationResult = UserManager.PasswordHasher.VerifyHashedPassword(user.Password, plainPassword);
                     if (verificationResult == PasswordVerificationResult.Failed)
                     {

--- a/src/Abp.Zero/Authorization/AbpLoginManager.cs
+++ b/src/Abp.Zero/Authorization/AbpLoginManager.cs
@@ -164,6 +164,15 @@ namespace Abp.Authorization
                     return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.InvalidUserNameOrEmailAddress, tenant);
                 }
 
+                var fromLdap = user.AuthenticationSource == "LDAP";
+                if (fromLdap)
+                {
+                    if (await UserManager.IsLockedOutAsync(user.Id))
+                    {
+                        return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.LockedOut, tenant, user);
+                    }
+                }
+
                 if (!loggedInFromExternalSource)
                 {
                     UserManager.InitializeLockoutSettings(tenantId);

--- a/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
+++ b/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
@@ -174,6 +174,14 @@ namespace Abp.Authorization
                 {
                     return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.InvalidUserNameOrEmailAddress, tenant);
                 }
+                var fromLdap = user.AuthenticationSource == "LDAP";
+                if (fromLdap)
+                {
+                    if (await UserManager.IsLockedOutAsync(user))
+                    {
+                        return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.LockedOut, tenant, user);
+                    }
+                }
 
                 if (!loggedInFromExternalSource)
                 {


### PR DESCRIPTION
I am developing an enterprise application. All my user login solely from LDAP.
And I have an admin portal to manage all application users.

Admin user can set a user's LockoutEndDateUtc column to temporarily prevent the user from login.

However, the LoginManager doesn't check lockout status if the user is logged in from LDAP.

I have added the logic to check lockout status in this PR.