### PR TITLE
Embeded resources

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/EmbeddedResources/EmbeddedResourceFileProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/EmbeddedResources/EmbeddedResourceFileProvider.cs
@@ -4,6 +4,8 @@ using Abp.Resources.Embedded;
 using Abp.Web.Configuration;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
+using System.Linq;
+using System.IO;
 
 namespace Abp.AspNetCore.EmbeddedResources
 {
@@ -35,6 +37,7 @@ namespace Abp.AspNetCore.EmbeddedResources
                 return new NotFoundFileInfo(subpath);
             }
 
+            var filename = Path.GetFileName(subpath);
             var resource = _embeddedResourceManager.Value.GetResource(subpath);
 
             if (resource == null || IsIgnoredFile(resource))
@@ -42,7 +45,7 @@ namespace Abp.AspNetCore.EmbeddedResources
                 return new NotFoundFileInfo(subpath);
             }
 
-            return new EmbeddedResourceItemFileInfo(resource);
+            return new EmbeddedResourceItemFileInfo(resource, filename);
         }
 
         public IDirectoryContents GetDirectoryContents(string subpath)
@@ -52,9 +55,15 @@ namespace Abp.AspNetCore.EmbeddedResources
                 return new NotFoundDirectoryContents();
             }
 
-            //TODO: Implement...?
-
-            return new NotFoundDirectoryContents();
+            // The file name is assumed to be the remainder of the resource name. 
+            if (subpath == null)
+            {
+                return new NotFoundDirectoryContents();
+            }
+            var resources = _embeddedResourceManager.Value.GetResources(subpath);
+            return new EmbeddedResourceItemDirectoryContents(resources
+                .Where(r=> !IsIgnoredFile(r))
+                .Select(r=> new EmbeddedResourceItemFileInfo(r, r.FileName.Substring(subpath.Length-1))));
         }
 
         public IChangeToken Watch(string filter)

--- a/src/Abp.AspNetCore/AspNetCore/EmbeddedResources/EmbeddedResourceItemDirectoryContents.cs
+++ b/src/Abp.AspNetCore/AspNetCore/EmbeddedResources/EmbeddedResourceItemDirectoryContents.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Abp.Resources.Embedded;
+using Microsoft.Extensions.FileProviders;
+
+namespace Abp.AspNetCore.EmbeddedResources
+{
+    public class EmbeddedResourceItemDirectoryContents : IDirectoryContents
+    {
+        private readonly IEnumerable<IFileInfo> _entries;
+
+        public EmbeddedResourceItemDirectoryContents(IEnumerable<IFileInfo> entries)
+        {
+            if (entries == null)
+            {
+                throw new ArgumentNullException(nameof(entries));
+            }
+            _entries = entries;
+        }
+
+        public bool Exists
+        {
+            get { return true; }
+        }
+
+        public IEnumerator<IFileInfo> GetEnumerator()
+        {
+            return _entries.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _entries.GetEnumerator();
+        }
+    }
+}

--- a/src/Abp.AspNetCore/AspNetCore/EmbeddedResources/EmbeddedResourceItemFileInfo.cs
+++ b/src/Abp.AspNetCore/AspNetCore/EmbeddedResources/EmbeddedResourceItemFileInfo.cs
@@ -13,17 +13,19 @@ namespace Abp.AspNetCore.EmbeddedResources
 
         public string PhysicalPath => null;
 
-        public string Name => _resourceItem.FileName;
+        public string Name => _name;
 
         public DateTimeOffset LastModified => _resourceItem.LastModifiedUtc;
 
         public bool IsDirectory => false;
         
         private readonly EmbeddedResourceItem _resourceItem;
+        private readonly string _name;
 
-        public EmbeddedResourceItemFileInfo(EmbeddedResourceItem resourceItem)
+        public EmbeddedResourceItemFileInfo(EmbeddedResourceItem resourceItem, string name)
         {
             _resourceItem = resourceItem;
+            _name = name;
         }
 
         public Stream CreateReadStream()

