### PR TITLE
Fix AbpRoleStore.FindById() exception when no role found

### DIFF
--- a/src/Abp.ZeroCore/Authorization/Roles/AbpRoleStore.cs
+++ b/src/Abp.ZeroCore/Authorization/Roles/AbpRoleStore.cs
@@ -210,7 +210,7 @@ namespace Abp.Authorization.Roles
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return _roleRepository.GetAsync(id.To<int>());
+            return _roleRepository.FirstOrDefaultAsync(id.To<int>());
         }
 
         /// <summary>


### PR DESCRIPTION
`AbpRoleStore.FindByIdAsync()` should not throw exception when no role with the given id is found.