### PR TITLE
Mvc DateTime Format should not be default

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
@@ -26,6 +26,8 @@ namespace Abp.AspNetCore.Configuration
 
         public bool SetNoCacheForAjaxResponses { get; set; }
 
+        public bool UseMvcDateTimeFormatForAppServices { get; set; }
+
         public List<Action<IRouteBuilder>> RouteConfiguration { get; }
 
         public AbpAspNetCoreConfiguration()
@@ -39,6 +41,7 @@ namespace Abp.AspNetCore.Configuration
             IsValidationEnabledForControllers = true;
             SetNoCacheForAjaxResponses = true;
             IsAuditingEnabled = true;
+            UseMvcDateTimeFormatForAppServices = false;
         }
        
         public AbpControllerAssemblySettingBuilder CreateControllersForAppServices(

--- a/src/Abp.AspNetCore/AspNetCore/Configuration/IAbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/IAbpAspNetCoreConfiguration.cs
@@ -33,7 +33,12 @@ namespace Abp.AspNetCore.Configuration
         /// Default: true.
         /// </summary>
         bool SetNoCacheForAjaxResponses { get; set; }
-        
+
+        /// <summary>
+        /// Default: false.
+        /// </summary>
+        bool UseMvcDateTimeFormatForAppServices { get; set; }
+
         /// <summary>
         /// Used to add route config for modules.
         /// </summary>

--- a/src/Abp.AspNetCore/Json/AbpMvcContractResolver.cs
+++ b/src/Abp.AspNetCore/Json/AbpMvcContractResolver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using Abp.AspNetCore.Configuration;
 using Abp.Dependency;
 using Abp.Reflection;
 using Abp.Timing;
@@ -13,12 +14,17 @@ namespace Abp.Json
     public class AbpMvcContractResolver : DefaultContractResolver
     {
         private readonly IIocResolver _iocResolver;
-        private bool _isDateTimeFormatResolved { get; set; } = false;
+        private bool _useMvcDateTimeFormat { get; set; }
         private string _datetimeFormat { get; set; } = null;
 
         public AbpMvcContractResolver(IIocResolver iocResolver)
         {
             _iocResolver = iocResolver;
+            using (var configuration = _iocResolver.ResolveAsDisposable<IAbpAspNetCoreConfiguration>())
+            {
+                _useMvcDateTimeFormat = configuration.Object.UseMvcDateTimeFormatForAppServices;
+            }
+
         }
 
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
@@ -42,7 +48,7 @@ namespace Abp.Json
                 var converter = new AbpDateTimeConverter();
 
                 // try to resolve MvcJsonOptions
-                if (!_isDateTimeFormatResolved)
+                if (_useMvcDateTimeFormat)
                 {
                     using (var mvcJsonOptions = _iocResolver.ResolveAsDisposable<IOptions<MvcJsonOptions>>())
                     {

--- a/src/Abp.AspNetCore/Json/AbpMvcContractResolver.cs
+++ b/src/Abp.AspNetCore/Json/AbpMvcContractResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using Abp.AspNetCore.Configuration;
 using Abp.Dependency;
+using Abp.Extensions;
 using Abp.Reflection;
 using Abp.Timing;
 using Microsoft.AspNetCore.Mvc;
@@ -57,7 +58,7 @@ namespace Abp.Json
                 }
 
                 // apply DateTimeFormat only if not empty
-                if (!string.IsNullOrWhiteSpace(_datetimeFormat))
+                if (!_datetimeFormat.IsNullOrWhiteSpace())
                 {
                     converter.DateTimeFormat = _datetimeFormat;
                 }


### PR DESCRIPTION
Fixes #3675

In PR #3506 , Mvc's `DateTimeFormat` was assume to be empty string if not set.

However, the default value for `DateTimeFormat` in [JsonSerializerSettings](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/JsonSerializerSettings.cs#L316) is not an empty string.

Therefore, changes in this PR aim to switch Mvc's `DateTimeFormat` to be used for app services only if it is being enabled in `IAbpAspNetCoreConfiguration`