### PR TITLE
Fix AuditedAttribute on property creating history for every property

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -87,7 +87,8 @@ namespace Abp.EntityHistory
 
             foreach (var entry in entityEntries)
             {
-                if (!ShouldSaveEntityHistory(entry))
+                var shouldSaveEntityHistory = ShouldSaveEntityHistory(entry);
+                if (!shouldSaveEntityHistory && !HasAuditedProperties(entry))
                 {
                     continue;
                 }
@@ -224,6 +225,12 @@ namespace Abp.EntityHistory
             return propertyChanges;
         }
 
+        private bool HasAuditedProperties(EntityEntry entityEntry)
+        {
+            var properties = entityEntry.Metadata.GetProperties();
+            return properties.Any(p => p.PropertyInfo?.IsDefined(typeof(AuditedAttribute)) ?? false);
+        }
+
         private bool IsCreated(EntityEntry entityEntry)
         {
             return entityEntry.State == EntityState.Added;
@@ -275,12 +282,6 @@ namespace Abp.EntityHistory
             }
 
             if (_configuration.Selectors.Any(selector => selector.Predicate(entityType)))
-            {
-                return true;
-            }
-
-            var properties = entityEntry.Metadata.GetProperties();
-            if (properties.Any(p => p.PropertyInfo?.IsDefined(typeof(AuditedAttribute)) ?? false))
             {
                 return true;
             }

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -264,14 +264,14 @@ namespace Abp.EntityHistory
                 return false;
             }
 
-            if (entityType.GetTypeInfo().IsDefined(typeof(AuditedAttribute), true))
-            {
-                return true;
-            }
-
             if (entityType.GetTypeInfo().IsDefined(typeof(DisableAuditingAttribute), true))
             {
                 return false;
+            }
+
+            if (entityType.GetTypeInfo().IsDefined(typeof(AuditedAttribute), true))
+            {
+                return true;
             }
 
             if (_configuration.Selectors.Any(selector => selector.Predicate(entityType)))

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -168,6 +168,11 @@ namespace Abp.EntityHistory
                 TenantId = AbpSession.TenantId
             };
 
+            if (!shouldSaveEntityHistory && entityChange.PropertyChanges.Count == 0)
+            {
+                return null;
+            }
+
             return entityChange;
         }
 

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -238,7 +238,7 @@ namespace Abp.Zero.EntityHistory
         }
 
         [Fact]
-        public void Should_Not_Write_History_For_Property_If_No_Audited_Attribute()
+        public void Should_Not_Write_History_If_Property_Has_No_Audited_Attribute()
         {
             /* Post.Body does not have Audited attribute. */
 
@@ -252,13 +252,7 @@ namespace Abp.Zero.EntityHistory
                 uow.Complete();
             }
 
-            _entityHistoryStore.Received().SaveAsync(Arg.Is<EntityChangeSet>(
-                s => s.EntityChanges.Count == 1 &&
-                     s.EntityChanges[0].ChangeType == EntityChangeType.Updated &&
-                     s.EntityChanges[0].EntityId == s.EntityChanges[0].EntityEntry.As<EntityEntry>().Entity.As<IEntity<Guid>>().Id.ToJsonString(false, false) &&
-                     s.EntityChanges[0].EntityTypeFullName == typeof(Post).FullName &&
-                     s.EntityChanges[0].PropertyChanges.Count == 0
-            ));
+            _entityHistoryStore.DidNotReceive().SaveAsync(Arg.Any<EntityChangeSet>());
         }
 
         #endregion


### PR DESCRIPTION
Fixes #3861

Includes a new test case: `Should_Not_Write_History_If_Property_Has_No_Audited_Attribute`