### PR TITLE
Handle property history for shadow properties

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -296,16 +296,15 @@ namespace Abp.EntityHistory
             }
 
             var propertyInfo = propertyEntry.Metadata.PropertyInfo;
-            if (propertyInfo.IsDefined(typeof(DisableAuditingAttribute), true))
+            if (propertyInfo != null && propertyInfo.IsDefined(typeof(DisableAuditingAttribute), true))
             {
                 return false;
             }
 
-            var classType = propertyInfo.DeclaringType;
-            if (classType != null)
+            var entityType = propertyEntry.EntityEntry.Entity.GetType();
+            if (entityType.GetTypeInfo().IsDefined(typeof(DisableAuditingAttribute), true))
             {
-                if (classType.GetTypeInfo().IsDefined(typeof(DisableAuditingAttribute), true) &&
-                    !propertyInfo.IsDefined(typeof(AuditedAttribute), true))
+                if (propertyInfo == null || !propertyInfo.IsDefined(typeof(AuditedAttribute), true))
                 {
                     return false;
                 }

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Comment.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Comment.cs
@@ -1,0 +1,13 @@
+﻿using Abp.Auditing;
+using Abp.Domain.Entities;
+
+namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
+{
+    [Audited]
+    public class Comment : Entity
+    {
+        public Post Post { get; set; }
+
+        public string Content { get; set; }
+    }
+}

--- a/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
+++ b/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
@@ -15,6 +15,8 @@ namespace Abp.ZeroCore.SampleApp.EntityFramework
 
         public DbSet<Post> Posts { get; set; }
 
+        public DbSet<Comment> Comments { get; set; }
+
         public SampleAppDbContext(DbContextOptions<SampleAppDbContext> options) 
             : base(options)
         {

--- a/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestBase.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestBase.cs
@@ -58,6 +58,10 @@ namespace Abp.Zero
                     var post4 = new Post { Blog = blog1, Title = "test-post-4-title", Body = "test-post-4-body", TenantId = 42 };
 
                     context.Posts.AddRange(post1, post2, post3, post4);
+
+                    var comment1 = new Comment { Post = post1, Content = "test-comment-1-content" };
+
+                    context.Comments.Add(comment1);
                 });
         }
 

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -199,7 +199,7 @@ namespace Abp.Zero.EntityHistory
         [Fact]
         public void Should_Write_History_But_Not_For_Property_If_Disabled_History_Tracking()
         {
-            /* Blog.Name has DisableHistoryTracking attribute. */
+            /* Blog.Name has DisableAuditing attribute. */
 
             using (var uow = Resolve<IUnitOfWorkManager>().Begin())
             {


### PR DESCRIPTION
Fixes #3214 

> As the [documentation](https://github.com/aspnet/EntityFrameworkCore/blob/c8bc1783f44cae6b9c0182b734d9bfc3761e75e5/src/EFCore/Metadata/IPropertyBase.cs#L33) says `PropertyInfo` can be null for shadow properties or properties mapped directly to fields.