### PR TITLE
Support a Reason property in EntityChangeSet

### DIFF
--- a/doc/WebSite/Entity-History.md
+++ b/doc/WebSite/Entity-History.md
@@ -4,16 +4,19 @@ ASP.NET Boilerplate provides an infrastructure to automatically log all
 entity and property change history.
 
 The saved fields for an entity change are: Related **tenant id**,
-changer **user id**, **entity change set id**, **entity id**,
-**entity type name**, **change time**, **change type**, the client's
-**IP address**, the client's **computer name** and the **browser info** (if
-entity is changed in a web request).
+**entity change set id**, **entity id**,
+**entity type name**, **change time** and the **change type**.
 
 The saved fields for an entity property change are: Related **tenant id**,
 **entity change id**, **property name**, **property type name**,
 **new value** and the **original value**.
 
 The entity changes are grouped in a change set for each SaveChanges call.
+
+The saved fields for an entity change set are: Related **tenant id**,
+changer **user id**, **creation time**, the client's
+**IP address**, the client's **computer name** and the **browser info** (if
+entities are changed in a web request).
 
 The Entity History tracking system uses
 [**IAbpSession**](/Pages/Documents/Abp-Session) to
@@ -71,25 +74,25 @@ You can add your selectors in your module's PreInitialize method.
 ### Enable/Disable by attributes
 
 While you can select tracked entities by configuration, you can use the
-**HistoryTracked** and **DisableHistoryTracking** attributes for a single
+**Audited** and **DisableAuditing** attributes for a single
 **entity** or an individual **property**. Example:
 
-    [HistoryTracked]
+    [Audited]
     public class MyEntity : Entity
     {
         public string MyProperty1 { get; set; }
 
-        [DisableHistoryTracking]
+        [DisableAuditing]
         public int MyProperty2 { get; set; }
 
         public long MyProperty3 { get; set; }
     }
 
 All properties of MyEntity are tracked except MyProperty2 since it's
-explicitly disabled. The HistoryTracked attribute can be used to
+explicitly disabled. The Audited attribute can be used to
 save change logs for a desired property.
 
-**DisableHistoryTracking** can be used for an entity or a single **property of an
+**DisableAuditing** can be used for an entity or a single **property of an
 entity**. Thus, you can **hide sensitive data** in change logs, such as
 passwords for example.
 
@@ -97,6 +100,6 @@ passwords for example.
 
 -   A property must be **public** in order to be saved in change logs.
     Private and protected properties are ignored.
--   DisableHistoryTracking takes priority over HistoryTracking attribute.
+-   DisableAuditing takes priority over Audited attribute.
 -   Only works for entities.
 -   Only works for scalar properties, e.g. string, int, bool...

--- a/doc/WebSite/Entity-History.md
+++ b/doc/WebSite/Entity-History.md
@@ -98,9 +98,13 @@ passwords for example.
 
 ### Reason
 
-Entity change set has a **Reason** property that can be used to further group
-change sets. Since each SaveChanges call creates an entity change set, a single
-request can result in more than one change set.
+Entity change set has a **Reason** property that can be used to understand why a
+set of changes had occurred, i.e. the use case that resulted in these changes.
+
+For example, Person A transfers money from Account A to Account B. Both account
+balances change and "Money transfer" is recorded as the Reason for this change set.
+Since a balance change can be due to other reasons, the Reason property explains
+why these changes were made.
 
 **Abp.AspNetCore** package implements **HttpRequestEntityChangeSetReasonProvider**,
 which returns HttpContext.Request's URL as the Reason.
@@ -145,7 +149,7 @@ You can use the **IEntityChangeSetReasonProvider.Use(...)** method as shown belo
             using (_reasonProvider.Use(reason))
             {
                 ...
-                
+
                 _unitOfWorkManager.Current.SaveChanges();
             }
         }

--- a/src/Abp.AspNetCore/AspNetCore/EntityHistory/HttpRequestEntityChangeSetReasonProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/EntityHistory/HttpRequestEntityChangeSetReasonProvider.cs
@@ -1,0 +1,29 @@
+﻿using Abp.Dependency;
+using Abp.EntityHistory;
+using Abp.Runtime;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+
+namespace Abp.AspNetCore.EntityHistory
+{
+    /// <summary>
+    /// Implements <see cref="IEntityChangeSetReasonProvider"/> to get reason from HTTP request.
+    /// </summary>
+    public class HttpRequestEntityChangeSetReasonProvider : EntityChangeSetReasonProviderBase, ISingletonDependency
+    {
+        [CanBeNull]
+        public override string Reason => HttpContextAccessor.HttpContext?.Request.GetDisplayUrl();
+
+        protected IHttpContextAccessor HttpContextAccessor { get; }
+
+        public HttpRequestEntityChangeSetReasonProvider(
+            IHttpContextAccessor httpContextAccessor,
+
+            IAmbientScopeProvider<ReasonOverride> reasonOverrideScopeProvider
+            ) : base(reasonOverrideScopeProvider)
+        {
+            HttpContextAccessor = httpContextAccessor;
+        }
+    }
+}

