### PR TITLE
Adjust to abp.utils.formatString argument format

### DIFF
--- a/src/Abp.Web.Resources/Abp/Framework/scripts/abp.js
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/abp.js
@@ -581,9 +581,16 @@
 
         var str = arguments[0];
 
-        for (var i = 1; i < arguments.length; i++) {
-            var placeHolder = '{' + (i - 1) + '}';
-            str = abp.utils.replaceAll(str, placeHolder, arguments[i]);
+        if (arguments.length == 2 && Array.isArray(arguments[1])) {
+            for (var i = 0; i < arguments[1].length; i++) {
+                var placeHolder = '{' + (i) + '}';
+                str = abp.utils.replaceAll(str, placeHolder, arguments[1][i]);
+            }
+        } else {
+            for (var i = 1; i < arguments.length; i++) {
+                var placeHolder = '{' + (i - 1) + '}';
+                str = abp.utils.replaceAll(str, placeHolder, arguments[i]);
+            }
         }
 
         return str;


### PR DESCRIPTION
Although the localization function "l" gets passed a "...args: any[]" parameter, after the parsing, it forwards the structure "[localizedText, [...args]]" to abp.utils.formatString -> it has now (as far as I could see) never more than 2 parameters, having the arguments list encapsulated in an additional array, therefore the current function will only work with 1 or less arguments. As soon as there are 2 or more arguments all of them get concatenated into placeholder {0} and placeholders {1}, {2}, etc. will remain untouched.
My change is defensive in case there still are some occasions where the old structure applies.