### PR TITLE
Add Required Attribute to Id field of EntityDto

### DIFF
--- a/src/Abp/Application/Services/Dto/EntityDto.cs
+++ b/src/Abp/Application/Services/Dto/EntityDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Abp.Application.Services.Dto
 {
@@ -36,6 +37,7 @@ namespace Abp.Application.Services.Dto
         /// <summary>
         /// Id of the entity.
         /// </summary>
+        [Required]
         public TPrimaryKey Id { get; set; }
 
         /// <summary>


### PR DESCRIPTION
The reason for this change is to allow swagger to set the id as required and not as optional.

Currently the swagger definition looks like this for a EntityDto.

```
{
    "UserDto": {
        "required": [
            "userName",
            ...
        ],
        "type": "object",
        "properties": {
            "userName": {
                "maxLength": 32,
                "minLength": 0,
                "type": "string"
            },
            ...
            "id": {
                "format": "int64",
                "type": "integer"
            }
        }
    }
}
```

As the Id field is missing under required swagger gen or nswag create a class in which the id is optional. Which it is not on the backend side. For optional id values there is `NullableIdDto`.