### PR TITLE
Set access to AbpStore property as protected in AbpUserManager

### DIFF
--- a/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
+++ b/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
@@ -108,7 +108,7 @@ namespace Abp.Authorization
             int? tenantId = tenant == null ? (int?)null : tenant.Id;
             using (UnitOfWorkManager.Current.SetTenantId(tenantId))
             {
-                var user = await UserManager.AbpStore.FindAsync(tenantId, login);
+                var user = await UserManager.FindAsync(tenantId, login);
                 if (user == null)
                 {
                     return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.UnknownExternalLogin, tenant);
@@ -169,7 +169,7 @@ namespace Abp.Authorization
                 //TryLoginFromExternalAuthenticationSources method may create the user, that's why we are calling it before AbpStore.FindByNameOrEmailAsync
                 var loggedInFromExternalSource = await TryLoginFromExternalAuthenticationSources(userNameOrEmailAddress, plainPassword, tenant);
 
-                var user = await UserManager.AbpStore.FindByNameOrEmailAsync(tenantId, userNameOrEmailAddress);
+                var user = await UserManager.FindByNameOrEmailAsync(tenantId, userNameOrEmailAddress);
                 if (user == null)
                 {
                     return new AbpLoginResult<TTenant, TUser>(AbpLoginResultType.InvalidUserNameOrEmailAddress, tenant);
@@ -221,7 +221,7 @@ namespace Abp.Authorization
 
             user.LastLoginTime = Clock.Now;
 
-            await UserManager.AbpStore.UpdateAsync(user);
+            await UserManager.UpdateAsync(user);
 
             await UnitOfWorkManager.Current.SaveChangesAsync();
 
@@ -301,7 +301,7 @@ namespace Abp.Authorization
                         var tenantId = tenant == null ? (int?)null : tenant.Id;
                         using (UnitOfWorkManager.Current.SetTenantId(tenantId))
                         {
-                            var user = await UserManager.AbpStore.FindByNameOrEmailAsync(tenantId, userNameOrEmailAddress);
+                            var user = await UserManager.FindByNameOrEmailAsync(tenantId, userNameOrEmailAddress);
                             if (user == null)
                             {
                                 user = await source.Object.CreateUserAsync(userNameOrEmailAddress, tenant);
@@ -320,7 +320,7 @@ namespace Abp.Authorization
                                     }
                                 }
 
-                                await UserManager.AbpStore.CreateAsync(user);
+                                await UserManager.CreateAsync(user);
                             }
                             else
                             {
@@ -328,7 +328,7 @@ namespace Abp.Authorization
 
                                 user.AuthenticationSource = source.Object.Name;
 
-                                await UserManager.AbpStore.UpdateAsync(user);
+                                await UserManager.UpdateAsync(user);
                             }
 
                             await UnitOfWorkManager.Current.SaveChangesAsync();

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
@@ -49,7 +49,7 @@ namespace Abp.Authorization.Users
 
         protected AbpRoleManager<TRole, TUser> RoleManager { get; }
 
-        public AbpUserStore<TRole, TUser> AbpStore { get; }
+        protected AbpUserStore<TRole, TUser> AbpStore { get; }
 
         public IMultiTenancyConfig MultiTenancy { get; set; }
 
@@ -295,14 +295,24 @@ namespace Abp.Authorization.Users
             await UserPermissionStore.AddPermissionAsync(user, new PermissionGrantInfo(permission.Name, false));
         }
 
-        public virtual async Task<TUser> FindByNameOrEmailAsync(string userNameOrEmailAddress)
+        public virtual Task<TUser> FindByNameOrEmailAsync(string userNameOrEmailAddress)
         {
-            return await AbpStore.FindByNameOrEmailAsync(userNameOrEmailAddress);
+            return AbpStore.FindByNameOrEmailAsync(userNameOrEmailAddress);
         }
 
         public virtual Task<List<TUser>> FindAllAsync(UserLoginInfo login)
         {
             return AbpStore.FindAllAsync(login);
+        }
+
+        public virtual Task<TUser> FindAsync(int? tenantId, UserLoginInfo login)
+        {
+            return AbpStore.FindAsync(tenantId, login);
+        }
+
+        public virtual Task<TUser> FindByNameOrEmailAsync(int? tenantId, string userNameOrEmailAddress)
+        {
+            return AbpStore.FindByNameOrEmailAsync(tenantId, userNameOrEmailAddress);
         }
 
         /// <summary>


### PR DESCRIPTION
This avoids confusion and protects from calling `AbpStore`'s methods directly. #3055 