### PR TITLE
Don't save property history for EntityChange.EntityId

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -290,6 +290,11 @@ namespace Abp.EntityHistory
 
         private bool ShouldSavePropertyHistory(PropertyEntry propertyEntry, bool defaultValue)
         {
+            if (propertyEntry.Metadata.Name == "Id")
+            {
+                return false;
+            }
+
             var propertyInfo = propertyEntry.Metadata.PropertyInfo;
             if (propertyInfo.IsDefined(typeof(DisableAuditingAttribute), true))
             {

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -63,7 +63,7 @@ namespace Abp.EntityHistory
             EntityChangeSetReasonProvider = NullEntityChangeSetReasonProvider.Instance;
             EntityHistoryStore = NullEntityHistoryStore.Instance;
         }
-        
+
         public virtual EntityChangeSet CreateEntityChangeSet(ICollection<EntityEntry> entityEntries)
         {
             var changeSet = new EntityChangeSet
@@ -92,13 +92,13 @@ namespace Abp.EntityHistory
                     continue;
                 }
 
-                var entityChangeInfo = CreateEntityChangeInfo(entry);
-                if (entityChangeInfo == null)
+                var entityChange = CreateEntityChange(entry);
+                if (entityChange == null)
                 {
                     continue;
                 }
 
-                changeSet.EntityChanges.Add(entityChangeInfo);
+                changeSet.EntityChanges.Add(entityChange);
             }
 
             return changeSet;
@@ -126,10 +126,10 @@ namespace Abp.EntityHistory
         }
 
         [CanBeNull]
-        private EntityChange CreateEntityChangeInfo(EntityEntry entityEntry)
+        private EntityChange CreateEntityChange(EntityEntry entityEntry)
         {
             var entity = entityEntry.Entity;
-            
+
             EntityChangeType changeType;
             switch (entityEntry.State)
             {
@@ -157,7 +157,7 @@ namespace Abp.EntityHistory
             }
 
             var entityType = entity.GetType();
-            var entityChangeInfo = new EntityChange
+            var entityChange = new EntityChange
             {
                 ChangeType = changeType,
                 EntityEntry = entityEntry, // [NotMapped]
@@ -167,7 +167,7 @@ namespace Abp.EntityHistory
                 TenantId = AbpSession.TenantId
             };
 
-            return entityChangeInfo;
+            return entityChange;
         }
 
         private DateTime GetChangeTime(EntityChange entityChange)
@@ -325,16 +325,16 @@ namespace Abp.EntityHistory
         /// </summary>
         private void UpdateChangeSet(EntityChangeSet changeSet)
         {
-            foreach (var entityChangeInfo in changeSet.EntityChanges)
+            foreach (var entityChange in changeSet.EntityChanges)
             {
                 /* Update change time */
 
-                entityChangeInfo.ChangeTime = GetChangeTime(entityChangeInfo);
+                entityChange.ChangeTime = GetChangeTime(entityChange);
 
                 /* Update entity id */
 
-                var entityEntry = entityChangeInfo.EntityEntry.As<EntityEntry>();
-                entityChangeInfo.EntityId = GetEntityId(entityEntry.Entity);
+                var entityEntry = entityChange.EntityEntry.As<EntityEntry>();
+                entityChange.EntityId = GetEntityId(entityEntry.Entity);
 
                 /* Update foreign keys */
 
@@ -345,14 +345,14 @@ namespace Abp.EntityHistory
                     foreach (var property in foreignKey.Properties)
                     {
                         var propertyEntry = entityEntry.Property(property.Name);
-                        var propertyChange = entityChangeInfo.PropertyChanges.FirstOrDefault(pc => pc.PropertyName == property.Name);
+                        var propertyChange = entityChange.PropertyChanges.FirstOrDefault(pc => pc.PropertyName == property.Name);
 
                         if (propertyChange == null)
                         {
                             if (!(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null))
                             {
                                 // Add foreign key
-                                entityChangeInfo.PropertyChanges.Add(new EntityPropertyChange
+                                entityChange.PropertyChanges.Add(new EntityPropertyChange
                                 {
                                     NewValue = propertyEntry.CurrentValue.ToJsonString(),
                                     OriginalValue = propertyEntry.OriginalValue.ToJsonString(),
@@ -370,7 +370,7 @@ namespace Abp.EntityHistory
                             if (newValue == propertyChange.NewValue)
                             {
                                 // No change
-                                entityChangeInfo.PropertyChanges.Remove(propertyChange);
+                                entityChange.PropertyChanges.Remove(propertyChange);
                             }
                             else
                             {

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -59,7 +59,7 @@ namespace Abp.Zero.EntityHistory
                      s.EntityChanges[0].ChangeType == EntityChangeType.Created &&
                      s.EntityChanges[0].EntityId == blog2Id.ToJsonString(false, false) &&
                      s.EntityChanges[0].EntityTypeFullName == typeof(Blog).FullName &&
-                     s.EntityChanges[0].PropertyChanges.Count == 3 && // Blog.Id, Blog.Name, Blog.Url
+                     s.EntityChanges[0].PropertyChanges.Count == 2 && // Blog.Name, Blog.Url
 
                      // Check "who did this change"
                      s.ImpersonatorTenantId == AbpSession.ImpersonatorTenantId &&
@@ -112,7 +112,7 @@ namespace Abp.Zero.EntityHistory
 
             UsingDbContext(tenantId, (context) =>
             {
-                context.EntityPropertyChanges.Count(f => f.TenantId == tenantId).ShouldBe(3);
+                context.EntityPropertyChanges.Count(f => f.TenantId == tenantId).ShouldBe(2);
             });
         }
 


### PR DESCRIPTION
- Don't save property history for `EntityChange.EntityId`
- Rename `EntityChangeInfo` to `EntityChange`