### PR TITLE
Bug fix-when AbpMemoryCache is Dispose

### DIFF
--- a/src/Abp/Runtime/Caching/Memory/AbpMemoryCache.cs
+++ b/src/Abp/Runtime/Caching/Memory/AbpMemoryCache.cs
@@ -11,14 +11,17 @@ namespace Abp.Runtime.Caching.Memory
     {
         private MemoryCache _memoryCache;
 
+        private Action<string> _disposeAction;
         /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="name">Unique name of the cache</param>
-        public AbpMemoryCache(string name)
+        /// <param name="disposeAction">The Action called when AbpMemoryCache dispose</param>
+        public AbpMemoryCache(string name, Action<string> disposeAction = null)
             : base(name)
         {
             _memoryCache = new MemoryCache(new OptionsWrapper<MemoryCacheOptions>(new MemoryCacheOptions()));
+            _disposeAction = disposeAction;
         }
 
         public override object GetOrDefault(string key)
@@ -66,6 +69,7 @@ namespace Abp.Runtime.Caching.Memory
         {
             _memoryCache.Dispose();
             base.Dispose();
+            _disposeAction?.Invoke(Name);
         }
     }
 }

--- a/src/Abp/Runtime/Caching/Memory/AbpMemoryCacheManager.cs
+++ b/src/Abp/Runtime/Caching/Memory/AbpMemoryCacheManager.cs
@@ -1,5 +1,6 @@
 ﻿using Abp.Dependency;
 using Abp.Runtime.Caching.Configuration;
+using System;
 
 namespace Abp.Runtime.Caching.Memory
 {
@@ -19,7 +20,8 @@ namespace Abp.Runtime.Caching.Memory
 
         protected override ICache CreateCacheImplementation(string name)
         {
-            return IocManager.Resolve<AbpMemoryCache>(new { name });
+            Action<string> disposeAction = (cacheName) => Caches.TryRemove(cacheName, out ICache cache);
+            return IocManager.Resolve<AbpMemoryCache>(new { name, disposeAction });
         }
     }
 }

--- a/test/Abp.Tests/Runtime/Caching/Memory/MemoryCacheManager_Tests.cs
+++ b/test/Abp.Tests/Runtime/Caching/Memory/MemoryCacheManager_Tests.cs
@@ -9,6 +9,7 @@ using Castle.MicroKernel.Registration;
 using NSubstitute;
 using Shouldly;
 using Xunit;
+using System.Linq;
 
 namespace Abp.Tests.Runtime.Caching.Memory
 {
@@ -49,6 +50,29 @@ namespace Abp.Tests.Runtime.Caching.Memory
             _cache.Get("B", () => new MyCacheItem { Value = 43 }).Value.ShouldBe(43);
             _cache.Get("B", () => new MyCacheItem { Value = 44 }).Value.ShouldBe(43); //Does not call factory, so value is not changed
         }
+
+        [Fact]
+        public void Cache_Dispose_Test()
+        {
+            using (var cache = _cacheManager.GetCache("DisposeCache"))
+            {
+                cache.Set("A", "A");
+            }
+            _cacheManager.GetAllCaches().FirstOrDefault(s => s.Name == "DisposeCache").ShouldBe(null);
+        }
+
+        [Fact]
+        public void Cache_Disposed_Set_Get_Test()
+        {
+            string cacheName = "DisposedSetGet";
+            using (var disposeCache = _cacheManager.GetCache(cacheName))
+            {
+            }
+            var cache = _cacheManager.GetCache(cacheName);
+            cache.Set("A", "A");
+            cache.GetOrDefault("A").ShouldBe<object>("A");
+        }
+
 
         [Fact]
         public void MultiThreading_Test()


### PR DESCRIPTION
the value of the AbpMemoryCache cannot be set again