### PR TITLE
IAsyncEventHandler Implementation

### DIFF
--- a/src/Abp/Events/Bus/EventBus.cs
+++ b/src/Abp/Events/Bus/EventBus.cs
@@ -496,14 +496,14 @@ namespace Abp.Events.Bus
                             {
                                 if (asyncEventHandler == null)
                                 {
-                                    throw new Exception($"Registered event handler for event type {eventType.Name} does not implement IAsyncEventHandler<{eventType.Name}> interface!");
+                                    throw new Exception($"Registered event handler for event type {asyncHandlerFactories.EventType.Name} does not implement IAsyncEventHandler<{asyncHandlerFactories.EventType.Name}> interface!");
                                 }
 
-                                var asyncHandlerType = typeof(IAsyncEventHandler<>).MakeGenericType(eventType);
+                                var asyncHandlerType = typeof(IAsyncEventHandler<>).MakeGenericType(asyncHandlerFactories.EventType);
 
                                 var method = asyncHandlerType.GetMethod(
                                     "HandleEventAsync",
-                                    new[] { eventType }
+                                    new[] { asyncHandlerFactories.EventType }
                                 );
 
                                 await (Task)method.Invoke(asyncEventHandler, new object[] { eventData });

--- a/src/Abp/Events/Bus/EventBus.cs
+++ b/src/Abp/Events/Bus/EventBus.cs
@@ -312,8 +312,6 @@ namespace Abp.Events.Bus
         /// <inheritdoc/>
         public async Task TriggerAsync(Type eventType, object eventSource, IEventData eventData)
         {
-            ExecutionContext.SuppressFlow();
-
             var asyncTasks = new List<Task>();
             var exceptions = new List<Exception>();
 
@@ -365,8 +363,6 @@ namespace Abp.Events.Bus
                     await TriggerAsync(baseEventType, eventData.EventSource, baseEventData);
                 }
             }
-
-            ExecutionContext.RestoreFlow();
 
             if (exceptions.Any())
             {

--- a/src/Abp/Events/Bus/EventBus.cs
+++ b/src/Abp/Events/Bus/EventBus.cs
@@ -64,7 +64,7 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
-        public IDisposable Register<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
+        public IDisposable AsyncRegister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
         {
             return Register(typeof(TEventData), new ActionAsyncEventHandler<TEventData>(action));
         }
@@ -76,7 +76,7 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
-        public IDisposable Register<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
+        public IDisposable AsyncRegister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
         {
             return Register(typeof(TEventData), handler);
         }
@@ -154,7 +154,7 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
-        public void Unregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
+        public void AsyncUnregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
         {
             Check.NotNull(action, nameof(action));
 
@@ -188,7 +188,7 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
-        public void Unregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
+        public void AsyncUnregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
         {
             Unregister(typeof(TEventData), handler);
         }

--- a/src/Abp/Events/Bus/EventBus.cs
+++ b/src/Abp/Events/Bus/EventBus.cs
@@ -390,7 +390,7 @@ namespace Abp.Events.Bus
 
                         throw new AggregateException("More than one error has occurred while triggering the event: " + eventType, exceptions);
                     }
-                });
+                }).Unwrap();
 
             ExecutionContext.RestoreFlow();
 
@@ -557,7 +557,7 @@ namespace Abp.Events.Bus
                             }
 
                             return exception;
-                        });
+                        }).Unwrap();
 
                     tasks.Add(task);
                 }
@@ -575,7 +575,7 @@ namespace Abp.Events.Bus
                             exceptions.Add(exception);
                         }
                     }
-                });
+                }).Unwrap();
         }
 
         private List<IEventHandlerFactory> GetOrCreateHandlerFactories(Type eventType)

--- a/src/Abp/Events/Bus/EventBus.cs
+++ b/src/Abp/Events/Bus/EventBus.cs
@@ -10,6 +10,7 @@ using Abp.Events.Bus.Factories.Internals;
 using Abp.Events.Bus.Handlers;
 using Abp.Events.Bus.Handlers.Internals;
 using Abp.Extensions;
+using Abp.Threading;
 using Abp.Threading.Extensions;
 using Castle.Core.Logging;
 
@@ -38,12 +39,20 @@ namespace Abp.Events.Bus
         private readonly ConcurrentDictionary<Type, List<IEventHandlerFactory>> _handlerFactories;
 
         /// <summary>
+        /// All registered async handler factories.
+        /// Key: Type of the event
+        /// Value: List of async handler factories
+        /// </summary>
+        private readonly ConcurrentDictionary<Type, List<IEventHandlerFactory>> _asyncHandlerFactories;
+
+        /// <summary>
         /// Creates a new <see cref="EventBus"/> instance.
         /// Instead of creating a new instace, you can use <see cref="Default"/> to use Global <see cref="EventBus"/>.
         /// </summary>
         public EventBus()
         {
             _handlerFactories = new ConcurrentDictionary<Type, List<IEventHandlerFactory>>();
+            _asyncHandlerFactories = new ConcurrentDictionary<Type, List<IEventHandlerFactory>>();
             Logger = NullLogger.Instance;
         }
 
@@ -54,7 +63,19 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
+        public IDisposable Register<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
+        {
+            return Register(typeof(TEventData), new ActionAsyncEventHandler<TEventData>(action));
+        }
+
+        /// <inheritdoc/>
         public IDisposable Register<TEventData>(IEventHandler<TEventData> handler) where TEventData : IEventData