--- a/src/Abp.AspNetCore/AspNetCore/EntityHistory/HttpRequestEntityChangeSetReasonProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/EntityHistory/HttpRequestEntityChangeSetReasonProvider.cs
@@ -13,7 +13,18 @@ namespace Abp.AspNetCore.EntityHistory
     public class HttpRequestEntityChangeSetReasonProvider : EntityChangeSetReasonProviderBase, ISingletonDependency
     {
         [CanBeNull]
-        public override string Reason => HttpContextAccessor.HttpContext?.Request.GetDisplayUrl();
+        public override string Reason
+        {
+            get
+            {
+                if (OverridedValue != null)
+                {
+                    return OverridedValue.Reason;
+                }
+
+                return HttpContextAccessor.HttpContext?.Request.GetDisplayUrl();
+            }
+        }
 
         protected IHttpContextAccessor HttpContextAccessor { get; }
 

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -68,7 +68,7 @@ namespace Abp.EntityHistory
         {
             var changeSet = new EntityChangeSet
             {
-                Reason = EntityChangeSetReasonProvider.Reason,
+                Reason = EntityChangeSetReasonProvider.Reason.TruncateWithPostfix(EntityChangeSet.MaxReasonLength),
 
                 // Fill "who did this change"
                 BrowserInfo = ClientInfoProvider.BrowserInfo.TruncateWithPostfix(EntityChangeSet.MaxBrowserInfoLength),

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -26,6 +26,7 @@ namespace Abp.EntityHistory
         public ILogger Logger { get; set; }
         public IAbpSession AbpSession { get; set; }
         public IClientInfoProvider ClientInfoProvider { get; set; }
+        public IEntityChangeSetReasonProvider EntityChangeSetReasonProvider { get; set; }
         public IEntityHistoryStore EntityHistoryStore { get; set; }
 
         private readonly IEntityHistoryConfiguration _configuration;
@@ -59,6 +60,7 @@ namespace Abp.EntityHistory
             AbpSession = NullAbpSession.Instance;
             Logger = NullLogger.Instance;
             ClientInfoProvider = NullClientInfoProvider.Instance;
+            EntityChangeSetReasonProvider = NullEntityChangeSetReasonProvider.Instance;
             EntityHistoryStore = NullEntityHistoryStore.Instance;
         }
         
@@ -66,6 +68,8 @@ namespace Abp.EntityHistory
         {
             var changeSet = new EntityChangeSet
             {
+                Reason = EntityChangeSetReasonProvider.Reason,
+
                 // Fill "who did this change"
                 BrowserInfo = ClientInfoProvider.BrowserInfo.TruncateWithPostfix(EntityChangeSet.MaxBrowserInfoLength),
                 ClientIpAddress = ClientInfoProvider.ClientIpAddress.TruncateWithPostfix(EntityChangeSet.MaxClientIpAddressLength),

--- a/src/Abp/AbpBootstrapper.cs
+++ b/src/Abp/AbpBootstrapper.cs
@@ -6,6 +6,7 @@ using Abp.Configuration.Startup;
 using Abp.Dependency;
 using Abp.Dependency.Installers;
 using Abp.Domain.Uow;
+using Abp.EntityHistory;
 using Abp.Modules;
 using Abp.PlugIns;
 using Abp.Runtime.Validation.Interception;
@@ -131,6 +132,7 @@ namespace Abp
             AuditingInterceptorRegistrar.Initialize(IocManager);
             UnitOfWorkRegistrar.Initialize(IocManager);
             AuthorizationInterceptorRegistrar.Initialize(IocManager);
+            EntityHistoryInterceptorRegistrar.Initialize(IocManager);
         }
 
         /// <summary>

--- a/src/Abp/AbpBootstrapper.cs
+++ b/src/Abp/AbpBootstrapper.cs
@@ -130,9 +130,9 @@ namespace Abp
         {
             ValidationInterceptorRegistrar.Initialize(IocManager);
             AuditingInterceptorRegistrar.Initialize(IocManager);
+            EntityHistoryInterceptorRegistrar.Initialize(IocManager);
             UnitOfWorkRegistrar.Initialize(IocManager);
             AuthorizationInterceptorRegistrar.Initialize(IocManager);
-            EntityHistoryInterceptorRegistrar.Initialize(IocManager);
         }
 
         /// <summary>

--- a/src/Abp/EntityHistory/EntityChangeSet.cs
+++ b/src/Abp/EntityHistory/EntityChangeSet.cs
@@ -26,6 +26,11 @@ namespace Abp.EntityHistory
         public const int MaxClientNameLength = 128;
 
         /// <summary>
+        /// Maximum length of <see cref="Reason"/> property.
+        /// </summary>
+        public const int MaxReasonLength = 256;
+
+        /// <summary>
         /// Browser information if this entity is changed in a web request.
         /// </summary>
         [MaxLength(MaxBrowserInfoLength)]
@@ -62,6 +67,12 @@ namespace Abp.EntityHistory
         /// ImpersonatorUserId.
         /// </summary>
         public virtual long? ImpersonatorUserId { get; set; }
+
+        /// <summary>
+        /// Reason for this change set.
+        /// </summary>
+        [MaxLength(MaxReasonLength)]
+        public virtual string Reason { get; set; }
 
         /// <summary>
         /// TenantId.

--- a/src/Abp/EntityHistory/EntityChangeSetReasonProviderBase.cs
+++ b/src/Abp/EntityHistory/EntityChangeSetReasonProviderBase.cs
@@ -1,0 +1,25 @@
+﻿using Abp.Runtime;
+using System;
+
+namespace Abp.EntityHistory
+{
+    public abstract class EntityChangeSetReasonProviderBase : IEntityChangeSetReasonProvider
+    {
+        public const string ReasonOverrideContextKey = "Abp.EntityHistory.Reason.Override";
+
+        public abstract string Reason { get; }
+
+        protected ReasonOverride OverridedValue => ReasonOverrideScopeProvider.GetValue(ReasonOverrideContextKey);
+        protected IAmbientScopeProvider<ReasonOverride> ReasonOverrideScopeProvider { get; }
+
+        protected EntityChangeSetReasonProviderBase(IAmbientScopeProvider<ReasonOverride> reasonOverrideScopeProvider)
+        {
+            ReasonOverrideScopeProvider = reasonOverrideScopeProvider;
+        }
+
+        public IDisposable Use(string reason)
+        {
+            return ReasonOverrideScopeProvider.BeginScope(ReasonOverrideContextKey, new ReasonOverride(reason));
+        }
+    }
+}

--- a/src/Abp/EntityHistory/EntityHistoryInterceptor.cs
+++ b/src/Abp/EntityHistory/EntityHistoryInterceptor.cs
@@ -1,0 +1,26 @@
+﻿using Castle.DynamicProxy;
+using System.Linq;
+
+namespace Abp.EntityHistory
+{
+    internal class EntityHistoryInterceptor : IInterceptor
+    {
+        public IEntityChangeSetReasonProvider ReasonProvider { get; set; }
+
+        public EntityHistoryInterceptor()
+        {
+            ReasonProvider = NullEntityChangeSetReasonProvider.Instance;
+        }
+
+        public void Intercept(IInvocation invocation)
+        {
+            var useCaseAttribute = invocation.MethodInvocationTarget.GetCustomAttributes(typeof(UseCaseAttribute), true).Cast<UseCaseAttribute>().FirstOrDefault();
+            var reason = useCaseAttribute?.Description;
+
+            using (ReasonProvider.Use(reason))
+            {
+                invocation.Proceed();
+            }
+        }
+    }
+}

--- a/src/Abp/EntityHistory/EntityHistoryInterceptor.cs
+++ b/src/Abp/EntityHistory/EntityHistoryInterceptor.cs
@@ -1,5 +1,6 @@
 ﻿using Castle.DynamicProxy;
 using System.Linq;
+using System.Reflection;
 
 namespace Abp.EntityHistory
 {
@@ -14,10 +15,11 @@ namespace Abp.EntityHistory
 
         public void Intercept(IInvocation invocation)
         {
-            var useCaseAttribute = invocation.MethodInvocationTarget.GetCustomAttributes(typeof(UseCaseAttribute), true).Cast<UseCaseAttribute>().FirstOrDefault();
-            var reason = useCaseAttribute?.Description;
+            var methodInfo = invocation.MethodInvocationTarget;
+            var useCaseAttribute = methodInfo.GetCustomAttributes<UseCaseAttribute>(true).FirstOrDefault()
+                  ?? methodInfo.DeclaringType.GetCustomAttributes<UseCaseAttribute>(true).First();
 
-            using (ReasonProvider.Use(reason))
+            using (ReasonProvider.Use(useCaseAttribute.Description))
             {
                 invocation.Proceed();
             }

--- a/src/Abp/EntityHistory/EntityHistoryInterceptorRegistrar.cs
+++ b/src/Abp/EntityHistory/EntityHistoryInterceptorRegistrar.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Abp.Dependency;
+using Castle.Core;
+
+namespace Abp.EntityHistory
+{
+    internal static class EntityHistoryInterceptorRegistrar
+    {
+        public static void Initialize(IIocManager iocManager)
+        {
+            iocManager.IocContainer.Kernel.ComponentRegistered += (key, handler) =>
+            {
+                if (!iocManager.IsRegistered<IEntityHistoryConfiguration>())
+                {
+                    return;
+                }
+
+                var entityHistoryConfiguration = iocManager.Resolve<IEntityHistoryConfiguration>();
+
+                if (ShouldIntercept(entityHistoryConfiguration, handler.ComponentModel.Implementation))
+                {
+                    handler.ComponentModel.Interceptors.Add(new InterceptorReference(typeof(EntityHistoryInterceptor)));
+                }
+            };
+        }
+        
+        private static bool ShouldIntercept(IEntityHistoryConfiguration entityHistoryConfiguration, Type type)
+        {
+            if (entityHistoryConfiguration.Selectors.Any(selector => selector.Predicate(type)))
+            {
+                return true;
+            }
+
+            if (type.GetTypeInfo().IsDefined(typeof(UseCaseAttribute), true))
+            {
+                return true;
+            }
+
+            if (type.GetMethods().Any(m => m.IsDefined(typeof(UseCaseAttribute), true)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Abp/EntityHistory/EntityHistoryInterceptorRegistrar.cs
+++ b/src/Abp/EntityHistory/EntityHistoryInterceptorRegistrar.cs
@@ -28,11 +28,6 @@ namespace Abp.EntityHistory
         
         private static bool ShouldIntercept(IEntityHistoryConfiguration entityHistoryConfiguration, Type type)
         {
-            if (entityHistoryConfiguration.Selectors.Any(selector => selector.Predicate(type)))
-            {
-                return true;
-            }
-
             if (type.GetTypeInfo().IsDefined(typeof(UseCaseAttribute), true))
             {
                 return true;

--- a/src/Abp/EntityHistory/IEntityChangeSetReasonProvider.cs
+++ b/src/Abp/EntityHistory/IEntityChangeSetReasonProvider.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Abp.EntityHistory
+{
+    /// <summary>
+    /// Defines some session information that can be useful for applications.
+    /// </summary>
+    public interface IEntityChangeSetReasonProvider
+    {
+        /// <summary>
+        /// Gets current Reason or null.
+        /// </summary>
+        string Reason { get; }
+
+        /// <summary>
+        /// Used to change <see cref="Reason"/> for a limited scope.
+        /// </summary>
+        /// <param name="reason"></param>
+        /// <returns></returns>
+        IDisposable Use(string reason);
+    }
+}

--- a/src/Abp/EntityHistory/NullEntityChangeSetReasonProvider.cs
+++ b/src/Abp/EntityHistory/NullEntityChangeSetReasonProvider.cs
@@ -1,0 +1,26 @@
+﻿using Abp.Runtime.Remoting;
+
+namespace Abp.EntityHistory
+{
+    /// <summary>
+    /// Implements null object pattern for <see cref="IEntityChangeSetReasonProvider"/>.
+    /// </summary>
+    public class NullEntityChangeSetReasonProvider : EntityChangeSetReasonProviderBase
+    {
+        /// <summary>
+        /// Singleton instance.
+        /// </summary>
+        public static NullEntityChangeSetReasonProvider Instance { get; } = new NullEntityChangeSetReasonProvider();
+
+        /// <inheritdoc/>
+        public override string Reason => null;
+
+        private NullEntityChangeSetReasonProvider()
+            : base(
+                  new DataContextAmbientScopeProvider<ReasonOverride>(new AsyncLocalAmbientDataContext())
+            )
+        {
+
+        }
+    }
+}

--- a/src/Abp/EntityHistory/ReasonOverride.cs
+++ b/src/Abp/EntityHistory/ReasonOverride.cs
@@ -1,0 +1,12 @@
+﻿namespace Abp.EntityHistory
+{
+    public class ReasonOverride
+    {
+        public string Reason { get; }
+
+        public ReasonOverride(string reason)
+        {
+            Reason = null;
+        }
+    }
+}

--- a/src/Abp/EntityHistory/ReasonOverride.cs
+++ b/src/Abp/EntityHistory/ReasonOverride.cs
@@ -6,7 +6,7 @@
 
         public ReasonOverride(string reason)
         {
-            Reason = null;
+            Reason = reason;
         }
     }
 }

--- a/src/Abp/EntityHistory/UseCaseAttribute.cs
+++ b/src/Abp/EntityHistory/UseCaseAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Abp.EntityHistory
+{
+    /// <summary>
+    /// This attribute is used to set the description for a single method or
+    /// all methods of a class or interface.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class UseCaseAttribute : Attribute
+    {
+        public string Description { get; set; }
+    }
+}

--- a/test/Abp.AspNetCore.Tests/Tests/EntityHistory_Reason_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/EntityHistory_Reason_Tests.cs
@@ -1,0 +1,81 @@
+﻿using Abp.AspNetCore.EntityHistory;
+using Abp.Dependency;
+using Abp.EntityHistory;
+using Shouldly;
+using Xunit;
+
+namespace Abp.AspNetCore.Tests
+{
+    public class EntityHistory_Reason_Tests : AppTestBase
+    {
+        private readonly MyNonUseCaseMarkedClass _nonUseCaseMarkedClass;
+        private readonly MyUseCaseMarkedClass _useCaseMarkedClass;
+
+        public EntityHistory_Reason_Tests()
+        {
+            _nonUseCaseMarkedClass = Resolve<MyNonUseCaseMarkedClass>();
+            _useCaseMarkedClass = Resolve<MyUseCaseMarkedClass>();
+        }
+
+        [Fact]
+        public void HttpRequestEntityChangeSetReasonProvider_Can_Be_Constructor_Injected()
+        {
+            _useCaseMarkedClass.ReasonProvider.ShouldBeOfType<HttpRequestEntityChangeSetReasonProvider>();
+        }
+
+        [Fact]
+        public void HttpRequestEntityChangeSetReasonProvider_Should_Be_Property_Injected()
+        {
+            _nonUseCaseMarkedClass.ReasonProvider.ShouldBeOfType<HttpRequestEntityChangeSetReasonProvider>();
+        }
+
+        [Fact]
+        public void Should_Intercept_UseCase_Marked_Classes()
+        {
+            _useCaseMarkedClass.NonUseCaseMarkedMethod();
+        }
+
+        [Fact]
+        public void Should_Intercept_UseCase_Marked_Methods()
+        {
+            _nonUseCaseMarkedClass.UseCaseMarkedMethod();
+        }
+    }
+
+    public static class Consts
+    {
+        public const string UseCaseDescription = "UseCaseDescription";
+    }
+
+    public class MyNonUseCaseMarkedClass : ITransientDependency
+    {
+        public IEntityChangeSetReasonProvider ReasonProvider { get; set; }
+
+        public MyNonUseCaseMarkedClass()
+        {
+            ReasonProvider = NullEntityChangeSetReasonProvider.Instance;
+        }
+
+        [UseCase(Description = Consts.UseCaseDescription)]
+        public virtual void UseCaseMarkedMethod()
+        {
+            ReasonProvider.Reason.ShouldBe(Consts.UseCaseDescription);
+        }
+    }
+
+    [UseCase(Description = Consts.UseCaseDescription)]
+    public class MyUseCaseMarkedClass : ITransientDependency
+    {
+        public readonly IEntityChangeSetReasonProvider ReasonProvider;
+
+        public MyUseCaseMarkedClass(IEntityChangeSetReasonProvider reasonProvider)
+        {
+            ReasonProvider = reasonProvider;
+        }
+
+        public virtual void NonUseCaseMarkedMethod()
+        {
+            ReasonProvider.Reason.ShouldBe(Consts.UseCaseDescription);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #2844

- [x] Add a ``Reason`` property to `EntityChangeSet`.
- [x] Create an ``IEntityChangeSetReasonProvider`` interface that has:
  - [x] `Reason` getter,
  - [x] `Use` method.
- [x] Implement ``NullEntityChangeSetReasonProvider`` by default.
- [x] In `Abp.AspNetCore` package, implement ``HttpRequestEntityChangeSetReasonProvider`` which returns `HttpContext.Request`'s URL as the `Reason`.
- [x] Implement and register `EntityHistoryInterceptor`.
- [x] Add tests.
- [x] Add documentation: [Entity-History.md#reason](https://github.com/acjh/aspnetboilerplate/blob/issue-2844/doc/WebSite/Entity-History.md#reason)