--- a/src/Abp/Resources/Embedded/EmbeddedFilePathHelper.cs
+++ b/src/Abp/Resources/Embedded/EmbeddedFilePathHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace Abp.Resources.Embedded
 {
@@ -6,7 +7,56 @@ namespace Abp.Resources.Embedded
     {
         public static string NormalizePath(string fullPath)
         {
-            return fullPath?.Replace("/", ".");
+            return fullPath?.Replace("/", ".").TrimStart('.');
+        }
+
+        public static string EncodeAsResourcesPath(string subPath)
+        {
+
+            var builder = new StringBuilder(subPath.Length);
+
+            // does the subpath contain directory portion - if so we need to encode it.
+            var indexOfLastSeperator = subPath.LastIndexOf('/');
+            if (indexOfLastSeperator != -1)
+            {
+                // has directory portion to encode.
+                for (int i = 0; i <= indexOfLastSeperator; i++)
+                {
+                    var currentChar = subPath[i];
+
+                    if (currentChar == '/')
+                    {
+                        if (i != 0) // omit a starting slash (/), encode any others as a dot
+                        {
+                            builder.Append('.');
+                        }
+                        continue;
+                    }
+
+                    if (currentChar == '-')
+                    {
+                        builder.Append('_');
+                        continue;
+                    }
+
+                    builder.Append(currentChar);
+                }
+            }
+
+            // now append (and encode as necessary) filename portion
+            if (subPath.Length > indexOfLastSeperator + 1)
+            {
+                // has filename to encode
+                for (int c = indexOfLastSeperator + 1; c < subPath.Length; c++)
+                {
+                    var currentChar = subPath[c];
+                    // no encoding to do on filename - so just append
+                    builder.Append(currentChar);
+                }
+            }
+
+            return builder.ToString();
+
         }
     }
 }

--- a/src/Abp/Resources/Embedded/EmbeddedFilePathHelper.cs
+++ b/src/Abp/Resources/Embedded/EmbeddedFilePathHelper.cs
@@ -6,24 +6,7 @@ namespace Abp.Resources.Embedded
     {
         public static string NormalizePath(string fullPath)
         {
-            var fileName = fullPath;
-            var extension = "";
-
-            if (fileName.Contains("."))
-            {
-                extension = fullPath.Substring(fileName.LastIndexOf(".", StringComparison.Ordinal));
-                if (extension.Contains("/"))
-                {
-                    //That means the file does not have extension, but a directory has "." char. So, clear extension.
-                    extension = "";
-                }
-                else
-                {
-                    fileName = fullPath.Substring(0, fullPath.Length - extension.Length);
-                }
-            }
-
-            return fileName + extension;
+            return fullPath?.Replace("/", ".");
         }
     }
 }

--- a/src/Abp/Resources/Embedded/EmbeddedResourceManager.cs
+++ b/src/Abp/Resources/Embedded/EmbeddedResourceManager.cs
@@ -25,7 +25,12 @@ namespace Abp.Resources.Embedded
         /// <inheritdoc/>
         public EmbeddedResourceItem GetResource(string fullPath)
         {
-            return _resources.Value.GetOrDefault(EmbeddedResourcePathHelper.NormalizePath(fullPath));
+            var resource = _resources.Value.GetOrDefault(EmbeddedResourcePathHelper.NormalizePath(fullPath));
+            if (resource != null)
+            {
+                return new EmbeddedResourceItem(System.IO.Path.GetFileName(fullPath), resource.Content, resource.Assembly);
+            }
+            return null;
         }
 
         private Dictionary<string, EmbeddedResourceItem> CreateResourcesDictionary()
@@ -36,8 +41,25 @@ namespace Abp.Resources.Embedded
             {
                 source.AddResources(resources);
             }
-
             return resources;
+        }
+
+        class EmbeddedResourceItemComparer : IEqualityComparer<string>
+        {
+            public bool Equals(string fullPath1, string fullPath2)
+            {
+                return InvariantResourceName(fullPath1).Equals(InvariantResourceName(fullPath2));
+            }
+
+            public int GetHashCode(string fullPath)
+            {
+                return InvariantResourceName(fullPath).GetHashCode();
+            }
+            private string InvariantResourceName(string fullPath)
+            {
+                return fullPath.Replace("/", ".");
+            }
+
         }
     }
 }

