### PR TITLE
MultiTenancySide attribute for Host/Tenant only

### DIFF
--- a/src/Abp/AbpBootstrapper.cs
+++ b/src/Abp/AbpBootstrapper.cs
@@ -8,6 +8,7 @@ using Abp.Dependency.Installers;
 using Abp.Domain.Uow;
 using Abp.EntityHistory;
 using Abp.Modules;
+using Abp.MultiTenancy;
 using Abp.PlugIns;
 using Abp.Runtime.Validation.Interception;
 using Castle.Core.Logging;
@@ -132,6 +133,7 @@ namespace Abp
             AuditingInterceptorRegistrar.Initialize(IocManager);
             EntityHistoryInterceptorRegistrar.Initialize(IocManager);
             UnitOfWorkRegistrar.Initialize(IocManager);
+            MultiTenancySideInterceptorRegistrar.Initialize(IocManager);
             AuthorizationInterceptorRegistrar.Initialize(IocManager);
         }
 

--- a/src/Abp/Localization/Sources/AbpXmlSource/Abp.xml
+++ b/src/Abp/Localization/Sources/AbpXmlSource/Abp.xml
@@ -13,6 +13,8 @@
     <text name="DefaultLanguage">Default language</text>
     <text name="ReceiveNotifications">Receive notifications</text>
     <text name="CurrentUserDidNotLoginToTheApplication">Current user did not login to the application!</text>
+    <text name="AnonymousHostUserMustNotCallTenantMethod">Anonymous host user must not call tenant method.</text>
+    <text name="AnonymousTenantUserMustNotCallHostMethod">Anonymous tenant user must not call host method.</text>
     <text name="TimeZone">Timezone</text>
     <text name="AllOfThesePermissionsMustBeGranted">Required permissions are not granted. All of these permissions must be granted: {0}</text>
     <text name="AtLeastOneOfThesePermissionsMustBeGranted">Required permissions are not granted. At least one of these permissions must be granted: {0}</text>

--- a/src/Abp/MultiTenancy/MultiTenancySideInterceptor.cs
+++ b/src/Abp/MultiTenancy/MultiTenancySideInterceptor.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using Abp.Authorization;
+using Abp.Localization;
+using Abp.Runtime.Session;
+using Castle.DynamicProxy;
+
+namespace Abp.MultiTenancy
+{
+    internal class MultiTenancySideInterceptor : IInterceptor
+    {
+        public IAbpSession AbpSession { get; set; }
+        public ILocalizationManager LocalizationManager { get; set; }
+
+        public MultiTenancySideInterceptor()
+        {
+            AbpSession = NullAbpSession.Instance;
+
+            LocalizationManager = NullLocalizationManager.Instance;
+        }
+
+        public void Intercept(IInvocation invocation)
+        {
+            if (AbpSession.UserId.HasValue)
+            {
+                invocation.Proceed();
+                return;
+            }
+
+            var methodInfo = invocation.MethodInvocationTarget;
+            var multiTenancySideAttribute = methodInfo.GetCustomAttributes(true).OfType<MultiTenancySideAttribute>().FirstOrDefault()
+                  ?? methodInfo.DeclaringType.GetCustomAttributes(true).OfType<MultiTenancySideAttribute>().FirstOrDefault();
+
+            if (multiTenancySideAttribute == null)
+            {
+                invocation.Proceed();
+                return;
+            }
+
+            if (multiTenancySideAttribute.Side.HasFlag(MultiTenancySides.Host) && AbpSession.TenantId.HasValue)
+            {
+                throw new AbpAuthorizationException(
+                    LocalizationManager.GetString(AbpConsts.LocalizationSourceName, "AnonymousTenantUserMustNotCallHostMethod")
+                    );
+            }
+            else if (multiTenancySideAttribute.Side.HasFlag(MultiTenancySides.Tenant) && !AbpSession.TenantId.HasValue)
+            {
+                throw new AbpAuthorizationException(
+                    LocalizationManager.GetString(AbpConsts.LocalizationSourceName, "AnonymousHostUserMustNotCallTenantMethod")
+                    );
+            }
+
+            invocation.Proceed();
+        }
+    }
+}

--- a/src/Abp/MultiTenancy/MultiTenancySideInterceptor.cs
+++ b/src/Abp/MultiTenancy/MultiTenancySideInterceptor.cs
@@ -36,13 +36,15 @@ namespace Abp.MultiTenancy
                 return;
             }
 
-            if (multiTenancySideAttribute.Side.HasFlag(MultiTenancySides.Host) && AbpSession.TenantId.HasValue)
+            var isHost = multiTenancySideAttribute.Side.HasFlag(MultiTenancySides.Host);
+            var isTenant = multiTenancySideAttribute.Side.HasFlag(MultiTenancySides.Tenant);
+            if ((!isTenant && AbpSession.TenantId.HasValue) && isHost)
             {
                 throw new AbpAuthorizationException(
                     LocalizationManager.GetString(AbpConsts.LocalizationSourceName, "AnonymousTenantUserMustNotCallHostMethod")
                     );
             }
