### PR TITLE
Dev

### DIFF
--- a/src/Abp.Web.Mvc/Web/Mvc/Uow/AbpMvcUowFilter.cs
+++ b/src/Abp.Web.Mvc/Web/Mvc/Uow/AbpMvcUowFilter.cs
@@ -65,19 +65,14 @@ namespace Abp.Web.Mvc.Uow
             {
                 return;
             }
+            
+            if (filterContext.Exception == null)
+            {
+                uow.Complete();
+            }
 
-            try
-            {
-                if (filterContext.Exception == null)
-                {
-                    uow.Complete();
-                }
-            }
-            finally
-            {
-                uow.Dispose();
-                SetCurrentUow(filterContext.HttpContext, null);
-            }
+            uow.Dispose();
+            SetCurrentUow(filterContext.HttpContext, null);
         }
 
         private static IUnitOfWorkCompleteHandle GetCurrentUow(HttpContextBase httpContext)

--- a/src/Abp/Domain/Uow/IUnitOfWork.cs
+++ b/src/Abp/Domain/Uow/IUnitOfWork.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Abp.Domain.Uow
 {
     /// <summary>

--- a/src/Abp/Domain/Uow/IUnitOfWorkCompleteHandle.cs
+++ b/src/Abp/Domain/Uow/IUnitOfWorkCompleteHandle.cs
@@ -11,6 +11,11 @@ namespace Abp.Domain.Uow
     public interface IUnitOfWorkCompleteHandle : IDisposable
     {
         /// <summary>
+        /// Will be set if Complete method throw an exception
+        /// </summary>
+        Exception ExceptionOnComplete { get; }
+
+        /// <summary>
         /// Completes this unit of work.
         /// It saves all changes and commit transaction if exists.
         /// </summary>

--- a/src/Abp/Domain/Uow/InnerUnitOfWorkCompleteHandle.cs
+++ b/src/Abp/Domain/Uow/InnerUnitOfWorkCompleteHandle.cs
@@ -17,6 +17,8 @@ namespace Abp.Domain.Uow
         private volatile bool _isCompleteCalled;
         private volatile bool _isDisposed;
 
+        public Exception ExceptionOnComplete => null;
+
         public void Complete()
         {
             _isCompleteCalled = true;

--- a/src/Abp/Domain/Uow/UnitOfWorkBase.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkBase.cs
@@ -256,7 +256,6 @@ namespace Abp.Domain.Uow
             catch (Exception ex)
             {
                 _exception = ex;
-                throw;
             }
         }
 
@@ -273,7 +272,6 @@ namespace Abp.Domain.Uow
             catch (Exception ex)
             {
                 _exception = ex;
-                throw;
             }
         }
 

--- a/src/Abp/Domain/Uow/UnitOfWorkBase.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkBase.cs
@@ -59,6 +59,8 @@ namespace Abp.Domain.Uow
         /// </summary>
         public IAbpSession AbpSession { protected get; set; }
 
+        public Exception ExceptionOnComplete { get { return _exception; } }
+
         protected IUnitOfWorkFilterExecuter FilterExecuter { get; }
 
         /// <summary>

--- a/test/Abp.TestBase.SampleApplication.Tests/People/PersonRepository_Tests_For_EntityChangeEvents.cs
+++ b/test/Abp.TestBase.SampleApplication.Tests/People/PersonRepository_Tests_For_EntityChangeEvents.cs
@@ -23,7 +23,7 @@ namespace Abp.TestBase.SampleApplication.Tests.People
         {
             _personRepository = Resolve<IRepository<Person>>();
         }
-        
+
         [Theory]
         [InlineData(TransactionScopeOption.Required)]
         [InlineData(TransactionScopeOption.RequiresNew)]
@@ -155,22 +155,16 @@ namespace Abp.TestBase.SampleApplication.Tests.People
                 });
 
             //Act
-            try
-            {
-                using (var uow = Resolve<IUnitOfWorkManager>().Begin())
-                {
-                    var person = _personRepository.Single(p => p.Name == "halil");
-                    person.Name = "halil2";
-                    _personRepository.Update(person);
 
-                    uow.Complete();
-                }
-
-                Assert.True(false, "Should not come here since ApplicationException is thrown!");
-            }
-            catch (ApplicationException)
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
             {
-                //hiding exception
+                var person = _personRepository.Single(p => p.Name == "halil");
+                person.Name = "halil2";
+                _personRepository.Update(person);
+
+                uow.Complete();
+
+                Assert.True(uow.ExceptionOnComplete != null, "");
             }
 
             //Assert
@@ -192,22 +186,15 @@ namespace Abp.TestBase.SampleApplication.Tests.People
                 });
 
             //Act
-            try
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
             {
-                using (var uow = Resolve<IUnitOfWorkManager>().Begin())
-                {
-                    var person = _personRepository.Single(p => p.Name == "halil");
-                    _personRepository.Delete(person);
-                    uow.Complete();
-                }
+                var person = _personRepository.Single(p => p.Name == "halil");
+                _personRepository.Delete(person);
+                uow.Complete();
 
-                Assert.True(false, "Should not come here since ApplicationException is thrown!");
+                Assert.True(uow.ExceptionOnComplete != null, "");
             }
-            catch (ApplicationException)
-            {
-                //hiding exception
-            }
-            
+
             _personRepository
                 .FirstOrDefault(p => p.Name == "halil")
                 .ShouldNotBeNull();

--- a/test/Abp.TestBase.SampleApplication.Tests/Uow/UnitOfWork_Event_Tests.cs
+++ b/test/Abp.TestBase.SampleApplication.Tests/Uow/UnitOfWork_Event_Tests.cs
@@ -116,7 +116,11 @@ namespace Abp.TestBase.SampleApplication.Tests.Uow
                     disposeCount++;
                 };
 
-                Assert.Throws<DbEntityValidationException>(() => uow.Complete());
+                Assert.ThrowsAsync<DbEntityValidationException>(() =>
+                {
+                    uow.Complete();
+                    throw uow.ExceptionOnComplete;
+                });
             }
 
             failedCount.ShouldBe(1);


### PR DESCRIPTION
I think there is no need to open Try-Catch for every Complete method for check is succeed or not. For this;

Added ExceptionOnComplete property to IUnitOfWorkCompleteHandle. Depending on this update; 'Should_Rollback_UOW_In_Updating_Event', 'Should_Rollback_UOW_In_Deleting_Event' and 'Should_Trigger_Failed_When_SaveChanges_Fails' tests updated