### PR TITLE
Abp.Zero, Abp.ZeroCore configurable LocalizationSourceName

### DIFF
--- a/src/Abp.Zero.Common/MultiTenancy/AbpTenantManager.cs
+++ b/src/Abp.Zero.Common/MultiTenancy/AbpTenantManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -34,6 +35,8 @@ namespace Abp.MultiTenancy
 
         public ILocalizationManager LocalizationManager { get; set; }
 
+        protected string LocalizationSourceName { get; set; }
+
         public ICacheManager CacheManager { get; set; }
 
         public IFeatureManager FeatureManager { get; set; }
@@ -57,6 +60,7 @@ namespace Abp.MultiTenancy
             TenantFeatureRepository = tenantFeatureRepository;
             EditionManager = editionManager;
             LocalizationManager = NullLocalizationManager.Instance;
+            LocalizationSourceName = AbpZeroConsts.LocalizationSourceName;
         }
 
         public virtual IQueryable<TTenant> Tenants { get { return TenantRepository.GetAll(); } }
@@ -229,9 +233,14 @@ namespace Abp.MultiTenancy
             return Task.FromResult(0);
         }
 
-        private string L(string name)
+        protected virtual string L(string name)
         {
-            return LocalizationManager.GetString(AbpZeroConsts.LocalizationSourceName, name);
+            return LocalizationManager.GetString(LocalizationSourceName, name);
+        }
+
+        protected virtual string L(string name, CultureInfo cultureInfo)
+        {
+            return LocalizationManager.GetString(LocalizationSourceName, name, cultureInfo);
         }
 
         public void HandleEvent(EntityChangedEventData<TTenant> eventData)

--- a/src/Abp.Zero.Ldap/Ldap/Configuration/LdapSettingProvider.cs
+++ b/src/Abp.Zero.Ldap/Ldap/Configuration/LdapSettingProvider.cs
@@ -10,6 +10,13 @@ namespace Abp.Zero.Ldap.Configuration
     /// </summary>
     public class LdapSettingProvider : SettingProvider
     {
+        protected string LocalizationSourceName { get; set; }
+
+        public LdapSettingProvider()
+        {
+            LocalizationSourceName = AbpZeroConsts.LocalizationSourceName;
+        }
+
         public override IEnumerable<SettingDefinition> GetSettingDefinitions(SettingDefinitionProviderContext context)
         {
             return new[]
@@ -23,9 +30,9 @@ namespace Abp.Zero.Ldap.Configuration
                    };
         }
 
-        private static ILocalizableString L(string name)
+        protected virtual ILocalizableString L(string name)
         {
-            return new LocalizableString(name, AbpZeroConsts.LocalizationSourceName);
+            return new LocalizableString(name, LocalizationSourceName);
         }
     }
 }

--- a/src/Abp.Zero/Authorization/Roles/AbpRoleManager.cs
+++ b/src/Abp.Zero/Authorization/Roles/AbpRoleManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Abp.Application.Features;
@@ -28,6 +29,8 @@ namespace Abp.Authorization.Roles
         where TUser : AbpUser<TUser>
     {
         public ILocalizationManager LocalizationManager { get; set; }
+
+        protected string LocalizationSourceName { get; set; }
 
         public IAbpSession AbpSession { get; set; }
 
@@ -75,6 +78,7 @@ namespace Abp.Authorization.Roles
             AbpStore = store;
             AbpSession = NullAbpSession.Instance;
             LocalizationManager = NullLocalizationManager.Instance;
+            LocalizationSourceName = AbpZeroConsts.LocalizationSourceName;
         }
 
         /// <summary>
@@ -440,9 +444,14 @@ namespace Abp.Authorization.Roles
             });
         }
 
-        private string L(string name)
+        protected virtual string L(string name)
         {
-            return LocalizationManager.GetString(AbpZeroConsts.LocalizationSourceName, name);
+            return LocalizationManager.GetString(LocalizationSourceName, name);
+        }
+
+        protected virtual string L(string name, CultureInfo cultureInfo)
+        {
+            return LocalizationManager.GetString(LocalizationSourceName, name, cultureInfo);
         }
 
         private int? GetCurrentTenantId()

--- a/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
@@ -48,6 +48,8 @@ namespace Abp.Authorization.Users
 
         public ILocalizationManager LocalizationManager { get; }
 
+        protected string LocalizationSourceName { get; set; }
+
         public IAbpSession AbpSession { get; set; }
 
         public FeatureDependencyContext FeatureDependencyContext { get; set; }
@@ -83,7 +85,8 @@ namespace Abp.Authorization.Users
         {
             AbpStore = userStore;
             RoleManager = roleManager;
-            LocalizationManager = localizationManager;
+            LocalizationManager = NullLocalizationManager.Instance;
+            LocalizationSourceName = AbpZeroConsts.LocalizationSourceName;
             _settingManager = settingManager;
 
             _permissionManager = permissionManager;
@@ -704,9 +707,14 @@ namespace Abp.Authorization.Users
                 : _settingManager.GetSettingValueForTenant<T>(settingName, tenantId.Value);
         }
 
