### PR TITLE
Fix badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# ASP.NET Boilerplate
 
-[![Build status](https://ci.appveyor.com/api/projects/status/tvad583r9lbimxh4?svg=true)](https://ci.appveyor.com/project/hikalkan/aspnetboilerplate)
+[![Build status](https://ci.appveyor.com/api/projects/status/tvad583r9lbimxh4/branch/dev?svg=true)](https://ci.appveyor.com/project/hikalkan/aspnetboilerplate)
 
 ## What is ABP?
 


### PR DESCRIPTION
Change the svg url as dev branch's. So that only a failing in dev branch can change the badge to `failing`.

If not, a failing in pull request (without merged) will also show in badge.