--- a/src/Abp/Resources/Embedded/EmbeddedResourceSet.cs
+++ b/src/Abp/Resources/Embedded/EmbeddedResourceSet.cs
@@ -34,10 +34,11 @@ namespace Abp.Resources.Embedded
 
                 using (var stream = Assembly.GetManifestResourceStream(resourceName))
                 {
-                    var filePath = RootPath + ConvertToRelativePath(resourceName);
+                    var relativePath = ConvertToRelativePath(resourceName);
+                    var filePath = EmbeddedResourcePathHelper.NormalizePath(RootPath + relativePath);
 
                     resources[filePath] = new EmbeddedResourceItem(
-                        CalculateFileName(filePath),
+                        relativePath,
                         stream.GetAllBytes(),
                         Assembly
                     );
@@ -47,18 +48,7 @@ namespace Abp.Resources.Embedded
 
         private string ConvertToRelativePath(string resourceName)
         {
-            resourceName = resourceName.Substring(ResourceNamespace.Length + 1);
-
-            var pathParts = resourceName.Split('.');
-            if (pathParts.Length <= 2)
-            {
-                return resourceName;
-            }
-
-            var folder = pathParts.Take(pathParts.Length - 2).JoinAsString("/");
-            var fileName = pathParts[pathParts.Length - 2] + "." + pathParts[pathParts.Length - 1];
-
-            return folder + "/" + fileName;
+            return resourceName.Substring(ResourceNamespace.Length + 1);
         }
 
         private static string CalculateFileName(string filePath)
@@ -67,7 +57,6 @@ namespace Abp.Resources.Embedded
             {
                 return filePath;
             }
-
             return filePath.Substring(filePath.LastIndexOf("/", StringComparison.Ordinal) + 1);
         }
     }

--- a/src/Abp/Resources/Embedded/EmbeddedResourceSet.cs
+++ b/src/Abp/Resources/Embedded/EmbeddedResourceSet.cs
@@ -35,10 +35,10 @@ namespace Abp.Resources.Embedded
                 using (var stream = Assembly.GetManifestResourceStream(resourceName))
                 {
                     var relativePath = ConvertToRelativePath(resourceName);
-                    var filePath = EmbeddedResourcePathHelper.NormalizePath(RootPath + relativePath);
+                    var filePath = EmbeddedResourcePathHelper.NormalizePath(RootPath) + relativePath;
 
                     resources[filePath] = new EmbeddedResourceItem(
-                        relativePath,
+                        filePath,
                         stream.GetAllBytes(),
                         Assembly
                     );
@@ -49,15 +49,6 @@ namespace Abp.Resources.Embedded
         private string ConvertToRelativePath(string resourceName)
         {
             return resourceName.Substring(ResourceNamespace.Length + 1);
-        }
-
-        private static string CalculateFileName(string filePath)
-        {
-            if (!filePath.Contains("/"))
-            {
-                return filePath;
-            }
-            return filePath.Substring(filePath.LastIndexOf("/", StringComparison.Ordinal) + 1);
         }
     }
 }

--- a/src/Abp/Resources/Embedded/IEmbeddedResourceManager.cs
+++ b/src/Abp/Resources/Embedded/IEmbeddedResourceManager.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+using System.Collections.Generic;
 
 namespace Abp.Resources.Embedded
 {
@@ -15,5 +16,12 @@ namespace Abp.Resources.Embedded
         /// <returns>The resource</returns>
         [CanBeNull]
         EmbeddedResourceItem GetResource([NotNull] string fullResourcePath);
+
+        /// <summary>
+        /// Used to get the list of embedded resource file.
+        /// </summary>
+        /// <param name="fullResourcePath">Full path of the resource</param>
+        /// <returns>The list of resource</returns>
+        IEnumerable<EmbeddedResourceItem> GetResources(string fullResourcePath);
     }
 }

--- a/test/Abp.Tests/Abp.Tests.csproj
+++ b/test/Abp.Tests/Abp.Tests.csproj
@@ -21,6 +21,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Resources\Embedded\MyResources\js_underscore\MyScriptFile.js" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\Embedded\MyResources\js-dash\MyScriptFile.js" />
+    <EmbeddedResource Include="Resources\Embedded\MyResources\js_underscore\MyScriptFile.js" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Abp\Abp.csproj" />
     <ProjectReference Include="..\..\src\Abp.TestBase\Abp.TestBase.csproj" />
   </ItemGroup>

