### PR TITLE
Better support for multiple SignalR hubs

### DIFF
--- a/doc/WebSite/SignalR-AspNetCore-Integration.md
+++ b/doc/WebSite/SignalR-AspNetCore-Integration.md
@@ -155,7 +155,7 @@ that we want to add a Hub to our application:
 
 <!-- -->
 
-    routes.MapHub<MyChatHub>("/myChatHub");
+    routes.MapHub<MyChatHub>("/signalr-myChatHub"); // Prefix with '/signalr'
 
 We implemented the **ITransientDependency** interface to simply register our hub to the
 [dependency injection](/Pages/Documents/Dependency-Injection) system
@@ -163,6 +163,7 @@ We implemented the **ITransientDependency** interface to simply register our hub
 [property-injected](/Pages/Documents/Dependency-Injection#property-injection-pattern)
 the [session](/Pages/Documents/Abp-Session) and
 [logger](/Pages/Documents/Logging).
+Alternatively, we can inherit AbpHubBase.
 
 **SendMessage** is a method of our hub that can be used by clients. We
 call the **getMessage** function of **all** clients in this method. We can
@@ -175,15 +176,18 @@ our hub.
 
     var chatHub = null;
 
-    abp.signalr.startConnection('/myChatHub', function (connection) {
+    abp.signalr.startConnection('/signalr-myChatHub', function (connection) {
         chatHub = connection; // Save a reference to the hub
 
         connection.on('getMessage', function (message) { // Register for incoming messages
             console.log('received message: ' + message);
         });
+    }).then(function (connection) {
+        abp.log.debug('Connected to myChatHub server!');
+        abp.event.trigger('myChatHub.connected');
     });
 
-    abp.event.on('abp.signalr.connected', function() { // Register for connect event
+    abp.event.on('myChatHub.connected', function() { // Register for connect event
         chatHub.invoke('sendMessage', "Hi everybody, I'm connected to the chat!"); // Send a message to the server
     });
 

--- a/doc/WebSite/SignalR-AspNetCore-Integration.md
+++ b/doc/WebSite/SignalR-AspNetCore-Integration.md
@@ -137,7 +137,7 @@ that we want to add a Hub to our application:
 
         public async Task SendMessage(string message)
         {
-            await Clients.All.InvokeAsync("getMessage", string.Format("User {0}: {1}", AbpSession.UserId, message));
+            await Clients.All.SendAsync("getMessage", string.Format("User {0}: {1}", AbpSession.UserId, message));
         }
 
         public override async Task OnConnectedAsync()

--- a/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js
@@ -40,21 +40,22 @@ var abp = abp || {};
     }
 
     // Connect to the server
-    abp.signalr.connect = function() {
+    abp.signalr.connect = function () {
         var url = abp.signalr.url || '/signalr';
 
         // Start the connection.
-        startConnection(url, configureConnection).then(function (connection) {
-            abp.log.debug('Connected to SignalR server!'); //TODO: Remove log
-            abp.event.trigger('abp.signalr.connected');
-            // Call the Register method on the hub.
-            connection.invoke('register').then(function () {
-                abp.log.debug('Registered to the SignalR server!'); //TODO: Remove log
+        startConnection(url, configureConnection)
+            .then(function (connection) {
+                abp.log.debug('Connected to SignalR server!'); //TODO: Remove log
+                abp.event.trigger('abp.signalr.connected');
+                // Call the Register method on the hub.
+                connection.invoke('register').then(function () {
+                    abp.log.debug('Registered to the SignalR server!'); //TODO: Remove log
+                });
+            })
+            .catch(function (error) {
+                abp.log.debug(error.message);
             });
-        })
-        .catch(function (error) {
-            abp.log.debug(error.message);
-        });
     };
 
     // Starts a connection with transport fallback - if the connection cannot be started using
@@ -73,16 +74,16 @@ var abp = abp || {};
 
         return function start(transport) {
             abp.log.debug(`Starting connection using ${signalR.TransportType[transport]} transport`);
-            var connection = new signalR.HubConnection(url, {transport: transport});
+            var connection = new signalR.HubConnection(url, { transport: transport });
             if (configureConnection && typeof configureConnection === 'function') {
                 configureConnection(connection);
             }
 
             return connection.start()
-                .then(function() {
+                .then(function () {
                     return connection;
                 })
-                .catch(function(error) {
+                .catch(function (error) {
                     abp.log.debug(`Cannot start the connection using ${signalR.TransportType[transport]} transport. ${error.message}`);
                     if (transport !== signalR.TransportType.LongPolling) {
                         return start(transport + 1);

--- a/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js
@@ -29,9 +29,7 @@ var abp = abp || {};
             }
 
             setTimeout(function () {
-                if ($.connection.hub.state === $.signalR.connectionState.disconnected) {
-                    $.connection.hub.start();
-                }
+                connection.start();
             }, 5000);
         });
 

--- a/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr-client.js
@@ -43,11 +43,6 @@ var abp = abp || {};
     abp.signalr.connect = function() {
         var url = abp.signalr.url || '/signalr';
 
-        // Add query string: https://github.com/aspnet/SignalR/issues/680
-        if (abp.signalr.qs) {
-            url += '?' + abp.signalr.qs;
-        }
-
         // Start the connection.
         startConnection(url, configureConnection).then(function (connection) {
             abp.log.debug('Connected to SignalR server!'); //TODO: Remove log
@@ -67,6 +62,15 @@ var abp = abp || {};
     // if this does not work it will try longPolling. If the connection cannot be started using
     // any of the available transports the function will return a rejected Promise.
     function startConnection(url, configureConnection) {
+        if (abp.signalr.remoteServiceBaseUrl) {
+            url = abp.signalr.remoteServiceBaseUrl + url;
+        }
+
+        // Add query string: https://github.com/aspnet/SignalR/issues/680
+        if (abp.signalr.qs) {
+            url += '?' + abp.signalr.qs;
+        }
+
         return function start(transport) {
             abp.log.debug(`Starting connection using ${signalR.TransportType[transport]} transport`);
             var connection = new signalR.HubConnection(url, {transport: transport});

--- a/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr.d.ts
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr.d.ts
@@ -6,6 +6,8 @@
 
         let qs: string;
 
+        let remoteServiceBaseUrl: string;
+
         let url: string;
 
         function connect(): any;

--- a/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr.d.ts
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr.d.ts
@@ -10,6 +10,8 @@
 
         function connect(): any;
 
+        function startConnection(url: string, configureConnection: Function): Promise<any>;
+
         namespace hubs {
 
             let common: any;


### PR DESCRIPTION
### Enhancements

Better support for multiple SignalR hubs ([module-zero-core-template#190](https://github.com/aspnetboilerplate/module-zero-core-template/issues/190), [SO question 48897720](https://stackoverflow.com/questions/48897720/multiple-signalr-connections-in-abp))

- Expose `startConnection` in abp.signalr.d.ts
- Expose `remoteServiceBaseUrl` in abp.signalr.d.ts
- Add `remoteServiceBaseUrl` and `qs` in `startConnection` — abp.signalr-client.js
- Update instructions for multiple SignalR hubs — SignalR-AspNetCore-Integration.md

Fix reconnect code
- Replace `$.connection` in abp.signalr-client.js
- Fix whitespace and indentation — abp.signalr-client.js

Update method call in documentation ([SO question 48875859](https://stackoverflow.com/questions/48875859/aspnetcore-signalr-iclientproxy-does-not-contain-a-definition-for-invokeasyn))
- Update SignalR code from InvokeAsync to SendAsync — SignalR-AspNetCore-Integration.md

### Usage (breaking changes)

Configuring `qs` and `remoteServiceBaseUrl` in SignalRAspNetCoreHelper.ts: (can still be improved)

```js
abp.signalr = {
    autoConnect: true,  // No change
    connect: undefined, // No change
    hubs: undefined,    // No change
    qs: AppConsts.authorization.encrptedAuthTokenName + "=" + ... // No change
    remoteServiceBaseUrl: AppConsts.remoteServiceBaseUrl,         // Add this
    startConnection: undefined,                                   // Add this
    url: '/signalr' // Changed from: AppConsts.remoteServiceBaseUrl + '/signalr'
};
```

Calling `startConnection` for multiple hubs in Angular:

```js
// Previous
const qs = AppConsts.authorization.encrptedAuthTokenName + "=" + encodeURIComponent(encryptedAuthToken);
const url = AppConsts.remoteServiceBaseUrl + '/signalr-myChatHub';
abp.signalr.startConnection(url + '?' + qs, function (connection) {
    // ...
});

// Proposed (same as jQuery)
abp.signalr.startConnection('/signalr-myChatHub', function (connection) {
    // ...
});
```