### PR TITLE
Change abp.signalr-client ES6 arrow function to ES5

### DIFF
--- a/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js
@@ -59,7 +59,7 @@ var abp = abp || {};
                 abp.log.debug('Registered to the SignalR server!'); //TODO: Remove log
             });
         })
-        .catch(error => {
+        .catch(function (error) {
             abp.log.debug(error.message);
         });
     };


### PR DESCRIPTION
Fixes #3078