--- a/test/Abp.Tests/Resources/Embedded/EmbeddedResourceTests.cs
+++ b/test/Abp.Tests/Resources/Embedded/EmbeddedResourceTests.cs
@@ -25,21 +25,60 @@ namespace Abp.Tests.Resources.Embedded
         [Fact]
         public void Should_Define_And_Get_Embedded_Resources()
         {
-            var resource = _embeddedResourceManager.GetResource("/MyApp/MyResources/js/MyScriptFile1.js");
+            var filepath = "/MyApp/MyResources/js/MyScriptFile1.js";
+            var resource = _embeddedResourceManager.GetResource(filepath);
+            var filename = System.IO.Path.GetFileName(filepath);
+            var extension = System.IO.Path.GetExtension(filepath);
 
             resource.ShouldNotBeNull();
             Assert.True(resource.Assembly == GetType().GetAssembly());
             Assert.True(resource.Content.Length > 0);
+            Assert.True(resource.FileName == filename);
+            Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
         }
 
         [Fact]
         public void Should_Get_Embedded_Resource_With_Dash_In_Name()
         {
-            var resource = _embeddedResourceManager.GetResource("/MyApp/MyResources/js/MyScriptFile1.js");
+            var filepath = "/MyApp/MyResources/js/MyScriptFile-2.js";
+            var resource = _embeddedResourceManager.GetResource(filepath);
+            var filename = System.IO.Path.GetFileName(filepath);
+            var extension = System.IO.Path.GetExtension(filepath);
 
             resource.ShouldNotBeNull();
             Assert.True(resource.Assembly == GetType().GetAssembly());
             Assert.True(resource.Content.Length > 0);
+            Assert.True(resource.FileName == filename);
+            Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
+        }
+
+        [Fact]
+        public void Should_Get_Embedded_Resource_With_Two_Dots_In_Name()
+        {
+            var filepath = "/MyApp/MyResources/js/MyScriptFile3.min.js";
+            var resource = _embeddedResourceManager.GetResource(filepath);
+            var filename = System.IO.Path.GetFileName(filepath);
+            var extension = System.IO.Path.GetExtension(filepath);
+
+            resource.ShouldNotBeNull();
+            Assert.True(resource.Assembly == GetType().GetAssembly());
+            Assert.True(resource.Content.Length > 0);
+            Assert.True(resource.FileName == filename);
+            Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
+        }
+
+        [Fact]
+        public void Should_Get_Embedded_Resource_With_Underscore_In_Name()
+        {
+            var filepath = "/MyApp/MyResources/js/MyScriptFile_4.js";
+            var resource = _embeddedResourceManager.GetResource(filepath);
+            var filename = System.IO.Path.GetFileName(filepath);
+            var extension = System.IO.Path.GetExtension(filepath);
+            resource.ShouldNotBeNull();
+            Assert.True(resource.Assembly == GetType().GetAssembly());
+            Assert.True(resource.Content.Length > 0);
+            Assert.True(resource.FileName == filename);
+            Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
         }
     }
 }

--- a/test/Abp.Tests/Resources/Embedded/EmbeddedResourceTests.cs
+++ b/test/Abp.Tests/Resources/Embedded/EmbeddedResourceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Abp.Reflection.Extensions;
 using Abp.Resources.Embedded;
 using Shouldly;
+using System.Linq;
 using Xunit;
 
 namespace Abp.Tests.Resources.Embedded
@@ -33,7 +34,7 @@ namespace Abp.Tests.Resources.Embedded
             resource.ShouldNotBeNull();
             Assert.True(resource.Assembly == GetType().GetAssembly());
             Assert.True(resource.Content.Length > 0);
-            Assert.True(resource.FileName == filename);
+            Assert.EndsWith(filename, resource.FileName);
             Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
         }
 
@@ -48,7 +49,7 @@ namespace Abp.Tests.Resources.Embedded
             resource.ShouldNotBeNull();
             Assert.True(resource.Assembly == GetType().GetAssembly());
             Assert.True(resource.Content.Length > 0);
-            Assert.True(resource.FileName == filename);
+            Assert.EndsWith(filename, resource.FileName);
             Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
         }
 
@@ -63,7 +64,7 @@ namespace Abp.Tests.Resources.Embedded
             resource.ShouldNotBeNull();
             Assert.True(resource.Assembly == GetType().GetAssembly());
             Assert.True(resource.Content.Length > 0);
-            Assert.True(resource.FileName == filename);
+            Assert.EndsWith(filename, resource.FileName);
             Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
         }
 
@@ -77,8 +78,45 @@ namespace Abp.Tests.Resources.Embedded
             resource.ShouldNotBeNull();
             Assert.True(resource.Assembly == GetType().GetAssembly());
             Assert.True(resource.Content.Length > 0);
