### PR TITLE
Get the primary key generation method through the EF metadata.

### DIFF
--- a/src/Abp.EntityFramework/EntityFramework/AbpDbContext.cs
+++ b/src/Abp.EntityFramework/EntityFramework/AbpDbContext.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Common;
 using System.Data.Entity;
+using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Core.Objects;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.Validation;
@@ -324,14 +325,29 @@ namespace Abp.EntityFramework
             if (entity != null && entity.Id == Guid.Empty)
             {
                 var entityType = ObjectContext.GetObjectType(entityAsObj.GetType());
-                var idProperty = entityType.GetProperty("Id");
-                var dbGeneratedAttr =
-                    ReflectionHelper.GetSingleAttributeOrDefault<DatabaseGeneratedAttribute>(idProperty);
-                if (dbGeneratedAttr == null || dbGeneratedAttr.DatabaseGeneratedOption == DatabaseGeneratedOption.None)
+
+
+                var edmProperty = GetEdmProperty(entityType, nameof(Entity.Id));
+               
+                if (edmProperty != null && edmProperty.StoreGeneratedPattern == StoreGeneratedPattern.None)
                 {
                     entity.Id = GuidGenerator.Create();
                 }
             }
+        }
+
+        EdmProperty GetEdmProperty(Type type, string propertyName)
+        {
+            var metadata = ((IObjectContextAdapter)this).ObjectContext.MetadataWorkspace;
+
+            var objectItemCollection = ((ObjectItemCollection)metadata.GetItemCollection(DataSpace.OSpace));
+
+            var entityType = metadata.GetItems<EntityType>(DataSpace.OSpace).Single(t => objectItemCollection.GetClrType(t) == type);
+
+            var entitySet = metadata.GetItems<EntityContainer>(DataSpace.SSpace).Single().EntitySets
+                .Single(s => s.ElementType.Name == entityType.Name);
+
+            return entitySet.ElementType.Properties.Single(e => string.Equals(e.Name, propertyName, StringComparison.OrdinalIgnoreCase));
         }
 
         protected virtual void CheckAndSetMustHaveTenantIdProperty(object entityAsObj)

--- a/src/Abp.EntityFrameworkCore/EntityFrameworkCore/AbpDbContext.cs
+++ b/src/Abp.EntityFrameworkCore/EntityFrameworkCore/AbpDbContext.cs
@@ -306,12 +306,9 @@ namespace Abp.EntityFrameworkCore
             var entity = entry.Entity as IEntity<Guid>;
             if (entity != null && entity.Id == Guid.Empty)
             {
-                var dbGeneratedAttr = ReflectionHelper
-                    .GetSingleAttributeOrDefault<DatabaseGeneratedAttribute>(
-                    entry.Property("Id").Metadata.PropertyInfo
-                    );
+                var idPropertyEntry = entry.Property("Id");
 
-                if (dbGeneratedAttr == null || dbGeneratedAttr.DatabaseGeneratedOption == DatabaseGeneratedOption.None)
+                if (idPropertyEntry != null && idPropertyEntry.Metadata.ValueGenerated == ValueGenerated.Never)
                 {
                     entity.Id = GuidGenerator.Create();
                 }


### PR DESCRIPTION
Unable to get correct results when using Fluent API.

```cs
       // EF 6
        protected override void OnModelCreating(DbModelBuilder modelBuilder)
        {
            modelBuilder.Entity<TestEnity>().Property(e=>e.Id).HasDatabaseGeneratedOption(DatabaseGeneratedOption.None);
        }

        // EF Core
        protected override void OnModelCreating(ModelBuilder modelBuilder)
        {
            modelBuilder.Entity<Category>().Property(e => e.Id).ValueGeneratedNever();
        }
```