### PR TITLE
Bugfix: Add using singleton Castle ProxyGenerator to avoid memoryleak in unit tests

### DIFF
--- a/src/Abp/Dependency/IocManager.cs
+++ b/src/Abp/Dependency/IocManager.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Castle.DynamicProxy;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using Castle.Windsor.Installer;
+using Castle.Windsor.Proxy;
 
 namespace Abp.Dependency
 {
@@ -17,6 +19,15 @@ namespace Abp.Dependency
         /// The Singleton instance.
         /// </summary>
         public static IocManager Instance { get; private set; }
+
+        /// <summary>
+        /// Singletone instance for Castle ProxyGenerator.
+        /// From Castle.Core documentation it is highly recomended to use single instance of ProxyGenerator to avoid memoryleaks and performance issues
+        /// Follow next links for more details:
+        /// <a href="https://github.com/castleproject/Core/blob/master/docs/dynamicproxy.md">Castle.Core documentation</a>,
+        /// <a href="http://kozmic.net/2009/07/05/castle-dynamic-proxy-tutorial-part-xii-caching/">Article</a>
+        /// </summary>
+        private static readonly ProxyGenerator ProxyGeneratorInstance = new ProxyGenerator();
 
         /// <summary>
         /// Reference to the Castle Windsor Container.
@@ -40,7 +51,7 @@ namespace Abp.Dependency
         /// </summary>
         public IocManager()
         {
-            IocContainer = new WindsorContainer();
+            IocContainer = new WindsorContainer(new DefaultProxyFactory(ProxyGeneratorInstance));
             _conventionalRegistrars = new List<IConventionalDependencyRegistrar>();
 
             //Register self!


### PR DESCRIPTION
Currently there is a memoryleak in Abp unit tests, which can be detected by using dotMemory (or other similar tool).
Castle.DynamicProxy.ProxyGenerator is a class, which is responsible for creating dynamic proxies, creating dynamic assemblies and saving results in internal cache. As follows from Castle.Core documentation (see link https://github.com/castleproject/Core/blob/master/docs/dynamicproxy.md) for web application it is highly recommended to use single instance of ProxyGenerator to avoid issues with memory and performance.
The issue is that while creating IocManager, it creates WindsorContainer with default constructor, which internally creates new ProxyGenerator each time. IocManager is creating in constructor of each AbpIntegratedTestBase, so it creates new instance of ProxyGenerator for each unit test. If checking unit tests with dotMemory, you can see a leak of objects of type IlGenerator, TypeBuilder etc, which consume memory. Also for each instance of ProxyGenerator dynamic assembly is created.
Using static instance of ProxyGenerator solves this memory leak issue. 