### PR TITLE
fix #3678 Add a constructor in the Log4NetLoggerFactory to implement the reloadOnChange feature.

### DIFF
--- a/src/Abp.Castle.Log4Net/Castle/Logging/Log4Net/Log4NetLoggerFactory.cs
+++ b/src/Abp.Castle.Log4Net/Castle/Logging/Log4Net/Log4NetLoggerFactory.cs
@@ -19,7 +19,19 @@ namespace Abp.Castle.Logging.Log4Net
         {
         }
 
-        public Log4NetLoggerFactory(string configFileName, bool reloadOnChange = false)
+        public Log4NetLoggerFactory(string configFileName)
+        {
+            _loggerRepository = LogManager.CreateRepository(
+                typeof(Log4NetLoggerFactory).GetAssembly(),
+                typeof(log4net.Repository.Hierarchy.Hierarchy)
+            );
+
+            var log4NetConfig = new XmlDocument();
+            log4NetConfig.Load(File.OpenRead(configFileName));
+            XmlConfigurator.Configure(_loggerRepository, log4NetConfig["log4net"]);
+        }
+
+        public Log4NetLoggerFactory(string configFileName, bool reloadOnChange)
         {
             _loggerRepository = LogManager.CreateRepository(
                 typeof(Log4NetLoggerFactory).GetAssembly(),


### PR DESCRIPTION
fix #3678 Add a constructor in the Log4NetLoggerFactory to implement the reloadOnChange feature.