### PR TITLE
Change link for Social Logins in doc

### DIFF
--- a/doc/WebSite/Zero/User-Management.md
+++ b/doc/WebSite/Zero/User-Management.md
@@ -292,5 +292,5 @@ Then you can get LDAP settings from any other source.
 
 #### Social Logins
 
-See [startup template](Startup-Template.md) document for social
-logins.
+See [social authentication](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/)
+document for social logins.


### PR DESCRIPTION
Fixes #2781

- Social logins documentation was removed in bcc339d
- If you are using an earlier version like ABP v2.3.0, you may refer to the documentation here: https://aspnetboilerplate.com/Pages/Documents/v2.3.0/Zero/Startup-Template#social-logins