### PR TITLE
Set FeatureDependencyContext.TenantId before using

### DIFF
--- a/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
@@ -160,6 +160,8 @@ namespace Abp.Authorization.Users
             //Check for depended features
             if (permission.FeatureDependency != null && GetCurrentMultiTenancySide() == MultiTenancySides.Tenant)
             {
+                FeatureDependencyContext.TenantId = GetCurrentTenantId();
+
                 if (!await permission.FeatureDependency.IsSatisfiedAsync(FeatureDependencyContext))
                 {
                     return false;

--- a/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
@@ -137,19 +137,19 @@ namespace Abp.Authorization.Users
         /// <summary>
         /// Check whether a user is granted for a permission.
         /// </summary>
-        /// <param name="user">User</param>
+        /// <param name="userId">User id</param>
         /// <param name="permission">Permission</param>
-        public virtual Task<bool> IsGrantedAsync(TUser user, Permission permission)
+        public virtual async Task<bool> IsGrantedAsync(long userId, Permission permission)
         {
-            return IsGrantedAsync(user.Id, permission);
+            return await IsGrantedAsync(await GetUserByIdAsync(userId), permission);
         }
 
         /// <summary>
         /// Check whether a user is granted for a permission.
         /// </summary>
-        /// <param name="userId">User id</param>
+        /// <param name="user">User</param>
         /// <param name="permission">Permission</param>
-        public virtual async Task<bool> IsGrantedAsync(long userId, Permission permission)
+        public virtual async Task<bool> IsGrantedAsync(TUser user, Permission permission)
         {
             //Check for multi-tenancy side
             if (!permission.MultiTenancySides.HasFlag(GetCurrentMultiTenancySide()))
@@ -160,7 +160,7 @@ namespace Abp.Authorization.Users
             //Check for depended features
             if (permission.FeatureDependency != null && GetCurrentMultiTenancySide() == MultiTenancySides.Tenant)
             {
-                FeatureDependencyContext.TenantId = GetCurrentTenantId();
+                FeatureDependencyContext.TenantId = user.TenantId;
 
                 if (!await permission.FeatureDependency.IsSatisfiedAsync(FeatureDependencyContext))
                 {
@@ -169,7 +169,7 @@ namespace Abp.Authorization.Users
             }
             
             //Get cached user permissions
-            var cacheItem = await GetUserPermissionCacheItemAsync(userId);
+            var cacheItem = await GetUserPermissionCacheItemAsync(user.Id);
             if (cacheItem == null)
             {
                 return false;

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
@@ -135,19 +135,19 @@ namespace Abp.Authorization.Users
         /// <summary>
         /// Check whether a user is granted for a permission.
         /// </summary>
-        /// <param name="user">User</param>
+        /// <param name="userId">User id</param>
         /// <param name="permission">Permission</param>
-        public virtual Task<bool> IsGrantedAsync(TUser user, Permission permission)
+        public virtual async Task<bool> IsGrantedAsync(long userId, Permission permission)
         {
-            return IsGrantedAsync(user.Id, permission);
+            return await IsGrantedAsync(await GetUserByIdAsync(userId), permission);
         }
 
         /// <summary>
         /// Check whether a user is granted for a permission.
         /// </summary>
-        /// <param name="userId">User id</param>
+        /// <param name="user">User</param>
         /// <param name="permission">Permission</param>
-        public virtual async Task<bool> IsGrantedAsync(long userId, Permission permission)
+        public virtual async Task<bool> IsGrantedAsync(TUser user, Permission permission)
         {
             //Check for multi-tenancy side
             if (!permission.MultiTenancySides.HasFlag(GetCurrentMultiTenancySide()))
@@ -158,7 +158,7 @@ namespace Abp.Authorization.Users
             //Check for depended features
             if (permission.FeatureDependency != null && GetCurrentMultiTenancySide() == MultiTenancySides.Tenant)
             {
-                FeatureDependencyContext.TenantId = GetCurrentTenantId();
+                FeatureDependencyContext.TenantId = user.TenantId;
 
                 if (!await permission.FeatureDependency.IsSatisfiedAsync(FeatureDependencyContext))
                 {
@@ -167,7 +167,7 @@ namespace Abp.Authorization.Users
             }
 
             //Get cached user permissions
-            var cacheItem = await GetUserPermissionCacheItemAsync(userId);
+            var cacheItem = await GetUserPermissionCacheItemAsync(user.Id);
             if (cacheItem == null)
             {
                 return false;

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
@@ -158,6 +158,8 @@ namespace Abp.Authorization.Users
             //Check for depended features
             if (permission.FeatureDependency != null && GetCurrentMultiTenancySide() == MultiTenancySides.Tenant)
             {
+                FeatureDependencyContext.TenantId = GetCurrentTenantId();
+
                 if (!await permission.FeatureDependency.IsSatisfiedAsync(FeatureDependencyContext))
                 {
                     return false;


### PR DESCRIPTION
Fixes #3152 

The current fix assumes that `TenantId` is correctly set in `CurrentUnitOfWork` or `AbpSession`.
Actually, we should use `user.TenantId`, similar to #2751. Should I push [`370f0ef`](https://github.com/acjh/aspnetboilerplate/commit/370f0ef64f953565a4fa29070e12c6f19c054e4e) to this PR?