-            Assert.True(resource.FileName == filename);
+            Assert.EndsWith(filename, resource.FileName);
             Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
+        }
+        [Fact]
+        public void Should_Get_Embedded_Resources_With_Dash_In_folder()
+        {
+            var filepath = "/MyApp/MyResources/js-dash/MyScriptFile.js";
+            var resource = _embeddedResourceManager.GetResource(filepath);
+            var filename = System.IO.Path.GetFileName(filepath);
+            var extension = System.IO.Path.GetExtension(filepath);
+
+            resource.ShouldNotBeNull();
+            Assert.True(resource.Assembly == GetType().GetAssembly());
+            Assert.True(resource.Content.Length > 0);
+            Assert.EndsWith(filename, resource.FileName);
+            Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
+        }
+        [Fact]
+        public void Should_Get_Embedded_Resource_With_Underscore_In_Folder()
+        {
+            var filepath = "/MyApp/MyResources/js_underscore/MyScriptFile.js";
+            var resource = _embeddedResourceManager.GetResource(filepath);
+            var filename = System.IO.Path.GetFileName(filepath);
+            var extension = System.IO.Path.GetExtension(filepath);
+
+            resource.ShouldNotBeNull();
+            Assert.True(resource.Assembly == GetType().GetAssembly());
+            Assert.True(resource.Content.Length > 0);
+            Assert.EndsWith(filename, resource.FileName);
+            Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
+        }
+        [Fact]
+        public void Should_Get_Embedded_Resources()
+        {
+            var filepath = "/MyApp/MyResources/js/";
+            var resources = _embeddedResourceManager.GetResources(filepath);
+
+            resources.ShouldNotBeNull();
+            Assert.True(resources.Count() == 4);
         }
     }
 }

--- a/test/Abp.Tests/Resources/Embedded/MyResources/js-dash/MyScriptFile.js
+++ b/test/Abp.Tests/Resources/Embedded/MyResources/js-dash/MyScriptFile.js
@@ -1,0 +1,2 @@
+﻿/* This file is just a sample to use in tests */
+alert('hello world!');

--- a/test/Abp.Tests/Resources/Embedded/MyResources/js/MyScriptFile3.min.js
+++ b/test/Abp.Tests/Resources/Embedded/MyResources/js/MyScriptFile3.min.js
@@ -1,0 +1,2 @@
+﻿/* This file is just a sample to use in tests */
+alert('hello world 2!');

--- a/test/Abp.Tests/Resources/Embedded/MyResources/js/MyScriptFile_4.js
+++ b/test/Abp.Tests/Resources/Embedded/MyResources/js/MyScriptFile_4.js
@@ -1,0 +1,2 @@
+﻿/* This file is just a sample to use in tests */
+alert('hello world 2!');

--- a/test/Abp.Tests/Resources/Embedded/MyResources/js_underscore/MyScriptFile.js
+++ b/test/Abp.Tests/Resources/Embedded/MyResources/js_underscore/MyScriptFile.js
@@ -1,0 +1,2 @@
+﻿/* This file is just a sample to use in tests */
+alert('hello world!');


### PR DESCRIPTION
- fix for double dots in filenames
- fix for dashes in foldernames
- new tests 
- implamentation of GetDirectoryContents of EmbeddedResourceFileProvider

Inpired by https://github.com/aspnet/FileSystem/issues/184

Background 
Actually in Abp the embeded resources are available thru the EmbeddedResourceFileProvider witch call the EmbeddedResourceManager. The EmbeddedResourceManager contain a dictionarry of EmbeddedResourceItem (key = filepath, value = Resource (name, content, assembly, LastModifiedUtc) ) witch is constructed based on EmbeddedResourceSet stored as sources in the  EmbeddedResourcesConfiguration.

The EmbeddedResourceManager try to find the file content based on the key witch is normally the filepath requested by the EmbeddedResourceFileProvider.

The issue is that the  EmbeddedResourceManager construct the dictionary based on the information in the assembly, witch not contain the real filepath. Because folders of embeded resources are stored with dots in the assembly (that's dotnet) and transform dashes in foldernames to underscores.

Solution
To fix this issue the key used in the dictionnary is transformed to a assembly filepath format.
Each filepath in the requests to the dictionary from the fileprovider is also transformed to a assembly filepath format.