### PR TITLE
fix #3643 Make the HandleAndWrapException method under AbpExceptionFilter can be overridden.

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionFilter.cs
@@ -59,7 +59,7 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
             }
         }
 
-        private void HandleAndWrapException(ExceptionContext context)
+        protected virtual void HandleAndWrapException(ExceptionContext context)
         {
             if (!ActionResultHelper.IsObjectResult(context.ActionDescriptor.GetMethodInfo().ReturnType))
             {


### PR DESCRIPTION
fix #3643 
Make the HandleAndWrapException method under AbpExceptionFilter can be overridden.