### PR TITLE
Remove faulty/duplicate CreateIndex

### DIFF
--- a/src/Abp.ZeroCore.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
+++ b/src/Abp.ZeroCore.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
@@ -489,23 +489,6 @@ namespace Abp.Zero.EntityFramework
 
             #endregion
 
-
-            #region UserNotificationInfo.IX_UserId_State_CreationTime
-
-            modelBuilder.Entity<UserNotificationInfo>()
-                .Property(e => e.TenantId)
-                .CreateIndex("IX_UserId_State_CreationTime", 1);
-
-            modelBuilder.Entity<UserNotificationInfo>()
-                .Property(e => e.State)
-                .CreateIndex("IX_UserId_State_CreationTime", 2);
-
-            modelBuilder.Entity<UserNotificationInfo>()
-                .Property(e => e.CreationTime)
-                .CreateIndex("IX_UserId_State_CreationTime", 2);
-
-            #endregion
-
             #region UserOrganizationUnit.IX_TenantId_UserId
 
             modelBuilder.Entity<UserOrganizationUnit>()


### PR DESCRIPTION
Fixes https://github.com/aspnetboilerplate/aspnetboilerplate/pull/2625#issuecomment-346883183:

> System.InvalidOperationException: The index with name 'IX_UserId_State_CreationTime' on table 'dbo.AbpUserNotifications' has the same column order of '1' specified for columns 'TenantId' and 'UserId'. Make sure a different order value is used for the IndexAttribute on each column of a multi-column index.

# Issue

The index with name 'IX_UserId_State_CreationTime'  is created twice for the same entity. The second one wrongly sets an index on `e.TenantId`, and the same column on `e.State` and `e.CreationTime`.

https://github.com/aspnetboilerplate/aspnetboilerplate/blob/f2df33b0e8070e16e5b1634e7f59f54e35df64ca/src/Abp.ZeroCore.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs#L334-L344

https://github.com/aspnetboilerplate/aspnetboilerplate/blob/f2df33b0e8070e16e5b1634e7f59f54e35df64ca/src/Abp.ZeroCore.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs#L495-L505

# Fix

I removed the second one.