+        {
+            return Register(typeof(TEventData), handler);
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Register<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
         {
             return Register(typeof(TEventData), handler);
         }
@@ -62,7 +83,7 @@ namespace Abp.Events.Bus
         /// <inheritdoc/>
         public IDisposable Register<TEventData, THandler>()
             where TEventData : IEventData
-            where THandler : IEventHandler<TEventData>, new()
+            where THandler : IEventHandler, new()
         {
             return Register(typeof(TEventData), new TransientEventHandlerFactory<THandler>());
         }
@@ -82,8 +103,23 @@ namespace Abp.Events.Bus
         /// <inheritdoc/>
         public IDisposable Register(Type eventType, IEventHandlerFactory handlerFactory)
         {
-            GetOrCreateHandlerFactories(eventType)
-                .Locking(factories => factories.Add(handlerFactory));
+            IEventHandler handler = handlerFactory.GetHandler();
+            List<IEventHandlerFactory> handlerFactories;
+
+            if (CheckEventHandlerType(handler, typeof(IEventHandler<>)))
+            {
+                handlerFactories = GetOrCreateHandlerFactories(eventType);
+            }
+            else if (CheckEventHandlerType(handler, typeof(IAsyncEventHandler<>)))
+            {
+                handlerFactories = GetOrCreateAsyncHandlerFactories(eventType);
+            }
+            else
+            {
+                throw new Exception($"Event handler to register for event type {eventType.Name} does not implement IEventHandler<{eventType.Name}> or IAsyncEventHandler<{eventType.Name}> interface!");
+            }
+
+            handlerFactories.Locking(factories => factories.Add(handlerFactory));
 
             return new FactoryUnregistrar(this, eventType, handlerFactory);
         }
@@ -117,7 +153,41 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
+        public void Unregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
+        {
+            Check.NotNull(action, nameof(action));
+
+            GetOrCreateAsyncHandlerFactories(typeof(TEventData))
+                .Locking(factories =>
+                {
+                    factories.RemoveAll(
+                        factory =>
+                        {
+                            var singleInstanceFactory = factory as SingleInstanceHandlerFactory;
+                            if (singleInstanceFactory == null)
+                            {
+                                return false;
+                            }
+
+                            var actionHandler = singleInstanceFactory.HandlerInstance as ActionAsyncEventHandler<TEventData>;
+                            if (actionHandler == null)
+                            {
+                                return false;
+                            }
+
+                            return actionHandler.Action == action;
+                        });
+                });
+        }
+
+        /// <inheritdoc/>
         public void Unregister<TEventData>(IEventHandler<TEventData> handler) where TEventData : IEventData
+        {
+            Unregister(typeof(TEventData), handler);
+        }
+
+        /// <inheritdoc/>
+        public void Unregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
         {
             Unregister(typeof(TEventData), handler);
         }
@@ -125,7 +195,23 @@ namespace Abp.Events.Bus
         /// <inheritdoc/>
         public void Unregister(Type eventType, IEventHandler handler)
         {
-            GetOrCreateHandlerFactories(eventType)
+            List<IEventHandlerFactory> handlerFactories;
+
+            if (CheckEventHandlerType(handler, typeof(IEventHandler<>)))
+            {
+                handlerFactories = GetOrCreateHandlerFactories(eventType);
+            }
+            else if (CheckEventHandlerType(handler, typeof(IAsyncEventHandler<>)))
+            {
+                handlerFactories = GetOrCreateAsyncHandlerFactories(eventType);
+            }
+            else
+            {
+                // skip unregister
+                return;
+            }
+
+            handlerFactories
                 .Locking(factories =>
                 {
                     factories.RemoveAll(
@@ -158,6 +244,7 @@ namespace Abp.Events.Bus
         public void UnregisterAll(Type eventType)
         {
             GetOrCreateHandlerFactories(eventType).Locking(factories => factories.Clear());
+            GetOrCreateAsyncHandlerFactories(eventType).Locking(factories => factories.Clear());
         }
 
         /// <inheritdoc/>
@@ -181,9 +268,7 @@ namespace Abp.Events.Bus
         /// <inheritdoc/>
         public void Trigger(Type eventType, object eventSource, IEventData eventData)
         {
-            var exceptions = new List<Exception>();
-
-            TriggerHandlingException(eventType, eventSource, eventData, exceptions);
+            List<Exception> exceptions = TriggerHandling(eventType, eventSource, eventData);
 
             if (exceptions.Any())
             {
@@ -196,6 +281,99 @@ namespace Abp.Events.Bus
             }
         }
 
+        /// <inheritdoc/>
+        public Task TriggerAsync<TEventData>(TEventData eventData) where TEventData : IEventData
+        {
+            return TriggerAsync((object)null, eventData);
+        }
+
+        /// <inheritdoc/>
+        public Task TriggerAsync<TEventData>(object eventSource, TEventData eventData) where TEventData : IEventData
+        {
+            return TriggerAsync(typeof(TEventData), eventSource, eventData);
+        }
+
+        /// <inheritdoc/>
+        public Task TriggerAsync(Type eventType, IEventData eventData)
+        {
+            return TriggerAsync(eventType, null, eventData);
+        }
+
+        /// <inheritdoc/>
+        public async Task TriggerAsync(Type eventType, object eventSource, IEventData eventData)
+        {
+            ExecutionContext.SuppressFlow();
+
+            List<Exception> exceptions = await TriggerAsyncHandling(eventType, eventSource, eventData);
+
+            ExecutionContext.RestoreFlow();
+
+            if (exceptions.Any())
+            {
+                if (exceptions.Count == 1)
+                {
+                    exceptions[0].ReThrow();
+                }
+
+                throw new AggregateException("More than one error has occurred while triggering the event: " + eventType, exceptions);
+            }
+        }
+
+        private bool CheckEventHandlerType(IEventHandler handler, Type handlerInterfaceType)
+        {
+            if (handler == null)
+            {
+                return false;
+            }
+
+            Type handlerType = handler.GetType();
+            return handlerType.GetInterfaces()
+                .Where(i => i.IsGenericType)
+                .Any(i => i.GetGenericTypeDefinition() == handlerInterfaceType);
+        }
+
+        private IEnumerable<EventTypeWithEventHandlerFactories> GetHandlerFactories(Type eventType)
+        {
+            var handlerFactoryList = new List<EventTypeWithEventHandlerFactories>();
+
+            foreach (var handlerFactory in _handlerFactories.Where(hf => ShouldTriggerEventForHandler(eventType, hf.Key)))
+            {
+                handlerFactoryList.Add(new EventTypeWithEventHandlerFactories(handlerFactory.Key, handlerFactory.Value));
+            }
+
+            return handlerFactoryList.ToArray();
+        }
+
+        private IEnumerable<EventTypeWithEventHandlerFactories> GetAsyncHandlerFactories(Type eventType)
+        {
+            var asyncHandlerFactoryList = new List<EventTypeWithEventHandlerFactories>();
+
+            foreach (var asyncHandlerFactory in _asyncHandlerFactories.Where(hf => ShouldTriggerEventForHandler(eventType, hf.Key)))
+            {
+                asyncHandlerFactoryList.Add(new EventTypeWithEventHandlerFactories(asyncHandlerFactory.Key, asyncHandlerFactory.Value));
+            }
+
+            return asyncHandlerFactoryList.ToArray();
+        }
+
+        private static bool ShouldTriggerEventForHandler(Type eventType, Type handlerType)
+        {
+            //Should trigger same type
+            if (handlerType == eventType)
+            {
+                return true;
+            }
+
+            //Should trigger for inherited types
+            if (handlerType.IsAssignableFrom(eventType))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        [Obsolete]
         private void TriggerHandlingException(Type eventType, object eventSource, IEventData eventData, List<Exception> exceptions)
         {
             //TODO: This method can be optimized by adding all possibilities to a dictionary.
@@ -249,104 +427,210 @@ namespace Abp.Events.Bus
                 if (baseArg != null)
                 {
                     var baseEventType = eventType.GetGenericTypeDefinition().MakeGenericType(baseArg);
-                    var constructorArgs = ((IEventDataWithInheritableGenericArgument) eventData).GetConstructorArgs();
-                    var baseEventData = (IEventData) Activator.CreateInstance(baseEventType, constructorArgs);
+                    var constructorArgs = ((IEventDataWithInheritableGenericArgument)eventData).GetConstructorArgs();
+                    var baseEventData = (IEventData)Activator.CreateInstance(baseEventType, constructorArgs);
                     baseEventData.EventTime = eventData.EventTime;
                     Trigger(baseEventType, eventData.EventSource, baseEventData);
                 }
             }
         }
 
-        private IEnumerable<EventTypeWithEventHandlerFactories> GetHandlerFactories(Type eventType)
+        private List<Exception> TriggerHandling(Type eventType, object eventSource, IEventData eventData)
         {
-            var handlerFactoryList = new List<EventTypeWithEventHandlerFactories>();
+            eventData.EventSource = eventSource;
 
-            foreach (var handlerFactory in _handlerFactories.Where(hf => ShouldTriggerEventForHandler(eventType, hf.Key)))
+            var exceptions = new List<Exception>();
+            var asyncTasks = new List<Task<Exception>>();
+
+            foreach (var asyncHandlerFactories in GetAsyncHandlerFactories(eventType))
             {
-                handlerFactoryList.Add(new EventTypeWithEventHandlerFactories(handlerFactory.Key, handlerFactory.Value));
-            }
-
-            return handlerFactoryList.ToArray();
-        }
-
-        private static bool ShouldTriggerEventForHandler(Type eventType, Type handlerType)
-        {
-            //Should trigger same type
-            if (handlerType == eventType)
-            {
-                return true;
-            }
-
-            //Should trigger for inherited types
-            if (handlerType.IsAssignableFrom(eventType))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <inheritdoc/>
-        public Task TriggerAsync<TEventData>(TEventData eventData) where TEventData : IEventData
-        {
-            return TriggerAsync((object)null, eventData);
-        }
-
-        /// <inheritdoc/>
-        public Task TriggerAsync<TEventData>(object eventSource, TEventData eventData) where TEventData : IEventData
-        {
-            ExecutionContext.SuppressFlow();
-
-            var task = Task.Factory.StartNew(
-                () =>
+                foreach (var asyncHandlerFactory in asyncHandlerFactories.EventHandlerFactories)
                 {
-                    try
-                    {
-                        Trigger(eventSource, eventData);
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Warn(ex.ToString(), ex);
-                    }
-                });
+                    asyncTasks.Add(TriggerAsyncHandlingException(eventType, eventSource, eventData, asyncHandlerFactory));
+                }
+            }
 
-            ExecutionContext.RestoreFlow();
-
-            return task;
-        }
-
-        /// <inheritdoc/>
-        public Task TriggerAsync(Type eventType, IEventData eventData)
-        {
-            return TriggerAsync(eventType, null, eventData);
-        }
-
-        /// <inheritdoc/>
-        public Task TriggerAsync(Type eventType, object eventSource, IEventData eventData)
-        {
-            ExecutionContext.SuppressFlow();
-
-            var task = Task.Factory.StartNew(
-                () =>
+            foreach (var handlerFactories in GetHandlerFactories(eventType))
+            {
+                foreach (var handlerFactory in handlerFactories.EventHandlerFactories)
                 {
-                    try
+                    Exception exception = TriggerHandlingException(eventType, eventSource, eventData, handlerFactory);
+                    if (exception != null)
                     {
-                        Trigger(eventType, eventSource, eventData);
+                        exceptions.Add(exception);
                     }
-                    catch (Exception ex)
+                }
+            }
+
+            AsyncHelper.RunSync(() => Task.WhenAll(asyncTasks.ToArray()));
+            foreach (Task<Exception> asyncTask in asyncTasks)
+            {
+                Exception exception = AsyncHelper.RunSync(() => asyncTask);
+                if (exception != null)
+                {
+                    exceptions.Add(exception);
+                }
+            }
+
+            //Implements generic argument inheritance. See IEventDataWithInheritableGenericArgument
+            if (eventType.GetTypeInfo().IsGenericType &&
+                eventType.GetGenericArguments().Length == 1 &&
+                typeof(IEventDataWithInheritableGenericArgument).IsAssignableFrom(eventType))
+            {
+                var genericArg = eventType.GetGenericArguments()[0];
+                var baseArg = genericArg.GetTypeInfo().BaseType;
+                if (baseArg != null)
+                {
+                    var baseEventType = eventType.GetGenericTypeDefinition().MakeGenericType(baseArg);
+                    var constructorArgs = ((IEventDataWithInheritableGenericArgument)eventData).GetConstructorArgs();
+                    var baseEventData = (IEventData)Activator.CreateInstance(baseEventType, constructorArgs);
+                    baseEventData.EventTime = eventData.EventTime;
+                    Trigger(baseEventType, eventData.EventSource, baseEventData);
+                }
+            }
+
+            return exceptions;
+        }
+
+        private async Task<List<Exception>> TriggerAsyncHandling(Type eventType, object eventSource, IEventData eventData)
+        {
+            eventData.EventSource = eventSource;
+
+            var exceptions = new List<Exception>();
+            var asyncTasks = new List<Task<Exception>>();
+
+            foreach (var asyncHandlerFactories in GetAsyncHandlerFactories(eventType))
+            {
+                foreach (var asyncHandlerFactory in asyncHandlerFactories.EventHandlerFactories)
+                {
+                    asyncTasks.Add(TriggerAsyncHandlingException(eventType, eventSource, eventData, asyncHandlerFactory));
+                }
+            }
+
+            foreach (var handlerFactories in GetHandlerFactories(eventType))
+            {
+                foreach (var handlerFactory in handlerFactories.EventHandlerFactories)
+                {
+                    Exception exception = TriggerHandlingException(eventType, eventSource, eventData, handlerFactory);
+                    if (exception != null)
                     {
-                        Logger.Warn(ex.ToString(), ex);
+                        exceptions.Add(exception);
                     }
-                });
+                }
+            }
 
-            ExecutionContext.RestoreFlow();
+            await Task.WhenAll(asyncTasks.ToArray());
+            foreach (Task<Exception> asyncTask in asyncTasks)
+            {
+                Exception exception = await asyncTask;
+                if (exception != null)
+                {
+                    exceptions.Add(exception);
+                }
+            }
 
-            return task;
+            //Implements generic argument inheritance. See IEventDataWithInheritableGenericArgument
+            if (eventType.GetTypeInfo().IsGenericType &&
+                eventType.GetGenericArguments().Length == 1 &&
+                typeof(IEventDataWithInheritableGenericArgument).IsAssignableFrom(eventType))
+            {
+                var genericArg = eventType.GetGenericArguments()[0];
+                var baseArg = genericArg.GetTypeInfo().BaseType;
+                if (baseArg != null)
+                {
+                    var baseEventType = eventType.GetGenericTypeDefinition().MakeGenericType(baseArg);
+                    var constructorArgs = ((IEventDataWithInheritableGenericArgument)eventData).GetConstructorArgs();
+                    var baseEventData = (IEventData)Activator.CreateInstance(baseEventType, constructorArgs);
+                    baseEventData.EventTime = eventData.EventTime;
+                    await TriggerAsync(baseEventType, eventData.EventSource, baseEventData);
+                }
+            }
+
+            return exceptions;
+        }
+
+        private Exception TriggerHandlingException(Type eventType, object eventSource, IEventData eventData, IEventHandlerFactory handlerFactory)
+        {
+            var eventHandler = handlerFactory.GetHandler();
+            Exception exception = null;
+
+            try
+            {
+                if (eventHandler == null)
+                {
+                    throw new Exception($"Registered event handler for event type {eventType.Name} does not implement IEventHandler<{eventType.Name}> interface!");
+                }
+
+                var handlerType = typeof(IEventHandler<>).MakeGenericType(eventType);
+
+                var method = handlerType.GetMethod(
+                    "HandleEvent",
+                    new[] { eventType }
+                );
+
+                method.Invoke(eventHandler, new object[] { eventData });
+            }
+            catch (TargetInvocationException ex)
+            {
+                exception = ex.InnerException;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            finally
+            {
+                handlerFactory.ReleaseHandler(eventHandler);
+            }
+
+            return exception;
+        }
+
+        private async Task<Exception> TriggerAsyncHandlingException(Type eventType, object eventSource, IEventData eventData, IEventHandlerFactory asyncHandlerFactory)
+        {
+            var asyncEventHandler = asyncHandlerFactory.GetHandler();
+            Exception exception = null;
+
+            try
+            {
+                if (asyncEventHandler == null)
+                {
+                    throw new Exception($"Registered event handler for event type {eventType.Name} does not implement IAsyncEventHandler<{eventType.Name}> interface!");
+                }
+
+                var asyncHandlerType = typeof(IAsyncEventHandler<>).MakeGenericType(eventType);
+
+                var method = asyncHandlerType.GetMethod(
+                    "HandleEventAsync",
+                    new[] { eventType }
+                );
+
+                await (Task)method.Invoke(asyncEventHandler, new object[] { eventData });
+            }
+            catch (TargetInvocationException ex)
+            {
+                exception = ex.InnerException;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            finally
+            {
+                asyncHandlerFactory.ReleaseHandler(asyncEventHandler);
+            }
+
+            return exception;
         }
 
         private List<IEventHandlerFactory> GetOrCreateHandlerFactories(Type eventType)
         {
             return _handlerFactories.GetOrAdd(eventType, (type) => new List<IEventHandlerFactory>());
+        }
+
+        private List<IEventHandlerFactory> GetOrCreateAsyncHandlerFactories(Type eventType)
+        {
+            return _asyncHandlerFactories.GetOrAdd(eventType, (type) => new List<IEventHandlerFactory>());
         }
 
         private class EventTypeWithEventHandlerFactories

--- a/src/Abp/Events/Bus/Factories/Internals/TransientEventHandlerFactory.cs
+++ b/src/Abp/Events/Bus/Factories/Internals/TransientEventHandlerFactory.cs
@@ -5,10 +5,10 @@ namespace Abp.Events.Bus.Factories.Internals
 {
     /// <summary>
     /// This <see cref="IEventHandlerFactory"/> implementation is used to handle events
-    /// by a single instance object. 
+    /// by a transient instance object. 
     /// </summary>
     /// <remarks>
-    /// This class always gets the same single instance of handler.
+    /// This class always creates a new transient instance of handler.
     /// </remarks>
     internal class TransientEventHandlerFactory<THandler> : IEventHandlerFactory 
         where THandler : IEventHandler, new()

--- a/src/Abp/Events/Bus/Handlers/IAsyncEventHandlerOfTEventData.cs
+++ b/src/Abp/Events/Bus/Handlers/IAsyncEventHandlerOfTEventData.cs
@@ -3,7 +3,7 @@
 namespace Abp.Events.Bus.Handlers
 {
     /// <summary>
-    /// Defines an interface of a class that handles events of type <see cref="TEventData"/>.
+    /// Defines an interface of a class that handles events asynchrounously of type <see cref="IAsyncEventHandler{TEventData}"/>.
     /// </summary>
     /// <typeparam name="TEventData">Event type to handle</typeparam>
     public interface IAsyncEventHandler<in TEventData> : IEventHandler

--- a/src/Abp/Events/Bus/Handlers/IAsyncEventHandlerOfTEventData.cs
+++ b/src/Abp/Events/Bus/Handlers/IAsyncEventHandlerOfTEventData.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+
+namespace Abp.Events.Bus.Handlers
+{
+    /// <summary>
+    /// Defines an interface of a class that handles events of type <see cref="TEventData"/>.
+    /// </summary>
+    /// <typeparam name="TEventData">Event type to handle</typeparam>
+    public interface IAsyncEventHandler<in TEventData> : IEventHandler
+    {
+        /// <summary>
+        /// Handler handles the event by implementing this method.
+        /// </summary>
+        /// <param name="eventData">Event data</param>
+        Task HandleEventAsync(TEventData eventData);
+    }
+}

--- a/src/Abp/Events/Bus/Handlers/IEventHandlerOfTEventData.cs
+++ b/src/Abp/Events/Bus/Handlers/IEventHandlerOfTEventData.cs
@@ -1,7 +1,7 @@
 ﻿namespace Abp.Events.Bus.Handlers
 {
     /// <summary>
-    /// Defines an interface of a class that handles events of type <see cref="TEventData"/>.
+    /// Defines an interface of a class that handles events of type <see cref="IEventHandler{TEventData}"/>.
     /// </summary>
     /// <typeparam name="TEventData">Event type to handle</typeparam>
     public interface IEventHandler<in TEventData> : IEventHandler

--- a/src/Abp/Events/Bus/Handlers/Internals/ActionAsyncEventHandler.cs
+++ b/src/Abp/Events/Bus/Handlers/Internals/ActionAsyncEventHandler.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+using Abp.Dependency;
+
+namespace Abp.Events.Bus.Handlers.Internals
+{
+    /// <summary>
+    /// This event handler is an adapter to be able to use an action as <see cref="IEventHandler{TEventData}"/> implementation.
+    /// </summary>
+    /// <typeparam name="TEventData">Event type</typeparam>
+    internal class ActionAsyncEventHandler<TEventData> :
+        IAsyncEventHandler<TEventData>,
+        ITransientDependency
+    {
+        /// <summary>
+        /// Function to handle the event.
+        /// </summary>
+        public Func<TEventData, Task> Action { get; private set; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ActionAsyncEventHandler{TEventData}"/>.
+        /// </summary>
+        /// <param name="handler">Action to handle the event</param>
+        public ActionAsyncEventHandler(Func<TEventData, Task> handler)
+        {
+            Action = handler;
+        }
+
+        /// <summary>
+        /// Handles the event.
+        /// </summary>
+        /// <param name="eventData"></param>
+        public async Task HandleEventAsync(TEventData eventData)
+        {
+            await Action(eventData);
+        }
+    }
+}

--- a/src/Abp/Events/Bus/IEventBus.cs
+++ b/src/Abp/Events/Bus/IEventBus.cs
@@ -21,6 +21,14 @@ namespace Abp.Events.Bus
         IDisposable Register<TEventData>(Action<TEventData> action) where TEventData : IEventData;
 
         /// <summary>
+        /// Registers to an async event.
+        /// Given action is called for all event occurrences.
+        /// </summary>
+        /// <param name="action">Action to handle events</param>
+        /// <typeparam name="TEventData">Event type</typeparam>
+        IDisposable Register<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData;
+
+        /// <summary>
         /// Registers to an event. 
         /// Same (given) instance of the handler is used for all event occurrences.
         /// </summary>
@@ -29,12 +37,20 @@ namespace Abp.Events.Bus
         IDisposable Register<TEventData>(IEventHandler<TEventData> handler) where TEventData : IEventData;
 
         /// <summary>
+        /// Registers to an async event. 
+        /// Same (given) instance of the async handler is used for all event occurrences.
+        /// </summary>
+        /// <typeparam name="TEventData">Event type</typeparam>
+        /// <param name="handler">Object to handle the event</param>
+        IDisposable Register<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData;
+
+        /// <summary>
         /// Registers to an event.
         /// A new instance of <see cref="THandler"/> object is created for every event occurrence.
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
         /// <typeparam name="THandler">Type of the event handler</typeparam>
-        IDisposable Register<TEventData, THandler>() where TEventData : IEventData where THandler : IEventHandler<TEventData>, new();
+        IDisposable Register<TEventData, THandler>() where TEventData : IEventData where THandler : IEventHandler, new();
 
         /// <summary>
         /// Registers to an event.
@@ -71,11 +87,25 @@ namespace Abp.Events.Bus
         void Unregister<TEventData>(Action<TEventData> action) where TEventData : IEventData;
 
         /// <summary>
+        /// Unregisters from an async event.
+        /// </summary>
+        /// <typeparam name="TEventData">Event type</typeparam>
+        /// <param name="action"></param>
+        void Unregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData;
+
+        /// <summary>
         /// Unregisters from an event.
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
         /// <param name="handler">Handler object that is registered before</param>
         void Unregister<TEventData>(IEventHandler<TEventData> handler) where TEventData : IEventData;
+
+        /// <summary>
+        /// Unregisters from an async event.
+        /// </summary>
+        /// <typeparam name="TEventData">Event type</typeparam>
+        /// <param name="handler">Handler object that is registered before</param>
+        void Unregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData;
 
         /// <summary>
         /// Unregisters from an event.

--- a/src/Abp/Events/Bus/IEventBus.cs
+++ b/src/Abp/Events/Bus/IEventBus.cs
@@ -26,7 +26,7 @@ namespace Abp.Events.Bus
         /// </summary>
         /// <param name="action">Action to handle events</param>
         /// <typeparam name="TEventData">Event type</typeparam>
-        IDisposable Register<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData;
+        IDisposable AsyncRegister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData;
 
         /// <summary>
         /// Registers to an event. 
@@ -42,7 +42,7 @@ namespace Abp.Events.Bus
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
         /// <param name="handler">Object to handle the event</param>
-        IDisposable Register<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData;
+        IDisposable AsyncRegister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData;
 
         /// <summary>
         /// Registers to an event.
@@ -91,7 +91,7 @@ namespace Abp.Events.Bus
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
         /// <param name="action"></param>
-        void Unregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData;
+        void AsyncUnregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData;
 
         /// <summary>
         /// Unregisters from an event.
@@ -105,7 +105,7 @@ namespace Abp.Events.Bus
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
         /// <param name="handler">Handler object that is registered before</param>
-        void Unregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData;
+        void AsyncUnregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData;
 
         /// <summary>
         /// Unregisters from an event.

--- a/src/Abp/Events/Bus/IEventBus.cs
+++ b/src/Abp/Events/Bus/IEventBus.cs
@@ -21,7 +21,7 @@ namespace Abp.Events.Bus
         IDisposable Register<TEventData>(Action<TEventData> action) where TEventData : IEventData;
 
         /// <summary>
-        /// Registers to an async event.
+        /// Registers to an event.
         /// Given action is called for all event occurrences.
         /// </summary>
         /// <param name="action">Action to handle events</param>
@@ -37,7 +37,7 @@ namespace Abp.Events.Bus
         IDisposable Register<TEventData>(IEventHandler<TEventData> handler) where TEventData : IEventData;
 
         /// <summary>
-        /// Registers to an async event. 
+        /// Registers to an event. 
         /// Same (given) instance of the async handler is used for all event occurrences.
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
@@ -87,7 +87,7 @@ namespace Abp.Events.Bus
         void Unregister<TEventData>(Action<TEventData> action) where TEventData : IEventData;
 
         /// <summary>
-        /// Unregisters from an async event.
+        /// Unregisters from an event.
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
         /// <param name="action"></param>
@@ -101,7 +101,7 @@ namespace Abp.Events.Bus
         void Unregister<TEventData>(IEventHandler<TEventData> handler) where TEventData : IEventData;
 
         /// <summary>
-        /// Unregisters from an async event.
+        /// Unregisters from an event.
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
         /// <param name="handler">Handler object that is registered before</param>

--- a/src/Abp/Events/Bus/IEventBus.cs
+++ b/src/Abp/Events/Bus/IEventBus.cs
@@ -65,15 +65,15 @@ namespace Abp.Events.Bus
         /// Given factory is used to create/release handlers
         /// </summary>
         /// <typeparam name="TEventData">Event type</typeparam>
-        /// <param name="handlerFactory">A factory to create/release handlers</param>
-        IDisposable Register<TEventData>(IEventHandlerFactory handlerFactory) where TEventData : IEventData;
+        /// <param name="factory">A factory to create/release handlers</param>
+        IDisposable Register<TEventData>(IEventHandlerFactory factory) where TEventData : IEventData;
 
         /// <summary>
         /// Registers to an event.
         /// </summary>
         /// <param name="eventType">Event type</param>
-        /// <param name="handlerFactory">A factory to create/release handlers</param>
-        IDisposable Register(Type eventType, IEventHandlerFactory handlerFactory);
+        /// <param name="factory">A factory to create/release handlers</param>
+        IDisposable Register(Type eventType, IEventHandlerFactory factory);
 
         #endregion
 

--- a/src/Abp/Events/Bus/NullEventBus.cs
+++ b/src/Abp/Events/Bus/NullEventBus.cs
@@ -28,7 +28,19 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
+        public IDisposable Register<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
+        {
+            return NullDisposable.Instance;
+        }
+
+        /// <inheritdoc/>
         public IDisposable Register<TEventData>(IEventHandler<TEventData> handler) where TEventData : IEventData
+        {
+            return NullDisposable.Instance;
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Register<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
         {
             return NullDisposable.Instance;
         }
@@ -36,7 +48,7 @@ namespace Abp.Events.Bus
         /// <inheritdoc/>
         public IDisposable Register<TEventData, THandler>()
             where TEventData : IEventData
-            where THandler : IEventHandler<TEventData>, new()
+            where THandler : IEventHandler, new()
         {
             return NullDisposable.Instance;
         }
@@ -65,7 +77,17 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
+        public void Unregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
+        {
+        }
+
+        /// <inheritdoc/>
         public void Unregister<TEventData>(IEventHandler<TEventData> handler) where TEventData : IEventData
+        {
+        }
+
+        /// <inheritdoc/>
+        public void Unregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
         {
         }
 

--- a/src/Abp/Events/Bus/NullEventBus.cs
+++ b/src/Abp/Events/Bus/NullEventBus.cs
@@ -28,7 +28,7 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
-        public IDisposable Register<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
+        public IDisposable AsyncRegister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
         {
             return NullDisposable.Instance;
         }
@@ -40,7 +40,7 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
-        public IDisposable Register<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
+        public IDisposable AsyncRegister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
         {
             return NullDisposable.Instance;
         }
@@ -77,7 +77,7 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
-        public void Unregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
+        public void AsyncUnregister<TEventData>(Func<TEventData, Task> action) where TEventData : IEventData
         {
         }
 
@@ -87,7 +87,7 @@ namespace Abp.Events.Bus
         }
 
         /// <inheritdoc/>
-        public void Unregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
+        public void AsyncUnregister<TEventData>(IAsyncEventHandler<TEventData> handler) where TEventData : IEventData
         {
         }
 

--- a/test/Abp.Tests/Events/Bus/ActionBasedEventHandlerTest.cs
+++ b/test/Abp.Tests/Events/Bus/ActionBasedEventHandlerTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Abp.Tests.Events.Bus
@@ -89,6 +91,28 @@ namespace Abp.Tests.Events.Bus
             EventBus.Trigger(this, new MySimpleEventData(4));
 
             Assert.Equal(6, totalData);
+        }
+
+        [Fact]
+        public async Task Should_Call_Action_On_Event_With_Correct_Source_Async()
+        {
+            int totalData = 0;
+
+            EventBus.AsyncRegister<MySimpleEventData>(
+                async eventData =>
+                {
+                    await Task.Delay(20);
+                    Interlocked.Add(ref totalData, eventData.Value);
+                    await Task.Delay(20);
+                    Assert.Equal(this, eventData.EventSource);
+                });
+
+            await EventBus.TriggerAsync(this, new MySimpleEventData(1));
+            await EventBus.TriggerAsync(this, new MySimpleEventData(2));
+            await EventBus.TriggerAsync(this, new MySimpleEventData(3));
+            await EventBus.TriggerAsync(this, new MySimpleEventData(4));
+
+            Assert.Equal(10, totalData);
         }
     }
 }

--- a/test/Abp.Tests/Events/Bus/EventBus_MultipleHandle_Test.cs
+++ b/test/Abp.Tests/Events/Bus/EventBus_MultipleHandle_Test.cs
@@ -19,8 +19,8 @@ namespace Abp.Tests.Events.Bus
 
             var asyncHandler = new MyAsyncEventHandler();
 
-            EventBus.Register<EntityChangedEventData<MyEntity>>(asyncHandler);
-            EventBus.Register<EntityCreatedEventData<MyEntity>>(asyncHandler);
+            EventBus.AsyncRegister<EntityChangedEventData<MyEntity>>(asyncHandler);
+            EventBus.AsyncRegister<EntityCreatedEventData<MyEntity>>(asyncHandler);
 
             EventBus.Trigger(new EntityCreatedEventData<MyEntity>(new MyEntity()));
 

--- a/test/Abp.Tests/Events/Bus/EventBus_MultipleHandle_Test.cs
+++ b/test/Abp.Tests/Events/Bus/EventBus_MultipleHandle_Test.cs
@@ -2,6 +2,7 @@
 using Abp.Events.Bus.Entities;
 using Abp.Events.Bus.Handlers;
 using Shouldly;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Abp.Tests.Events.Bus
@@ -16,10 +17,18 @@ namespace Abp.Tests.Events.Bus
             EventBus.Register<EntityChangedEventData<MyEntity>>(handler);
             EventBus.Register<EntityCreatedEventData<MyEntity>>(handler);
 
+            var asyncHandler = new MyAsyncEventHandler();
+
+            EventBus.Register<EntityChangedEventData<MyEntity>>(asyncHandler);
+            EventBus.Register<EntityCreatedEventData<MyEntity>>(asyncHandler);
+
             EventBus.Trigger(new EntityCreatedEventData<MyEntity>(new MyEntity()));
 
             handler.EntityCreatedEventCount.ShouldBe(1);
             handler.EntityChangedEventCount.ShouldBe(1);
+
+            asyncHandler.EntityCreatedEventCount.ShouldBe(1);
+            asyncHandler.EntityChangedEventCount.ShouldBe(1);
         }
 
         public class MyEntity : Entity
@@ -42,6 +51,26 @@ namespace Abp.Tests.Events.Bus
             public void HandleEvent(EntityCreatedEventData<MyEntity> eventData)
             {
                 EntityCreatedEventCount++;
+            }
+        }
+
+        public class MyAsyncEventHandler :
+            IAsyncEventHandler<EntityChangedEventData<MyEntity>>,
+            IAsyncEventHandler<EntityCreatedEventData<MyEntity>>
+        {
+            public int EntityChangedEventCount { get; set; }
+            public int EntityCreatedEventCount { get; set; }
+
+            public Task HandleEventAsync(EntityChangedEventData<MyEntity> eventData)
+            {
+                EntityChangedEventCount++;
+                return Task.FromResult(0);
+            }
+
+            public Task HandleEventAsync(EntityCreatedEventData<MyEntity> eventData)
+            {
+                EntityCreatedEventCount++;
+                return Task.FromResult(0);
             }
         }
     }

--- a/test/Abp.Tests/Events/Bus/MySimpleTransientAsyncEventHandler.cs
+++ b/test/Abp.Tests/Events/Bus/MySimpleTransientAsyncEventHandler.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using Abp.Events.Bus.Handlers;
+
+namespace Abp.Tests.Events.Bus
+{
+    public class MySimpleTransientAsyncEventHandler : IAsyncEventHandler<MySimpleEventData>, IDisposable
+    {
+        public static int HandleCount { get; set; }
+
+        public static int DisposeCount { get; set; }
+
+        public Task HandleEventAsync(MySimpleEventData eventData)
+        {
+            ++HandleCount;
+            return Task.FromResult(0);
+        }
+
+        public void Dispose()
+        {
+            ++DisposeCount;
+        }
+    }
+}

--- a/test/Abp.Tests/Events/Bus/TransientDisposableEventHandlerTest.cs
+++ b/test/Abp.Tests/Events/Bus/TransientDisposableEventHandlerTest.cs
@@ -8,13 +8,17 @@ namespace Abp.Tests.Events.Bus
         public void Should_Call_Handler_AndDispose()
         {
             EventBus.Register<MySimpleEventData, MySimpleTransientEventHandler>();
-            
+            EventBus.Register<MySimpleEventData, MySimpleTransientAsyncEventHandler>();
+
             EventBus.Trigger(new MySimpleEventData(1));
             EventBus.Trigger(new MySimpleEventData(2));
             EventBus.Trigger(new MySimpleEventData(3));
 
-            Assert.Equal(MySimpleTransientEventHandler.HandleCount, 3);
-            Assert.Equal(MySimpleTransientEventHandler.DisposeCount, 3);
+            Assert.Equal(3, MySimpleTransientEventHandler.HandleCount);
+            Assert.Equal(3, MySimpleTransientEventHandler.DisposeCount);
+
+            Assert.Equal(3, MySimpleTransientAsyncEventHandler.HandleCount);
+            Assert.Equal(3, MySimpleTransientAsyncEventHandler.DisposeCount);
         }
     }
 }


### PR DESCRIPTION
Resolved #2691 

- Added `IAsyncEventHandler` as suggested in the issue.
- Added `AsyncRegister` & `AsyncUnregister` methods in `IEventBus`.
- Added another `ConcurrentDictionary<Type, List<IEventHandlerFactory>>` in `EventBus` to maintain synchronous & asynchronous handlers independently
- `TriggerAsync` will run asynchronous handlers first then synchronous handlers, and `await` all asynchronous handlers after execution of all synchronous handlers.

Initially, I thought of using `Async` suffix, however, it becomes confusing with `TriggerAsync`, which the former is registering/un-registering async handler, and the later is triggering the event asynchronously.

Also, I did try to keep the method signature as `Register(...)` for both synchronous & asynchronous event handlers by using the signatures
``` c#
void Register(Action<TEventData> action);
void Register(Func<TEventData, Task> action);
``` 
but it causes all existing `Register(Action<TEventData> action)`  method calls in the tests to be interpreted it as  `Register(Func<TEventData, Task> action)`.


