### PR TITLE
Fixes to Abp.Quartz.Tests, Test projects and Cake

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,4 @@
+#tool nuget:?package=vswhere
 #tool "nuget:?package=xunit.runner.console&version=2.3.0-beta5-build3769"
 
 //////////////////////////////////////////////////////////////////////
@@ -11,6 +12,11 @@ var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 var toolpath = Argument("toolpath", @"tools");
 var branch = Argument("branch", EnvironmentVariable("APPVEYOR_REPO_BRANCH"));
+
+var vsLatest  = VSWhereLatest();
+var msBuildPathX64 = (vsLatest==null)
+                            ? null
+                            : vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/amd64/MSBuild.exe");
 
 var testProjects = new List<Tuple<string, string[]>>
                 {
@@ -69,7 +75,7 @@ Task("Build")
     .IsDependentOn("Restore-NuGet-Packages")
     .Does(() =>
     {
-        MSBuild(solution, new MSBuildSettings(){Configuration = configuration}
+        MSBuild(solution, new MSBuildSettings(){Configuration = configuration, ToolPath = msBuildPathX64}
                                                .WithProperty("SourceLinkCreate","true"));
     });
 

--- a/test/Abp.Castle.Log4Net.Tests/Abp.Castle.Log4Net.Tests.csproj
+++ b/test/Abp.Castle.Log4Net.Tests/Abp.Castle.Log4Net.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <Content Include="log4net.config">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/test/Abp.MailKit.Tests/Abp.MailKit.Tests.csproj
+++ b/test/Abp.MailKit.Tests/Abp.MailKit.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <ProjectReference Include="..\..\src\Abp.MailKit\Abp.MailKit.csproj" />
     <ProjectReference Include="..\Abp.Tests\Abp.Tests.csproj" />
   </ItemGroup>

--- a/test/Abp.Quartz.Tests/Abp.Quartz.Tests.csproj
+++ b/test/Abp.Quartz.Tests/Abp.Quartz.Tests.csproj
@@ -34,12 +34,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Abp.Quartz.Tests.xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
   <ProjectExtensions><VisualStudio><UserProperties Abp_1Quartz_1Tests_1xunit_1runner_1json__JSONSchema="http://json.schemastore.org/xunit.runner.schema" /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/test/Abp.Quartz.Tests/Abp.Quartz.Tests.xunit.runner.json
+++ b/test/Abp.Quartz.Tests/Abp.Quartz.Tests.xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "parallelizeTestCollections": false
-}

--- a/test/Abp.Quartz.Tests/QuartzTests.cs
+++ b/test/Abp.Quartz.Tests/QuartzTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Abp.Dependency;
@@ -19,13 +19,11 @@ namespace Abp.Quartz.Tests
         {
             _quartzScheduleJobManager = LocalIocManager.Resolve<IQuartzScheduleJobManager>();
             _abpQuartzConfiguration = LocalIocManager.Resolve<IAbpQuartzConfiguration>();
-
-            ScheduleJobs();
         }
 
-        private void ScheduleJobs()
+        private async Task ScheduleJobs()
         {
-            _quartzScheduleJobManager.ScheduleAsync<HelloJob>(
+            await _quartzScheduleJobManager.ScheduleAsync<HelloJob>(
                 job =>
                 {
                     job.WithDescription("HelloJobDescription")
@@ -39,7 +37,7 @@ namespace Abp.Quartz.Tests
                            .StartNow();
                 });
 
-            _quartzScheduleJobManager.ScheduleAsync<GoodByeJob>(
+            await _quartzScheduleJobManager.ScheduleAsync<GoodByeJob>(
                 job =>
                 {
                     job.WithDescription("GoodByeJobDescription")
@@ -57,6 +55,8 @@ namespace Abp.Quartz.Tests
         [Fact]
         public async Task QuartzScheduler_Jobs_ShouldBeRegistered()
         {
+            await ScheduleJobs();
+
             _abpQuartzConfiguration.Scheduler.ShouldNotBeNull();
             _abpQuartzConfiguration.Scheduler.IsStarted.ShouldBe(true);
             (await _abpQuartzConfiguration.Scheduler.CheckExists(JobKey.Create("HelloJobKey"))).ShouldBe(true);
@@ -64,8 +64,10 @@ namespace Abp.Quartz.Tests
         }
 
         [Fact]
-        public void QuartzScheduler_Jobs_ShouldBeExecuted_With_SingletonDependency()
+        public async Task QuartzScheduler_Jobs_ShouldBeExecuted_With_SingletonDependency()
         {
+            await ScheduleJobs();
+
             var helloDependency = LocalIocManager.Resolve<IHelloDependency>();
             var goodByeDependency = LocalIocManager.Resolve<IGoodByeDependency>();
 

--- a/test/Abp.Quartz.Tests/QuartzTests.cs
+++ b/test/Abp.Quartz.Tests/QuartzTests.cs
@@ -72,7 +72,7 @@ namespace Abp.Quartz.Tests
             var goodByeDependency = LocalIocManager.Resolve<IGoodByeDependency>();
 
             //Wait for execution!
-            Thread.Sleep(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
             helloDependency.ExecutionCount.ShouldBeGreaterThan(0);
             goodByeDependency.ExecutionCount.ShouldBeGreaterThan(0);

--- a/test/Abp.Quartz.Tests/QuartzTests.cs
+++ b/test/Abp.Quartz.Tests/QuartzTests.cs
@@ -53,23 +53,18 @@ namespace Abp.Quartz.Tests
         }
 
         [Fact]
-        public async Task QuartzScheduler_Jobs_ShouldBeRegistered()
+        public async Task QuartzScheduler_Jobs_ShouldBe_Registered_And_Executed_With_SingletonDependency()
         {
+            // There should be only one test case in this project, or the unit test may fail in AppVeyor
             await ScheduleJobs();
+
+            var helloDependency = LocalIocManager.Resolve<IHelloDependency>();
+            var goodByeDependency = LocalIocManager.Resolve<IGoodByeDependency>();
 
             _abpQuartzConfiguration.Scheduler.ShouldNotBeNull();
             _abpQuartzConfiguration.Scheduler.IsStarted.ShouldBe(true);
             (await _abpQuartzConfiguration.Scheduler.CheckExists(JobKey.Create("HelloJobKey"))).ShouldBe(true);
             (await _abpQuartzConfiguration.Scheduler.CheckExists(JobKey.Create("GoodByeJobKey"))).ShouldBe(true);
-        }
-
-        [Fact]
-        public async Task QuartzScheduler_Jobs_ShouldBeExecuted_With_SingletonDependency()
-        {
-            await ScheduleJobs();
-
-            var helloDependency = LocalIocManager.Resolve<IHelloDependency>();
-            var goodByeDependency = LocalIocManager.Resolve<IGoodByeDependency>();
 
             //Wait for execution!
             await Task.Delay(TimeSpan.FromSeconds(5));

--- a/test/Abp.Quartz.Tests/QuartzTests.cs
+++ b/test/Abp.Quartz.Tests/QuartzTests.cs
@@ -33,7 +33,7 @@ namespace Abp.Quartz.Tests
                 {
                     trigger.WithIdentity("HelloJobTrigger")
                            .WithDescription("HelloJobTriggerDescription")
-                           .WithSimpleSchedule(schedule => schedule.WithRepeatCount(5).WithInterval(TimeSpan.FromSeconds(1)).Build())
+                           .WithSimpleSchedule(schedule => schedule.WithRepeatCount(5).WithInterval(TimeSpan.FromSeconds(1)))
                            .StartNow();
                 });
 
@@ -47,7 +47,7 @@ namespace Abp.Quartz.Tests
                 {
                     trigger.WithIdentity("GoodByeJobTrigger")
                            .WithDescription("GoodByeJobTriggerDescription")
-                           .WithSimpleSchedule(schedule => schedule.WithRepeatCount(5).WithInterval(TimeSpan.FromSeconds(1)).Build())
+                           .WithSimpleSchedule(schedule => schedule.WithRepeatCount(5).WithInterval(TimeSpan.FromSeconds(1)))
                            .StartNow();
                 });
         }


### PR DESCRIPTION
# Summary
- Cake: Add vswhere to run cake in a development machine 
- Add missing packages for Test Project
- Fix Quartz Test broken 
- Remove the build() calling to schedule 
- Change the Thread.Sleep to Task.Delay in QuartzTests.cs 
- Temporary fix test broken in AppVeyor 

# About the fix to Abp.Quartz.Tests
(The commit 47777b150b5a4519c331364708cb1a7dafa039e9 actually fixed it)

After #3282 , I managed to [access AppVeyor's windows build worker via remote desktop](https://www.appveyor.com/docs/how-to/rdp-to-build-worker/) and ran the test case in it, so that I could reproduce the test broken constantly.

I find that the test will pass when there is only one test case (`Fact`) in the `Abp.Quartz.Tests`. When I remove the test case `QuartzScheduler_Jobs_ShouldBeRegistered`, test case `QuartzScheduler_Jobs_ShouldBeExecuted_With_SingletonDependency` passed. And it failed when I added `QuartzScheduler_Jobs_ShouldBeRegistered` again, even I haven't modified `QuartzScheduler_Jobs_ShouldBeExecuted_With_SingletonDependency` at all.

Move one test case to a new TestClass don't work.

So I deleted `QuartzScheduler_Jobs_ShouldBeRegistered` and moved its assertion to `QuartzScheduler_Jobs_ShouldBeExecuted_With_SingletonDependency`.

I have tested my modification 5 times in AppVeyor's RDP, they were all passed. 

As for the reason why previous test broke in AppVeyor and why this modification fixes it, I still don't know.