### PR TITLE
Fix NRE in AbpEntityMaterializerSource

### DIFF
--- a/src/Abp.EntityFrameworkCore/EntityFrameworkCore/AbpEntityMaterializerSource.cs
+++ b/src/Abp.EntityFrameworkCore/EntityFrameworkCore/AbpEntityMaterializerSource.cs
@@ -67,6 +67,11 @@ namespace Abp.EntityFrameworkCore
                 return false;
             }
 
+            if (property.PropertyInfo == null)
+            {
+                return false;
+            }
+
             if (property.PropertyInfo.IsDefined(typeof(DisableDateTimeNormalizationAttribute), true))
             {
                 return true;


### PR DESCRIPTION
As the [documentation](https://github.com/aspnet/EntityFrameworkCore/blob/c8bc1783f44cae6b9c0182b734d9bfc3761e75e5/src/EFCore/Metadata/IPropertyBase.cs#L33) says `PropertyInfo` can be null for shadow properties or properties mapped directly to fields.