### PR TITLE
Register automapper configuration in IOC

### DIFF
--- a/src/Abp.AutoMapper/AutoMapper/AbpAutoMapperModule.cs
+++ b/src/Abp.AutoMapper/AutoMapper/AbpAutoMapperModule.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Abp.Localization;
-using Abp.Modules;
 using System.Reflection;
 using Abp.Configuration.Startup;
+using Abp.Localization;
+using Abp.Modules;
 using Abp.Reflection;
 using AutoMapper;
 using Castle.MicroKernel.Registration;
@@ -16,7 +16,7 @@ namespace Abp.AutoMapper
 
         private static volatile bool _createdMappingsBefore;
         private static readonly object SyncObj = new object();
-        
+
         public AbpAutoMapperModule(ITypeFinder typeFinder)
         {
             _typeFinder = typeFinder;
@@ -59,12 +59,18 @@ namespace Abp.AutoMapper
                     }
 
                     IocManager.IocContainer.Register(
+                        Component.For<IConfigurationProvider>().Instance(Mapper.Configuration).LifestyleSingleton()
+                    );
+                    IocManager.IocContainer.Register(
                         Component.For<IMapper>().Instance(Mapper.Instance).LifestyleSingleton()
                     );
                 }
                 else
                 {
                     var config = new MapperConfiguration(configurer);
+                    IocManager.IocContainer.Register(
+                        Component.For<IConfigurationProvider>().Instance(config).LifestyleSingleton()
+                    );
                     IocManager.IocContainer.Register(
                         Component.For<IMapper>().Instance(config.CreateMapper()).LifestyleSingleton()
                     );


### PR DESCRIPTION
Register AutoMapper`s IConfigurationProvider to be able to retrieve it later.

This could be used to validate the configuration via AssertConfigurationIsValid.