### PR TITLE
Update DefaultLanguagesCreator.cs

### DIFF
--- a/test/Abp.ZeroCore.SampleApp/EntityFramework/Seed/Host/DefaultLanguagesCreator.cs
+++ b/test/Abp.ZeroCore.SampleApp/EntityFramework/Seed/Host/DefaultLanguagesCreator.cs
@@ -14,7 +14,7 @@ namespace Abp.ZeroCore.SampleApp.EntityFramework.Seed.Host
         {
             return new List<ApplicationLanguage>
             {
-                new ApplicationLanguage(null, "en", "English", "famfamfam-flags gb"),
+                new ApplicationLanguage(null, "en-gb", "English", "famfamfam-flags gb"),
                 new ApplicationLanguage(null, "tr", "Türkçe", "famfamfam-flags tr")
             };
         }


### PR DESCRIPTION
Localization misleads in the UK. Uk date format is dd/MM/yyyy. As the gb opted out from the language name the dates are displayed in the US date format.  To fix the issue the gb should be placed in gb flag or the flag should be changed to us flag.