### PR TITLE
Add more IncludeIf extensions for EF Core

### DIFF
--- a/src/Abp.EntityFrameworkCore/EntityFrameworkCore/Extensions/QueryableExtensions.cs
+++ b/src/Abp.EntityFrameworkCore/EntityFrameworkCore/Extensions/QueryableExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 
 namespace Abp.EntityFrameworkCore.Extensions
 {
@@ -10,33 +11,19 @@ namespace Abp.EntityFrameworkCore.Extensions
     /// </summary>
     public static class QueryableExtensions
     {
-        //EntityFramework does not support Include with string path.
-
-        ///// <summary>
-        ///// Specifies the related objects to include in the query results.
-        ///// </summary>
-        ///// <param name="source">The source <see cref="IQueryable"/> on which to call Include.</param>
-        ///// <param name="condition">A boolean value to determine to include <see cref="path"/> or not.</param>
-        ///// <param name="path">The dot-separated list of related objects to return in the query results.</param>
-        //public static IQueryable IncludeIf(this IQueryable source, bool condition, string path)
-        //{
-        //    return condition
-        //        ? source.Include(path)
-        //        : source;
-        //}
-
-        ///// <summary>
-        ///// Specifies the related objects to include in the query results.
-        ///// </summary>
-        ///// <param name="source">The source <see cref="IQueryable{T}"/> on which to call Include.</param>
-        ///// <param name="condition">A boolean value to determine to include <see cref="path"/> or not.</param>
-        ///// <param name="path">The dot-separated list of related objects to return in the query results.</param>
-        //public static IQueryable<T> IncludeIf<T>(this IQueryable<T> source, bool condition, string path)
-        //{
-        //    return condition
-        //        ? source.Include(path)
-        //        : source;
-        //}
+        /// <summary>
+        /// Specifies the related objects to include in the query results.
+        /// </summary>
+        /// <param name="source">The source <see cref="IQueryable{T}"/> on which to call Include.</param>
+        /// <param name="condition">A boolean value to determine to include <paramref name="path"/> or not.</param>
+        /// <param name="path">The dot-separated list of related objects to return in the query results.</param>
+        public static IQueryable<T> IncludeIf<T>(this IQueryable<T> source, bool condition, string path)
+            where T : class
+        {
+            return condition
+                ? source.Include(path)
+                : source;
+        }
 
         /// <summary>
         /// Specifies the related objects to include in the query results.
@@ -49,6 +36,23 @@ namespace Abp.EntityFrameworkCore.Extensions
         {
             return condition
                 ? source.Include(path)
+                : source;
+        }
+
+        /// <summary>
+        /// Specifies the related objects to include in the query results.
+        /// </summary>
+        /// <param name="source">The source <see cref="IQueryable{T}"/> on which to call Include.</param>
+        /// <param name="condition">A boolean value to determine to include <paramref name="include"/> or not.</param>
+        /// <param name="include">A function to include one or more navigation properties using Include/ThenInclude chaining operators.</param>
+        public static IQueryable<T> IncludeIf<T>(
+            this IQueryable<T> source,
+            bool condition,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include)
+            where T : class
+        {
+            return condition
+                ? include(source)
                 : source;
         }
     }


### PR DESCRIPTION
One extension is for adding navigation properties using string expression.

The other is when you want to include multiple navigation properties using `Include` and `IncludeThen` operators.
Example: `query.IncludeIf(true, q => q.Include(blog => blog.Posts).ThenInclude(post => post.Tags))`