### PR TITLE
Update Microsoft.AspNetCore.SignalR package

### DIFF
--- a/src/Abp.Web.SignalR.AspNetCore/Abp.Web.SignalR.AspNetCore.csproj
+++ b/src/Abp.Web.SignalR.AspNetCore/Abp.Web.SignalR.AspNetCore.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="2.1.0-preview1-27815" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.0-preview1-27891" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Follows #2790 

Let's update from `2.1.0-preview1-`**`27815`** to `1.0.0-preview1-`**`27891`** before ABP v3.3.0 is published.
This makes it less confusing when updating to `1.0.0-preview1` once it's officially released on NuGet.