-        private string L(string name)
+        protected virtual string L(string name)
         {
-            return LocalizationManager.GetString(AbpZeroConsts.LocalizationSourceName, name);
+            return LocalizationManager.GetString(LocalizationSourceName, name);
+        }
+
+        protected virtual string L(string name, CultureInfo cultureInfo)
+        {
+            return LocalizationManager.GetString(LocalizationSourceName, name, cultureInfo);
         }
 
         private int? GetCurrentTenantId()

--- a/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
@@ -85,7 +85,7 @@ namespace Abp.Authorization.Users
         {
             AbpStore = userStore;
             RoleManager = roleManager;
-            LocalizationManager = NullLocalizationManager.Instance;
+            LocalizationManager = localizationManager;
             LocalizationSourceName = AbpZeroConsts.LocalizationSourceName;
             _settingManager = settingManager;
 

--- a/src/Abp.Zero/IdentityFramework/IdentityResultExtensions.cs
+++ b/src/Abp.Zero/IdentityFramework/IdentityResultExtensions.cs
@@ -70,6 +70,11 @@ namespace Abp.IdentityFramework
 
         public static string LocalizeErrors(this IdentityResult identityResult, ILocalizationManager localizationManager)
         {
+            return LocalizeErrors(identityResult, localizationManager, AbpZeroConsts.LocalizationSourceName);
+        }
+
+        public static string LocalizeErrors(this IdentityResult identityResult, ILocalizationManager localizationManager, string localizationSourceName)
+        {
             if (identityResult.Succeeded)
             {
                 throw new ArgumentException("identityResult.Succeeded should be false in order to localize errors.");
@@ -85,12 +90,12 @@ namespace Abp.IdentityFramework
                 return identityResult.Errors.JoinAsString(" ");
             }
 
-            return identityResult.Errors.Select(err => LocalizeErrorMessage(err, localizationManager)).JoinAsString(" ");
+            return identityResult.Errors.Select(err => LocalizeErrorMessage(err, localizationManager, localizationSourceName)).JoinAsString(" ");
         }
 
-        private static string LocalizeErrorMessage(string identityErrorMessage, ILocalizationManager localizationManager)
+        private static string LocalizeErrorMessage(string identityErrorMessage, ILocalizationManager localizationManager, string localizationSourceName)
         {
-            var localizationSource = localizationManager.GetSource(AbpZeroConsts.LocalizationSourceName);
+            var localizationSource = localizationManager.GetSource(localizationSourceName);
 
             foreach (var identityLocalization in IdentityLocalizations)
             {

--- a/src/Abp.Zero/IdentityFramework/IdentityResultExtensions.cs
+++ b/src/Abp.Zero/IdentityFramework/IdentityResultExtensions.cs
@@ -90,13 +90,12 @@ namespace Abp.IdentityFramework
                 return identityResult.Errors.JoinAsString(" ");
             }
 
-            return identityResult.Errors.Select(err => LocalizeErrorMessage(err, localizationManager, localizationSourceName)).JoinAsString(" ");
+            var localizationSource = localizationManager.GetSource(localizationSourceName);
+            return identityResult.Errors.Select(err => LocalizeErrorMessage(err, localizationSource)).JoinAsString(" ");
         }
 
-        private static string LocalizeErrorMessage(string identityErrorMessage, ILocalizationManager localizationManager, string localizationSourceName)
+        private static string LocalizeErrorMessage(string identityErrorMessage, ILocalizationSource localizationSource)
         {
-            var localizationSource = localizationManager.GetSource(localizationSourceName);
-
             foreach (var identityLocalization in IdentityLocalizations)
             {
                 string[] values;

--- a/src/Abp.ZeroCore/Authorization/Roles/AbpRoleManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Roles/AbpRoleManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,8 @@ namespace Abp.Authorization.Roles
         where TUser : AbpUser<TUser>
     {
         public ILocalizationManager LocalizationManager { get; set; }
+
+        protected string LocalizationSourceName { get; set; }
 
         public IAbpSession AbpSession { get; set; }
 
@@ -75,6 +78,7 @@ namespace Abp.Authorization.Roles
             AbpStore = store;
             AbpSession = NullAbpSession.Instance;
             LocalizationManager = NullLocalizationManager.Instance;
+            LocalizationSourceName = AbpZeroConsts.LocalizationSourceName;
         }
 
         /// <summary>
@@ -439,9 +443,14 @@ namespace Abp.Authorization.Roles
             });
         }
 
