### PR TITLE
BugFix AutoMapKey inheritance

### DIFF
--- a/src/Abp.AutoMapper/Abp.AutoMapper.csproj
+++ b/src/Abp.AutoMapper/Abp.AutoMapper.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Collection" Version="3.1.3" />
+    <PackageReference Include="AutoMapper.Collection" Version="4.0.0" />
     <PackageReference Include="AutoMapper" Version="7.0.1" />
   </ItemGroup>
 

--- a/test/Abp.AutoMapper.Tests/Abp.AutoMapper.Tests.csproj
+++ b/test/Abp.AutoMapper.Tests/Abp.AutoMapper.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Collection" Version="3.1.3" />
+    <PackageReference Include="AutoMapper.Collection" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/test/Abp.AutoMapper.Tests/AutoMapper_Inheritance_Tests.cs
+++ b/test/Abp.AutoMapper.Tests/AutoMapper_Inheritance_Tests.cs
@@ -1,5 +1,7 @@
 ﻿using AutoMapper;
+using AutoMapper.EquivalencyExpression;
 using Shouldly;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Abp.AutoMapper.Tests
@@ -15,6 +17,11 @@ namespace Abp.AutoMapper.Tests
                 configuration.CreateAutoAttributeMaps(typeof(MyTargetClassToMap));
                 configuration.CreateAutoAttributeMaps(typeof(EntityDto));
                 configuration.CreateAutoAttributeMaps(typeof(DerivedEntityDto));
+                configuration.CreateAutoAttributeMaps(typeof(MyAutoMapKeyClass1));
+                configuration.CreateAutoAttributeMaps(typeof(MyAutoMapKeyClass3));
+                configuration.CreateAutoAttributeMaps(typeof(MyAutoMapKeyClass5));
+                configuration.CreateAutoAttributeMaps(typeof(MyAutoMapKeyClass7));
+                configuration.AddCollectionMappers();
             });
 
             _mapper = config.CreateMapper();