-            else if (multiTenancySideAttribute.Side.HasFlag(MultiTenancySides.Tenant) && !AbpSession.TenantId.HasValue)
+            else if ((!isHost && !AbpSession.TenantId.HasValue) && isTenant)
             {
                 throw new AbpAuthorizationException(
                     LocalizationManager.GetString(AbpConsts.LocalizationSourceName, "AnonymousHostUserMustNotCallTenantMethod")

--- a/src/Abp/MultiTenancy/MultiTenancySideInterceptorRegistrar.cs
+++ b/src/Abp/MultiTenancy/MultiTenancySideInterceptorRegistrar.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Abp.Configuration.Startup;
+using Abp.Dependency;
+using Castle.Core;
+
+namespace Abp.MultiTenancy
+{
+    internal static class MultiTenancySideInterceptorRegistrar
+    {
+        public static void Initialize(IIocManager iocManager)
+        {
+            iocManager.IocContainer.Kernel.ComponentRegistered += (key, handler) =>
+            {
+                if (!iocManager.IsRegistered<IMultiTenancyConfig>())
+                {
+                    return;
+                }
+
+                var multiTenancyConfiguration = iocManager.Resolve<IMultiTenancyConfig>();
+
+                if (ShouldIntercept(multiTenancyConfiguration, handler.ComponentModel.Implementation))
+                {
+                    handler.ComponentModel.Interceptors.Add(new InterceptorReference(typeof(MultiTenancySideAttribute)));
+                }
+            };
+        }
+
+        private static bool ShouldIntercept(IMultiTenancyConfig multiTenancyConfig, Type type)
+        {
+            if (!multiTenancyConfig.IsEnabled)
+            {
+                return false;
+            }
+
+            if (type.GetTypeInfo().IsDefined(typeof(MultiTenancySideAttribute), true))
+            {
+                return true;
+            }
+
+            if (type.GetMethods().Any(m => m.IsDefined(typeof(MultiTenancySideAttribute), true)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Abp/MultiTenancy/MultiTenancySideInterceptorRegistrar.cs
+++ b/src/Abp/MultiTenancy/MultiTenancySideInterceptorRegistrar.cs
@@ -22,7 +22,7 @@ namespace Abp.MultiTenancy
 
                 if (ShouldIntercept(multiTenancyConfiguration, handler.ComponentModel.Implementation))
                 {
-                    handler.ComponentModel.Interceptors.Add(new InterceptorReference(typeof(MultiTenancySideAttribute)));
+                    handler.ComponentModel.Interceptors.Add(new InterceptorReference(typeof(MultiTenancySideInterceptor)));
                 }
             };
         }

--- a/test/Abp.AspNetCore.Tests/App/AppModule.cs
+++ b/test/Abp.AspNetCore.Tests/App/AppModule.cs
@@ -19,6 +19,7 @@ namespace Abp.AspNetCore.App
         public override void PreInitialize()
         {
             Configuration.Auditing.IsEnabledForAnonymousUsers = true;
+            Configuration.MultiTenancy.IsEnabled = true;
 
             Configuration.ReplaceService<IAuditingStore, MockAuditingStore>();
             Configuration.ReplaceService<ITenantStore, TestTenantStore>();

--- a/test/Abp.AspNetCore.Tests/Tests/MultiTenancy_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/MultiTenancy_Tests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Abp.AspNetCore.App.Controllers;
 using Abp.Authorization;
-using Abp.Configuration.Startup;
 using Abp.Dependency;
 using Abp.MultiTenancy;
 using Abp.Web.Models;
@@ -21,7 +20,6 @@ namespace Abp.AspNetCore.Tests
 
         public MultiTenancy_Tests()
         {
-            IocManager.Resolve<IMultiTenancyConfig>().IsEnabled = true;
             _multiTenancyConfiguration = Resolve<IWebMultiTenancyConfiguration>();
             _multiTenancyClass = Resolve<MyMultiTenancyClass>();
             _tenantClass = Resolve<MyTenantClass>();

--- a/test/Abp.AspNetCore.Tests/Tests/MultiTenancy_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/MultiTenancy_Tests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Abp.AspNetCore.App.Controllers;
+using Abp.Authorization;
 using Abp.Configuration.Startup;
+using Abp.Dependency;
 using Abp.MultiTenancy;
 using Abp.Web.Models;
 using Abp.Web.MultiTenancy;
@@ -14,11 +16,15 @@ namespace Abp.AspNetCore.Tests
     public class MultiTenancy_Tests : AppTestBase
     {
         private readonly IWebMultiTenancyConfiguration _multiTenancyConfiguration;
+        private readonly MyMultiTenancyClass _multiTenancyClass;
+        private readonly MyTenantClass _tenantClass;
 
         public MultiTenancy_Tests()
         {
             IocManager.Resolve<IMultiTenancyConfig>().IsEnabled = true;
             _multiTenancyConfiguration = Resolve<IWebMultiTenancyConfiguration>();
+            _multiTenancyClass = Resolve<MyMultiTenancyClass>();
+            _tenantClass = Resolve<MyTenantClass>();
         }
 
         [Fact]
@@ -88,6 +94,116 @@ namespace Abp.AspNetCore.Tests
 
             //Assert
             response.Result.ShouldBe(1);
+        }
+
+        [Fact]
+        public void Should_Not_Intercept_Class_For_Authenticated_User()
+        {
+            using (AbpSession.Use(null, 1))
+            {
+                //Allow authenticated host user to call tenant method
+                _tenantClass.TenantMethod();
+            }
+
+            using (AbpSession.Use(1, 1))
+            {
+                //Allow authenticated tenant user to call host method
+                _tenantClass.HostMethod();
+            }
+        }
+
+        [Fact]
+        public void Should_Not_Intercept_Method_For_Authenticated_User()
+        {
+            using (AbpSession.Use(null, 1))
+            {
+                //Allow authenticated host user to call tenant method
+                _multiTenancyClass.TenantMethod();
+            }
+
+            using (AbpSession.Use(1, 1))
+            {
+                //Allow authenticated tenant user to call host method
+                _multiTenancyClass.HostMethod();
+            }
+        }
+
+        [Fact]
+        public void Should_Intercept_Class_For_Anonymous_Host_User()
+        {
+            using (AbpSession.Use(null, null))
+            {
+                Should.Throw<AbpAuthorizationException>(() => _tenantClass.TenantMethod()).Message.ShouldBe("Anonymous host user must not call tenant method.");
+            }
+        }
+
+        [Fact]
+        public void Should_Intercept_Method_For_Anonymous_Host_User()
+        {
+            using (AbpSession.Use(null, null))
+            {
+                Should.Throw<AbpAuthorizationException>(() => _multiTenancyClass.TenantMethod()).Message.ShouldBe("Anonymous host user must not call tenant method.");
+            }
+        }
+
+        [Fact]
+        public void Should_Intercept_Class_For_Anonymous_Tenant_User()
+        {
+            using (AbpSession.Use(1, null))
+            {
+                Should.Throw<AbpAuthorizationException>(() => _tenantClass.HostMethod()).Message.ShouldBe("Anonymous tenant user must not call host method.");
+            }
+        }
+
+        [Fact]
+        public void Should_Intercept_Method_For_Anonymous_Tenant_User()
+        {
+            using (AbpSession.Use(1, null))
+            {
+                Should.Throw<AbpAuthorizationException>(() => _multiTenancyClass.HostMethod()).Message.ShouldBe("Anonymous tenant user must not call host method.");
+            }
+        }
+    }
+
+    public class MyMultiTenancyClass : ITransientDependency
+    {
+        public MyMultiTenancyClass()
+        {
+        }
+
+        [MultiTenancySide(MultiTenancySides.Host)]
+        public virtual void HostMethod()
+        {
+        }
+
+        [MultiTenancySide(MultiTenancySides.Tenant)]
+        public virtual void TenantMethod()
+        {
+        }
+
+        public virtual void AnotherMethod()
+        {
+        }
+    }
+
+    [MultiTenancySide(MultiTenancySides.Tenant)]
+    public class MyTenantClass : ITransientDependency
+    {
+        public MyTenantClass()
+        {
+        }
+
+        [MultiTenancySide(MultiTenancySides.Host)]
+        public virtual void HostMethod()
+        {
+        }
+
+        public virtual void TenantMethod()
+        {
+        }
+
+        public virtual void AnotherMethod()
+        {
         }
     }
 }

--- a/test/Abp.AspNetCore.Tests/Tests/MultiTenancy_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/MultiTenancy_Tests.cs
@@ -141,6 +141,7 @@ namespace Abp.AspNetCore.Tests
             using (AbpSession.Use(null, null))
             {
                 Should.Throw<AbpAuthorizationException>(() => _multiTenancyClass.TenantMethod()).Message.ShouldBe("Anonymous host user must not call tenant method.");
+                _multiTenancyClass.BothMethod();
             }
         }
 
@@ -159,6 +160,7 @@ namespace Abp.AspNetCore.Tests
             using (AbpSession.Use(1, null))
             {
                 Should.Throw<AbpAuthorizationException>(() => _multiTenancyClass.HostMethod()).Message.ShouldBe("Anonymous tenant user must not call host method.");
+                _multiTenancyClass.BothMethod();
             }
         }
     }
@@ -179,7 +181,8 @@ namespace Abp.AspNetCore.Tests
         {
         }
 
-        public virtual void AnotherMethod()
+        [MultiTenancySide(MultiTenancySides.Host | MultiTenancySides.Tenant)]
+        public virtual void BothMethod()
         {
         }
     }


### PR DESCRIPTION
Resolves #1527

Introduced `MutliTenancySideInterceptor` and `MultiTenancySideInterceptorRegistrar`

Interceptor is enabled by `MultiTenancyConfiguration` which is configured during module `PreInitialize()`

### Pending
 - [ ] Exception Message Localization