### PR TITLE
ProxyJsScriptingFuncHelper should be public

### DIFF
--- a/src/Abp.Web.Common/Web/Api/ProxyScripting/Generators/ProxyScriptingJsFuncHelper.cs
+++ b/src/Abp.Web.Common/Web/Api/ProxyScripting/Generators/ProxyScriptingJsFuncHelper.cs
@@ -8,7 +8,7 @@ using Abp.Web.Api.Modeling;
 
 namespace Abp.Web.Api.ProxyScripting.Generators
 {
-    internal static class ProxyScriptingJsFuncHelper
+    public static class ProxyScriptingJsFuncHelper
     {
         private const string ValidJsVariableNameChars = "abcdefghijklmnopqrstuxwvyzABCDEFGHIJKLMNOPQRSTUXWVYZ0123456789_";
 


### PR DESCRIPTION
This allows users to create their own script generators and use the existing helper functionality