### PR TITLE
closed  #2940 Added RouteConfiguration to IAbpAspNetCoreConfiguration…

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Abp.AspNetCore.Mvc.Results.Caching;
 using Abp.Domain.Uow;
 using Abp.Web.Models;
+using Microsoft.AspNetCore.Routing;
 
 namespace Abp.AspNetCore.Configuration
 {
@@ -25,6 +26,8 @@ namespace Abp.AspNetCore.Configuration
 
         public bool SetNoCacheForAjaxResponses { get; set; }
 
+        public List<Action<IRouteBuilder>> RouteConfiguration { get; }
+
         public AbpAspNetCoreConfiguration()
         {
             DefaultWrapResultAttribute = new WrapResultAttribute();
@@ -32,11 +35,12 @@ namespace Abp.AspNetCore.Configuration
             DefaultUnitOfWorkAttribute = new UnitOfWorkAttribute();
             ControllerAssemblySettings = new ControllerAssemblySettingList();
             FormBodyBindingIgnoredTypes = new List<Type>();
+            RouteConfiguration = new List<Action<IRouteBuilder>>();
             IsValidationEnabledForControllers = true;
             SetNoCacheForAjaxResponses = true;
             IsAuditingEnabled = true;
         }
-
+       
         public AbpControllerAssemblySettingBuilder CreateControllersForAppServices(
             Assembly assembly,
             string moduleName = AbpControllerAssemblySetting.DefaultServiceModuleName,

--- a/src/Abp.AspNetCore/AspNetCore/Configuration/IAbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/IAbpAspNetCoreConfiguration.cs
@@ -33,6 +33,11 @@ namespace Abp.AspNetCore.Configuration
         /// Default: true.
         /// </summary>
         bool SetNoCacheForAjaxResponses { get; set; }
+        
+        /// <summary>
+        /// Used to add route config for modules.
+        /// </summary>
+        List<Action<IRouteBuilder>> RouteConfiguration { get; }
 
         AbpControllerAssemblySettingBuilder CreateControllersForAppServices(
             Assembly assembly,

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Extensions/RouteBuilderExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Extensions/RouteBuilderExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Routing;
+
+namespace Abp.AspNetCore.Mvc.Extensions
+{
+    public static class RouteBuilderExtensions
+    {
+        public static void ConfigureAll(this List<Action<IRouteBuilder>> routeBuilderActions, IRouteBuilder routes)
+        {
+            if (routeBuilderActions == null)
+            {
+                throw new ArgumentNullException(nameof(routeBuilderActions));
+            }
+
+            routeBuilderActions.ForEach(action =>
+            {
+                action(routes);
+            });
+        }
+    }
+}

--- a/test/Abp.AspNetCore.Tests/App/AppModule.cs
+++ b/test/Abp.AspNetCore.Tests/App/AppModule.cs
@@ -9,6 +9,7 @@ using Abp.Auditing;
 using Abp.Localization;
 using Abp.MultiTenancy;
 using Abp.Reflection.Extensions;
+using Microsoft.AspNetCore.Builder;
 
 namespace Abp.AspNetCore.App
 {
@@ -27,6 +28,13 @@ namespace Abp.AspNetCore.App
                 .CreateControllersForAppServices(
                     typeof(AppModule).GetAssembly()
                 );
+
+            Configuration.IocManager.Resolve<IAbpAspNetCoreConfiguration>().RouteConfiguration.Add(routes =>
+            {
+                routes.MapRoute(
+                    name: "default",
+                    template: "{controller=Home}/{action=Index}/{id?}");
+            });
         }
 
         public override void Initialize()

--- a/test/Abp.AspNetCore.Tests/App/Startup.cs
+++ b/test/Abp.AspNetCore.Tests/App/Startup.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Abp.AspNetCore.Configuration;
+using Abp.AspNetCore.Mvc.Extensions;
 using Abp.AspNetCore.TestBase;
 using Abp.Reflection.Extensions;
 using Microsoft.AspNetCore.Builder;
@@ -32,9 +34,7 @@ namespace Abp.AspNetCore.App
 
             app.UseMvc(routes =>
             {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                app.ApplicationServices.GetRequiredService<IAbpAspNetCoreConfiguration>().RouteConfiguration.ConfigureAll(routes);
             });
         }
     }

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/AbpAspNetCoreDemoModule.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/AbpAspNetCoreDemoModule.cs
@@ -8,13 +8,14 @@ using Abp.Modules;
 using Abp.Reflection.Extensions;
 using AbpAspNetCoreDemo.Core;
 using AbpAspNetCoreDemo.Db;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 
 namespace AbpAspNetCoreDemo
 {
     [DependsOn(
-        typeof(AbpAspNetCoreModule), 
+        typeof(AbpAspNetCoreModule),
         typeof(AbpAspNetCoreDemoCoreModule),
         typeof(AbpEntityFrameworkCoreModule),
         typeof(AbpCastleLog4NetModule)
@@ -41,6 +42,14 @@ namespace AbpAspNetCoreDemo
                 .CreateControllersForAppServices(
                     typeof(AbpAspNetCoreDemoCoreModule).GetAssembly()
                 );
+
+
+            Configuration.IocManager.Resolve<IAbpAspNetCoreConfiguration>().RouteConfiguration.Add(routes =>
+            {
+                routes.MapRoute(
+                    name: "default",
+                    template: "{controller=Home}/{action=Index}/{id?}");
+            });
         }
 
         public override void Initialize()

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/Startup.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/Startup.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using Abp.AspNetCore;
+using Abp.AspNetCore.Configuration;
+using Abp.AspNetCore.Mvc.Extensions;
 using Abp.Castle.Logging.Log4Net;
 using Abp.PlugIns;
 using AbpAspNetCoreDemo.Controllers;
@@ -86,9 +88,7 @@ namespace AbpAspNetCoreDemo
 
             app.UseMvc(routes =>
             {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                app.ApplicationServices.GetRequiredService<IAbpAspNetCoreConfiguration>().RouteConfiguration.ConfigureAll(routes);
             });
         }
     }


### PR DESCRIPTION
…. Each module can add/remove routes with the following example

```c#
Configuration.IocManager.Resolve<IAbpAspNetCoreConfiguration>().RouteConfiguration.Add(routes =>{
    routes.MapRoute(
        name: "default",
        template: "{controller=Home}/{action=Index}/{id?}");
});
```

Finally, at Startup class following action can be executed to configure all routes

```c#
app.UseMvc(routes =>
{
    app.ApplicationServices.GetRequiredService<IAbpAspNetCoreConfiguration>()
        .RouteConfiguration.ConfigureAll(routes);
});
```