@@ -47,7 +54,7 @@ namespace Abp.AutoMapper.Tests
         //[Fact] //TODO: That's a problem but related to AutoMapper rather than ABP.
         public void Should_Map_EntityProxy_To_EntityDto_And_To_DrivedEntityDto()
         {
-            var proxy = new EntityProxy() { Value = "42"};
+            var proxy = new EntityProxy() { Value = "42" };
             var target = _mapper.Map<EntityDto>(proxy);
             var target2 = _mapper.Map<DerivedEntityDto>(proxy);
             target.Value.ShouldBe("42");
@@ -69,5 +76,170 @@ namespace Abp.AutoMapper.Tests
 
         [AutoMapFrom(typeof(DerivedEntity))]
         public class DerivedEntityDto : EntityDto { }
+
+        private class MyEntityDto
+        {
+            [AutoMapKey]
+            public int Id { get; set; }
+        }
+
+        private class MyDerivedEntityDto : Abp.Application.Services.Dto.EntityDto
+        {
+            [AutoMapKey]
+            public new int Id { get; set; }
+        }
+
+        private class MyDualKeyEntityDto
+        {
+            [AutoMapKey]
+            public int Id { get; set; }
+
+            [AutoMapKey]
+            public int SecondId { get; set; }
+        }
+
+        private class MyDerivedDualKeyEntityDto : Abp.Application.Services.Dto.EntityDto
+        {
+            [AutoMapKey]
+            public new int Id { get; set; }
+
+            [AutoMapKey]
+            public int SecondId { get; set; }
+        }
+
+        private class MyDualKeyEntity
+        {
+           public int Id { get; set; }
+
+            public int SecondId { get; set; }
+        }
+
+        [AutoMapTo(typeof(MyAutoMapKeyClass2))]
+        private class MyAutoMapKeyClass1 : MyEntityDto
+        {
+            public string TestProp { get; set; }
+        }
+
+        private class MyAutoMapKeyClass2 : Abp.Domain.Entities.Entity
+        {
+
+            public string TestProp { get; set; }
+
+            public int Value { get; set; }
+        }
+
+        [AutoMapTo(typeof(MyAutoMapKeyClass4))]
+        private class MyAutoMapKeyClass3 : MyDerivedEntityDto
+        {
+            public string TestProp { get; set; }
+        }
+
+        private class MyAutoMapKeyClass4 : Abp.Domain.Entities.Entity
+        {
+
+            public string TestProp { get; set; }
+
+            public int Value { get; set; }
+        }
+
+        [AutoMapTo(typeof(MyAutoMapKeyClass6))]
+        private class MyAutoMapKeyClass5 : MyDualKeyEntityDto
+        {
+            public string TestProp { get; set; }
+        }
+
+        private class MyAutoMapKeyClass6 : MyDualKeyEntity
+        {
+
+            public string TestProp { get; set; }
+
+            public int Value { get; set; }
+        }
+
+        [AutoMapTo(typeof(MyAutoMapKeyClass8))]
+        private class MyAutoMapKeyClass7 : MyDerivedDualKeyEntityDto
+        {
+            public string TestProp { get; set; }
+        }
+
+        private class MyAutoMapKeyClass8 : MyDualKeyEntity
+        {
+
+            public string TestProp { get; set; }
+
+            public int Value { get; set; }
+        }
+        [Fact]
+        public void AutoMapKey_MapTo_DerivedCollection_Tests()
+        {
+            var list1 = new List<MyAutoMapKeyClass1>
+                        {
+                            new MyAutoMapKeyClass1 { Id = 1, TestProp = "New test value 1"},
+                            new MyAutoMapKeyClass1 { Id = 2, TestProp = "New test value 2"}
+                        };
+            var list2 = new List<MyAutoMapKeyClass2>
+                        {
+                            new MyAutoMapKeyClass2 { Id = 1, TestProp = "Test value 1", Value = 5},
+                            new MyAutoMapKeyClass2 { Id = 2, TestProp = "Test value 2", Value = 10}
+                        };
+            var list3 = new List<MyAutoMapKeyClass3>
+                        {
+                            new MyAutoMapKeyClass3 { Id = 1, TestProp = "New test value 1"},
+                            new MyAutoMapKeyClass3 { Id = 2, TestProp = "New test value 2"}
+                        };
+            var list4 = new List<MyAutoMapKeyClass4>
+                        {
+                            new MyAutoMapKeyClass4 { Id = 1, TestProp = "Test value 1", Value = 5},
+                            new MyAutoMapKeyClass4 { Id = 2, TestProp = "Test value 2", Value = 10}
+                        };
+            var list5 = new List<MyAutoMapKeyClass5>
+                        {
+                            new MyAutoMapKeyClass5 { Id = 1, SecondId = 2, TestProp = "New test value 1"},
+                            new MyAutoMapKeyClass5 { Id = 2, SecondId = 3, TestProp = "New test value 2"}
+                        };
+            var list6 = new List<MyAutoMapKeyClass6>
+                        {
+                            new MyAutoMapKeyClass6 { Id = 1, SecondId = 2,  TestProp = "Test value 1", Value = 5},
+                            new MyAutoMapKeyClass6 { Id = 2, SecondId = 3,  TestProp = "Test value 2", Value = 10}
+                        };
+            var list7 = new List<MyAutoMapKeyClass7>
+                        {
+                            new MyAutoMapKeyClass7 { Id = 1, SecondId = 2,  TestProp = "New test value 1"},
+                            new MyAutoMapKeyClass7 { Id = 2, SecondId = 3,  TestProp = "New test value 2"}
+                        };
+            var list8 = new List<MyAutoMapKeyClass8>
+                        {
+                            new MyAutoMapKeyClass8 { Id = 1, SecondId = 2,  TestProp = "Test value 1", Value = 5},
+                            new MyAutoMapKeyClass8 { Id = 2, SecondId = 3,  TestProp = "Test value 2", Value = 10}
+                        };
+
+            _mapper.Map(list1, list2);
+            list2.Count.ShouldBe(2);
+            list2[0].TestProp.ShouldBe("New test value 1");
+            list2[0].Value.ShouldBe(5);
+            list2[1].TestProp.ShouldBe("New test value 2");
+            list2[1].Value.ShouldBe(10);
+
+            _mapper.Map(list3, list4);
+            list4.Count.ShouldBe(2);
+            list4[0].TestProp.ShouldBe("New test value 1");
+            list4[0].Value.ShouldBe(5);
+            list4[1].TestProp.ShouldBe("New test value 2");
+            list4[1].Value.ShouldBe(10);
+
+            _mapper.Map(list5, list6);
+            list6.Count.ShouldBe(2);
+            list6[0].TestProp.ShouldBe("New test value 1");
+            list6[0].Value.ShouldBe(5);
+            list6[1].TestProp.ShouldBe("New test value 2");
+            list6[1].Value.ShouldBe(10);
+
+            _mapper.Map(list7, list8);
+            list8.Count.ShouldBe(2);
+            list8[0].TestProp.ShouldBe("New test value 1");
+            list8[0].Value.ShouldBe(5);
+            list8[1].TestProp.ShouldBe("New test value 2");
+            list8[1].Value.ShouldBe(10);
+        }
     }
 }

--- a/test/Abp.AutoMapper.Tests/AutoMapping_Tests.cs
+++ b/test/Abp.AutoMapper.Tests/AutoMapping_Tests.cs
@@ -15,11 +15,11 @@ namespace Abp.AutoMapper.Tests
         {
             var config = new MapperConfiguration(configuration =>
             {
-                configuration.AddCollectionMappers();
                 configuration.CreateAutoAttributeMaps(typeof(MyClass1));
                 configuration.CreateAutoAttributeMaps(typeof(MyClass2));
                 configuration.CreateAutoAttributeMaps(typeof(MyAutoMapKeyClass1));
                 configuration.CreateAutoAttributeMaps(typeof(MyAutoMapKeyClass2));
+                configuration.AddCollectionMappers();
             });
 
             _mapper = config.CreateMapper();


### PR DESCRIPTION
There was a bug with AutoMapper.Collections that prevent the mapping to work with AutoMapKey and inheritance. I added a couple of tests and update AutoMapper.Collections.

There is a strange thing if i run AutoMapping_Tests.cs and AutoMapper_Inheritance_Tests.cs one after another they will fail. But if i run them individually or i run all the test they pass.

Would be nice if it could be integrated to the next release!