### PR TITLE
Fixes #3805 - Switch to Microsoft.AspNetCore.App 

### DIFF
--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/AbpAspNetCoreDemo.csproj
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/AbpAspNetCoreDemo.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>AbpAspNetCoreDemo</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>AbpAspNetCoreDemo</PackageId>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Switch to `Microsoft.AspNetCore.App` from `Microsoft.AspNetCore.All`
- Added `Microsoft.VisualStudio.Web.BrowserLink` since it is not included in `Microsoft.AspNetCore.App`