### PR TITLE
fixes #2785 use AbpDateTimeModelBinderProvider as the primary binder …

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/AbpMvcOptionsExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/AbpMvcOptionsExtensions.cs
@@ -37,7 +37,7 @@ namespace Abp.AspNetCore.Mvc
 
         private static void AddModelBinders(MvcOptions options)
         {
-            options.ModelBinderProviders.Add(new AbpDateTimeModelBinderProvider());
+            options.ModelBinderProviders.Insert(0, new AbpDateTimeModelBinderProvider());
         }
     }
 }

--- a/test/Abp.AspNetCore.Tests/App/Controllers/SimpleTestController.cs
+++ b/test/Abp.AspNetCore.Tests/App/Controllers/SimpleTestController.cs
@@ -89,5 +89,11 @@ namespace Abp.AspNetCore.App.Controllers
         {
             return Content(CultureInfo.CurrentCulture.Name);
         }
+
+        [HttpGet]
+        public string GetDateTimeKind(SimpleDateModel input)
+        {
+            return input.Date.Kind.ToString().ToLower();
+        }
     }
 }

--- a/test/Abp.AspNetCore.Tests/App/Models/SimpleDateRangeModel.cs
+++ b/test/Abp.AspNetCore.Tests/App/Models/SimpleDateRangeModel.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Abp.AspNetCore.App.Models
+{
+    public class SimpleDateModel
+    {
+        public DateTime Date { get; set; }
+    }
+}

--- a/test/Abp.AspNetCore.Tests/Tests/DateTimeModelBinder_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/DateTimeModelBinder_Tests.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading.Tasks;
+using Abp.AspNetCore.App.Controllers;
+using Abp.Timing;
+using Abp.Web.Models;
+using Shouldly;
+using Xunit;
+
+namespace Abp.AspNetCore.Tests
+{
+    public class DateTimeModelBinder_Tests : AppTestBase
+    {
+        [Theory]
+        [InlineData("2016-04-13T08:58:10.526Z", "utc")]
+        [InlineData("2016-04-13T08:58:10.526", "local")]
+        [InlineData("2016-04-13 08:58:10.526Z", "utc")]
+        [InlineData("2016-04-13 08:58:10.526", "local")]
+        public async Task Controller_Should_Receive_Correct_DateTimeKind_For_Current_ClockProvider(string date, string expectedKind)
+        {
+            Clock.Provider = StringToClockProvider(expectedKind);
+
+            var response = await GetResponseAsObjectAsync<AjaxResponse<string>>(
+                GetUrl<SimpleTestController>(
+                    nameof(SimpleTestController.GetDateTimeKind),
+                    new
+                    {
+                        date = date
+                    }
+                )
+            );
+
+            response.Result.ShouldBe(expectedKind.ToLower());
+        }
+
+        private IClockProvider StringToClockProvider(string dateTimeKind)
+        {
+            if (dateTimeKind == "local")
+            {
+                return ClockProviders.Local;
+            }
+
+            if (dateTimeKind == "utc")
+            {
+                return ClockProviders.Utc;
+            }
+
+            return ClockProviders.Unspecified;
+        }
+    }
+}


### PR DESCRIPTION
…provider for datetime