### PR TITLE
ProxyScriptingHelper should be public

### DIFF
--- a/src/Abp.Web.Common/Web/Api/ProxyScripting/Generators/ProxyScriptingHelper.cs
+++ b/src/Abp.Web.Common/Web/Api/ProxyScripting/Generators/ProxyScriptingHelper.cs
@@ -7,7 +7,7 @@ using Abp.Web.Api.Modeling;
 
 namespace Abp.Web.Api.ProxyScripting.Generators
 {
-    internal static class ProxyScriptingHelper
+    public static class ProxyScriptingHelper
     {
         public const string DefaultHttpVerb = "POST";
 


### PR DESCRIPTION
This allows custom script generators to be created by the user.