### PR TITLE
Fix test case for Entity History

### DIFF
--- a/src/Abp/EntityHistory/EntityChange.cs
+++ b/src/Abp/EntityHistory/EntityChange.cs
@@ -44,7 +44,7 @@ namespace Abp.EntityHistory
         public virtual string EntityId { get; set; }
 
         /// <summary>
-        /// AssemblyQualifiedName of the entity type.
+        /// FullName of the entity type.
         /// </summary>
         [MaxLength(MaxEntityTypeFullNameLength)]
         public virtual string EntityTypeFullName { get; set; }

--- a/src/Abp/EntityHistory/EntityPropertyChange.cs
+++ b/src/Abp/EntityHistory/EntityPropertyChange.cs
@@ -50,7 +50,7 @@ namespace Abp.EntityHistory
 
         /// <summary>
         /// Type of the JSON serialized <see cref="NewValue"/> and <see cref="OriginalValue"/>.
-        /// It's AssemblyQualifiedName of the type.
+        /// It's the FullName of the type.
         /// </summary>
         [MaxLength(MaxPropertyTypeFullNameLength)]
         public virtual string PropertyTypeFullName { get; set; }

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -133,7 +133,7 @@ namespace Abp.Zero.EntityHistory
                      s.EntityChanges[0].PropertyChanges.FirstOrDefault().NewValue == newValue.ToJsonString(false, false) &&
                      s.EntityChanges[0].PropertyChanges.FirstOrDefault().OriginalValue == originalValue.ToJsonString(false, false) &&
                      s.EntityChanges[0].PropertyChanges.FirstOrDefault().PropertyName == nameof(Blog.Url) &&
-                     s.EntityChanges[0].PropertyChanges.FirstOrDefault().PropertyTypeFullName == typeof(Blog).GetProperty(nameof(Blog.Url)).PropertyType.AssemblyQualifiedName
+                     s.EntityChanges[0].PropertyChanges.FirstOrDefault().PropertyTypeFullName == typeof(Blog).GetProperty(nameof(Blog.Url)).PropertyType.FullName
             ));
         }
 


### PR DESCRIPTION
Follows [`7c9da13`](https://github.com/aspnetboilerplate/aspnetboilerplate/commit/7c9da13e12fbe4ee46cd049ccfd999becc866c1b#diff-bbc0190d25035d0627fe4d1dd507f974L136)

This went unnoticed as AppVeyor fails [expectedly](https://github.com/aspnetboilerplate/aspnetboilerplate/pull/2852#issuecomment-355879832) on an earlier test case ([496](https://ci.appveyor.com/project/hikalkan/aspnetboilerplate/build/1.0.1746/tests)) due to #2855.
This causes AppVeyor to not complete the full test suite ([835](https://ci.appveyor.com/project/hikalkan/aspnetboilerplate/build/1.0.1731-fqwqwfad/tests)+).

I wonder if the known cause can be [resolved](https://forum.aspnetboilerplate.com/viewtopic.php?p=25550#p25551) on AppVeyor.
Or should the `[Fact]` attribute of [that test case](https://github.com/aspnetboilerplate/aspnetboilerplate/blob/9ad69f50505cce8bc36c23693270875656406671/test/Abp.Tests/Timing/TimezoneHelper_Tests.cs#L47) be commented out for now?