### PR TITLE
Set TenantId for IMayHaveTenant entities (Entity History)

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -163,7 +163,8 @@ namespace Abp.EntityHistory
                 EntityEntry = entityEntry, // [NotMapped]
                 EntityId = entityId,
                 EntityTypeFullName = entityType.FullName,
-                PropertyChanges = GetPropertyChanges(entityEntry)
+                PropertyChanges = GetPropertyChanges(entityEntry),
+                TenantId = AbpSession.TenantId
             };
 
             return entityChangeInfo;
@@ -214,7 +215,8 @@ namespace Abp.EntityHistory
                         NewValue = isDeleted ? null : propertyEntry.CurrentValue.ToJsonString().TruncateWithPostfix(EntityPropertyChange.MaxValueLength),
                         OriginalValue = isCreated ? null : propertyEntry.OriginalValue.ToJsonString().TruncateWithPostfix(EntityPropertyChange.MaxValueLength),
                         PropertyName = property.Name,
-                        PropertyTypeFullName = property.ClrType.FullName
+                        PropertyTypeFullName = property.ClrType.FullName,
+                        TenantId = AbpSession.TenantId
                     });
                 }
             }


### PR DESCRIPTION
From the documentation on [Multi-Tenancy](https://aspnetboilerplate.com/Pages/Documents/Multi-Tenancy#additional-notes):

> When you define an entity type as IMustHaveTenant or IMayHaveTenant, **always set the TenantId** when you create a new entity (While ASP.NET Boilerplate tries to set it from current TenantId, it may not be possible in some cases, especially for IMayHaveTenant entities).