### PR TITLE
Set FeatureDependencyContext.TenantId before using it

### DIFF
--- a/src/Abp.Zero/Authorization/Roles/AbpRoleManager.cs
+++ b/src/Abp.Zero/Authorization/Roles/AbpRoleManager.cs
@@ -332,6 +332,8 @@ namespace Abp.Authorization.Roles
 
         public async Task GrantAllPermissionsAsync(TRole role)
         {
+            FeatureDependencyContext.TenantId = role.TenantId;
+
             var permissions = _permissionManager.GetAllPermissions(role.GetMultiTenancySide())
                                                 .Where(permission => 
                                                     permission.FeatureDependency == null || 

--- a/src/Abp.ZeroCore/Authorization/Roles/AbpRoleManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Roles/AbpRoleManager.cs
@@ -333,6 +333,8 @@ namespace Abp.Authorization.Roles
 
         public async Task GrantAllPermissionsAsync(TRole role)
         {
+            FeatureDependencyContext.TenantId = role.TenantId;
+
             var permissions = _permissionManager.GetAllPermissions(role.GetMultiTenancySide())
                 .Where(permission =>
                     permission.FeatureDependency == null ||

--- a/src/Abp.ZeroCore/Authorization/Roles/AbpRoleManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Roles/AbpRoleManager.cs
@@ -336,10 +336,10 @@ namespace Abp.Authorization.Roles
             FeatureDependencyContext.TenantId = role.TenantId;
 
             var permissions = _permissionManager.GetAllPermissions(role.GetMultiTenancySide())
-                .Where(permission =>
-                    permission.FeatureDependency == null ||
-                    permission.FeatureDependency.IsSatisfied(FeatureDependencyContext)
-                );
+                                                .Where(permission =>
+                                                    permission.FeatureDependency == null ||
+                                                    permission.FeatureDependency.IsSatisfied(FeatureDependencyContext)
+                                                );
 
             await SetGrantedPermissionsAsync(role, permissions);
         }


### PR DESCRIPTION
Fixes #2748
Follows https://github.com/aspnetboilerplate/aspnetboilerplate/commit/5110b86dcc7ff4c48085da596664ddfebb084a75

`GrantAllPermissionsAsync` should set `FeatureDependencyContext.TenantId` based on the `role` that the permissions are being granted to. This makes the logic more obvious in:

```c#
public async Task GrantAllPermissionsAsync(TRole role)
{
    FeatureDependencyContext = role.TenantId;

    // ...
    // permission.FeatureDependency.IsSatisfied(FeatureDependencyContext)
    // ...
}
```

This would also be consistent with how it's being done when `FeatureDependencyContext` is used in [`NotificationDefinitionManager`](https://github.com/aspnetboilerplate/aspnetboilerplate/blob/7852b028eb0499a802d3cb31d5790353e2ece0f7/src/Abp/Notifications/NotificationDefinitionManager.cs#L87) and [`UserNavigationManager`](https://github.com/aspnetboilerplate/aspnetboilerplate/blob/fc3a82fa9bee61ca12fde0ba1592ef1025c36fac/src/Abp/Application/Navigation/UserNavigationManager.cs#L69) to check the feature dependency.