-        private string L(string name)
+        protected virtual string L(string name)
         {
-            return LocalizationManager.GetString(AbpZeroConsts.LocalizationSourceName, name);
+            return LocalizationManager.GetString(LocalizationSourceName, name);
+        }
+
+        protected virtual string L(string name, CultureInfo cultureInfo)
+        {
+            return LocalizationManager.GetString(LocalizationSourceName, name, cultureInfo);
         }
 
         private int? GetCurrentTenantId()

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Abp.Application.Features;
@@ -45,6 +46,8 @@ namespace Abp.Authorization.Users
         }
 
         public ILocalizationManager LocalizationManager { get; set; }
+
+        protected string LocalizationSourceName { get; set; }
 
         public IAbpSession AbpSession { get; set; }
 
@@ -105,6 +108,8 @@ namespace Abp.Authorization.Users
 
             AbpStore = store;
             RoleManager = roleManager;
+            LocalizationManager = NullLocalizationManager.Instance;
+            LocalizationSourceName = AbpZeroConsts.LocalizationSourceName;
         }
 
         public override async Task<IdentityResult> CreateAsync(TUser user)
@@ -691,9 +696,14 @@ namespace Abp.Authorization.Users
                 : _settingManager.GetSettingValueForTenantAsync<T>(settingName, tenantId.Value);
         }
 
-        private string L(string name)
+        protected virtual string L(string name)
         {
-            return LocalizationManager.GetString(AbpZeroConsts.LocalizationSourceName, name);
+            return LocalizationManager.GetString(LocalizationSourceName, name);
+        }
+
+        protected virtual string L(string name, CultureInfo cultureInfo)
+        {
+            return LocalizationManager.GetString(LocalizationSourceName, name, cultureInfo);
         }
 
         private int? GetCurrentTenantId()

--- a/src/Abp.ZeroCore/IdentityFramework/IdentityResultExtensions.cs
+++ b/src/Abp.ZeroCore/IdentityFramework/IdentityResultExtensions.cs
@@ -74,6 +74,11 @@ namespace Abp.IdentityFramework
 
         public static string LocalizeErrors(this IdentityResult identityResult, ILocalizationManager localizationManager)
         {
+            return LocalizeErrors(identityResult, localizationManager, AbpZeroConsts.LocalizationSourceName);
+        }
+
+        public static string LocalizeErrors(this IdentityResult identityResult, ILocalizationManager localizationManager, string localizationSourceName)
+        {
             if (identityResult.Succeeded)
             {
                 throw new ArgumentException("identityResult.Succeeded should be false in order to localize errors.");
@@ -84,12 +89,12 @@ namespace Abp.IdentityFramework
                 throw new ArgumentException("identityResult.Errors should not be null.");
             }
 
-            return identityResult.Errors.Select(err => LocalizeErrorMessage(err.Description, localizationManager)).JoinAsString(" ");
+            return identityResult.Errors.Select(err => LocalizeErrorMessage(err.Description, localizationManager, localizationSourceName)).JoinAsString(" ");
         }
 
-        private static string LocalizeErrorMessage(string identityErrorMessage, ILocalizationManager localizationManager)
+        private static string LocalizeErrorMessage(string identityErrorMessage, ILocalizationManager localizationManager, string localizationSourceName)
         {
-            var localizationSource = localizationManager.GetSource(AbpZeroConsts.LocalizationSourceName);
+            var localizationSource = localizationManager.GetSource(localizationSourceName);
 
             foreach (var identityLocalization in IdentityLocalizations)
             {

--- a/src/Abp.ZeroCore/IdentityFramework/IdentityResultExtensions.cs
+++ b/src/Abp.ZeroCore/IdentityFramework/IdentityResultExtensions.cs
@@ -89,13 +89,12 @@ namespace Abp.IdentityFramework
                 throw new ArgumentException("identityResult.Errors should not be null.");
             }
 
-            return identityResult.Errors.Select(err => LocalizeErrorMessage(err.Description, localizationManager, localizationSourceName)).JoinAsString(" ");
+            var localizationSource = localizationManager.GetSource(localizationSourceName);
+            return identityResult.Errors.Select(err => LocalizeErrorMessage(err.Description, localizationSource)).JoinAsString(" ");
         }
 
-        private static string LocalizeErrorMessage(string identityErrorMessage, ILocalizationManager localizationManager, string localizationSourceName)
+        private static string LocalizeErrorMessage(string identityErrorMessage, ILocalizationSource localizationSource)
         {
-            var localizationSource = localizationManager.GetSource(localizationSourceName);
-
             foreach (var identityLocalization in IdentityLocalizations)
             {
                 string[] values;


### PR DESCRIPTION
Fixes #3452 

As mentioned, `LocalizationSourceName` is added to the following classes
- `AbpUserManager`
- `AbpRoleManager`
- `AbpTenantManager`
- `LdapSettingProvider`

Added new `LocalizeErrors()` overload to accept `LocalizationSourceName`
```c#
public static string LocalizeErrors(this IdentityResult identityResult, ILocalizationManager localizationManager, string localizationSourceName){
    // more code ...
}
```