### PR TITLE
Introduce Multi-keys actions for ICache

### DIFF
--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCache.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCache.cs
@@ -96,8 +96,11 @@ namespace Abp.Runtime.Caching.Redis
             var redisPairs = pairs.Select(p => new KeyValuePair<RedisKey, RedisValue>
                                           (GetLocalizedRedisKey(p.Key), Serialize(p.Value, GetSerializableType(p.Value)))
                                          );
-            //TODO: currently Redis does not have command to bulk insert key/value pairs and set expiry time at the same time
-            //See https://github.com/StackExchange/StackExchange.Redis/blob/master/src/StackExchange.Redis/Interfaces/IDatabase.cs#L1924
+
+            if (slidingExpireTime.HasValue || absoluteExpireTime.HasValue)
+            {
+                Logger.WarnFormat("{0}/{1} is not supported for Redis bulk insert of key-value pairs", nameof(slidingExpireTime), nameof(absoluteExpireTime));
+            }
             _database.StringSet(redisPairs.ToArray());
         }
 
@@ -111,8 +114,10 @@ namespace Abp.Runtime.Caching.Redis
             var redisPairs = pairs.Select(p => new KeyValuePair<RedisKey, RedisValue>
                                           (GetLocalizedRedisKey(p.Key), Serialize(p.Value, GetSerializableType(p.Value)))
                                          );
-            //TODO: currently Redis does not have command to bulk insert key/value pairs and set expiry time at the same time
-            //See https://github.com/StackExchange/StackExchange.Redis/blob/master/src/StackExchange.Redis/Interfaces/IDatabase.cs#L1924
+            if (slidingExpireTime.HasValue || absoluteExpireTime.HasValue)
+            {
+                Logger.WarnFormat("{0}/{1} is not supported for Redis bulk insert of key-value pairs", nameof(slidingExpireTime), nameof(absoluteExpireTime));
+            }
             await _database.StringSetAsync(redisPairs.ToArray());
         }
 

--- a/src/Abp/Runtime/Caching/CacheBase.cs
+++ b/src/Abp/Runtime/Caching/CacheBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Castle.Core.Logging;
 using Nito.AsyncEx;
@@ -85,6 +87,70 @@ namespace Abp.Runtime.Caching
             return item;
         }
 
+        public virtual object[] Get(string[] keys, Func<string, object> factory)
+        {
+            object[] items = null;
+
+            try
+            {
+                items = GetOrDefault(keys);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex.ToString(), ex);
+            }
+
+            if (items == null)
+            {
+                items = new object[keys.Length];
+            }
+
+            if (items.Any(i => i == null))
+            {
+                lock (SyncObj)
+                {
+                    try
+                    {
+                        items = GetOrDefault(keys);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex.ToString(), ex);
+                    }
+
+                    var fetched = new List<KeyValuePair<string, object>>();
+                    for (var i = 0; i < items.Length; i++)
+                    {
+                        string key = keys[i];
+                        object value = items[i];
+                        if (value == null)
+                        {
+                            value = factory(key);
+                        }
+
+                        if (value != null)
+                        {
+                            fetched.Add(new KeyValuePair<string, object>(key, value));
+                        }
+                    }
+
+                    if (fetched.Any())
+                    {
+                        try
+                        {
+                            Set(fetched.ToArray());
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error(ex.ToString(), ex);
+                        }
+                    }
+                }
+            }
+
+            return items;
+        }
+
         public virtual async Task<object> GetAsync(string key, Func<string, Task<object>> factory)
         {
             object item = null;
@@ -135,14 +201,96 @@ namespace Abp.Runtime.Caching
             return item;
         }
 
+        public virtual async Task<object[]> GetAsync(string[] keys, Func<string, Task<object>> factory)
+        {
+            object[] items = null;
+
+            try
+            {
+                items = await GetOrDefaultAsync(keys);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex.ToString(), ex);
+            }
+
+            if (items == null)
+            {
+                items = new object[keys.Length];
+            }
+
+            if (items.Any(i => i == null))
+            {
+                using (await _asyncLock.LockAsync())
+                {
+                    try
+                    {
+                        items = await GetOrDefaultAsync(keys);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex.ToString(), ex);
+                    }
+
+                    var fetched = new List<KeyValuePair<string, object>>();
+                    for (var i = 0; i < items.Length; i++)
+                    {
+                        string key = keys[i];
+                        object value = items[i];
+                        if (value == null)
+                        {
+                            value = factory(key);
+                        }
+
+                        if (value != null)
+                        {
+                            fetched.Add(new KeyValuePair<string, object>(key, value));
+                        }
+                    }
+
+                    if (fetched.Any())
+                    {
+                        try
+                        {
+                            await SetAsync(fetched.ToArray());
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error(ex.ToString(), ex);
+                        }
+                    }
+                }
+            }
+
+            return items;
+        }
+
         public abstract object GetOrDefault(string key);
+
+        public virtual object[] GetOrDefault(string[] keys)
+        {
+            return keys.Select(GetOrDefault).ToArray();
+        }
 
         public virtual Task<object> GetOrDefaultAsync(string key)
         {
             return Task.FromResult(GetOrDefault(key));
         }
 
+        public virtual Task<object[]> GetOrDefaultAsync(string[] keys)
+        {
+            return Task.FromResult(GetOrDefault(keys));
+        }
+
         public abstract void Set(string key, object value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        public virtual void Set(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null)
+        {
+            foreach (var pair in pairs)
+            {
+                Set(pair.Key, pair.Value, slidingExpireTime, absoluteExpireTime);
+            }
+        }
 
         public virtual Task SetAsync(string key, object value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null)
         {
@@ -150,12 +298,30 @@ namespace Abp.Runtime.Caching
             return Task.FromResult(0);
         }
 
+        public virtual Task SetAsync(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null)
+        {
+            return Task.WhenAll(pairs.Select(p => SetAsync(p.Key, p.Value, slidingExpireTime, absoluteExpireTime)));
+        }
+
         public abstract void Remove(string key);
+
+        public virtual void Remove(string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                Remove(key);
+            }
+        }
 
         public virtual Task RemoveAsync(string key)
         {
             Remove(key);
             return Task.FromResult(0);
+        }
+
+        public virtual Task RemoveAsync(string[] keys)
+        {
+            return Task.WhenAll(keys.Select(RemoveAsync));
         }
 
         public abstract void Clear();

--- a/src/Abp/Runtime/Caching/CacheExtensions.cs
+++ b/src/Abp/Runtime/Caching/CacheExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Abp.Runtime.Caching
@@ -13,24 +14,45 @@ namespace Abp.Runtime.Caching
             return cache.Get(key, k => factory());
         }
 
+        public static object[] Get(this ICache cache, string[] keys, Func<object> factory)
+        {
+            return keys.Select(key => cache.Get(key, k => factory())).ToArray();
+        }
+
         public static Task<object> GetAsync(this ICache cache, string key, Func<Task<object>> factory)
         {
             return cache.GetAsync(key, k => factory());
+        }
+
+        public static Task<object[]> GetAsync(this ICache cache, string[] keys, Func<Task<object>> factory)
+        {
+            var tasks = keys.Select(key => cache.GetAsync(key, k => factory()));
+            return Task.WhenAll(tasks);
         }
 
         public static ITypedCache<TKey, TValue> AsTyped<TKey, TValue>(this ICache cache)
         {
             return new TypedCacheWrapper<TKey, TValue>(cache);
         }
-        
+
         public static TValue Get<TKey, TValue>(this ICache cache, TKey key, Func<TKey, TValue> factory)
         {
             return (TValue)cache.Get(key.ToString(), (k) => (object)factory(key));
         }
 
+        public static TValue[] Get<TKey, TValue>(this ICache cache, TKey[] keys, Func<TKey, TValue> factory)
+        {
+            return keys.Select(key => (TValue)cache.Get(key.ToString(), (k) => (object)factory(key))).ToArray();
+        }
+
         public static TValue Get<TKey, TValue>(this ICache cache, TKey key, Func<TValue> factory)
         {
             return cache.Get(key, (k) => factory());
+        }
+
+        public static TValue[] Get<TKey, TValue>(this ICache cache, TKey[] keys, Func<TValue> factory)
+        {
+            return keys.Select(key => cache.Get(key, (k) => factory())).ToArray();
         }
 
         public static async Task<TValue> GetAsync<TKey, TValue>(this ICache cache, TKey key, Func<TKey, Task<TValue>> factory)
@@ -44,9 +66,29 @@ namespace Abp.Runtime.Caching
             return (TValue)value;
         }
 
+        public static async Task<TValue[]> GetAsync<TKey, TValue>(this ICache cache, TKey[] keys, Func<TKey, Task<TValue>> factory)
+        {
+            var tasks = keys.Select(key =>
+            {
+                return cache.GetAsync(key.ToString(), async (keyAsString) =>
+                {
+                    var v = await factory(key);
+                    return (object)v;
+                });
+            });
+            var values = await Task.WhenAll(tasks);
+            return values.Select(value => (TValue)value).ToArray();
+        }
+
         public static Task<TValue> GetAsync<TKey, TValue>(this ICache cache, TKey key, Func<Task<TValue>> factory)
         {
             return cache.GetAsync(key, (k) => factory());
+        }
+
+        public static Task<TValue[]> GetAsync<TKey, TValue>(this ICache cache, TKey[] keys, Func<Task<TValue>> factory)
+        {
+            var tasks = keys.Select(key => cache.GetAsync(key, (k) => factory()));
+            return Task.WhenAll(tasks);
         }
 
         public static TValue GetOrDefault<TKey, TValue>(this ICache cache, TKey key)
@@ -57,7 +99,22 @@ namespace Abp.Runtime.Caching
                 return default(TValue);
             }
 
-            return (TValue) value;
+            return (TValue)value;
+        }
+
+        public static TValue[] GetOrDefault<TKey, TValue>(this ICache cache, TKey[] keys)
+        {
+            var values = keys.Select(key =>
+            {
+                var value = cache.GetOrDefault(key.ToString());
+                if (value == null)
+                {
+                    return default(TValue);
+                }
+                return (TValue)value;
+            });
+
+            return values.ToArray();
         }
 
         public static async Task<TValue> GetOrDefaultAsync<TKey, TValue>(this ICache cache, TKey key)
@@ -69,6 +126,21 @@ namespace Abp.Runtime.Caching
             }
 
             return (TValue)value;
+        }
+
+        public static async Task<TValue[]> GetOrDefaultAsync<TKey, TValue>(this ICache cache, TKey[] keys)
+        {
+            var tasks = keys.Select(async (key) =>
+            {
+                var value = await cache.GetOrDefaultAsync(key.ToString());
+                if (value == null)
+                {
+                    return default(TValue);
+                }
+                return (TValue)value;
+            });
+
+            return await Task.WhenAll(tasks);
         }
     }
 }

--- a/src/Abp/Runtime/Caching/ICache.cs
+++ b/src/Abp/Runtime/Caching/ICache.cs
@@ -75,7 +75,7 @@ namespace Abp.Runtime.Caching
         object GetOrDefault(string key);
 
         /// <summary>
-        /// Gets items from the cache. For every key that is not found, the null is returned.
+        /// Gets items from the cache. For every key that is not found, a null value is returned.
         /// </summary>
         /// <param name="keys">Keys</param>
         /// <returns>Cached items</returns>
@@ -89,7 +89,7 @@ namespace Abp.Runtime.Caching
         Task<object> GetOrDefaultAsync(string key);
 
         /// <summary>
-        /// Gets items from the cache. For every key that is not found, the null is returned.
+        /// Gets items from the cache. For every key that is not found, a null value is returned.
         /// </summary>
         /// <param name="keys">Keys</param>
         /// <returns>Cached items</returns>
@@ -146,7 +146,7 @@ namespace Abp.Runtime.Caching
         Task SetAsync(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
-        /// Removes a cache item by it's key.
+        /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
         /// </summary>
         /// <param name="key">Key</param>
         void Remove(string key);
@@ -164,7 +164,7 @@ namespace Abp.Runtime.Caching
         Task RemoveAsync(string key);
 
         /// <summary>
-        /// Removes cache items by their keys (does nothing if given key does not exists in the cache).
+        /// Removes cache items by their keys.
         /// </summary>
         /// <param name="keys">Keys</param>
         Task RemoveAsync(string[] keys);

--- a/src/Abp/Runtime/Caching/ICache.cs
+++ b/src/Abp/Runtime/Caching/ICache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Abp.Runtime.Caching
@@ -37,6 +38,16 @@ namespace Abp.Runtime.Caching
         object Get(string key, Func<string, object> factory);
 
         /// <summary>
+        /// Gets items from the cache.
+        /// This method hides cache provider failures (and logs them),
+        /// uses the factory method to get the object if cache provider fails.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <param name="factory">Factory method to create cache item if not exists</param>
+        /// <returns>Cached item</returns>
+        object[] Get(string[] keys, Func<string, object> factory);
+
+        /// <summary>
         /// Gets an item from the cache.
         /// This method hides cache provider failures (and logs them),
         /// uses the factory method to get the object if cache provider fails.
@@ -47,6 +58,16 @@ namespace Abp.Runtime.Caching
         Task<object> GetAsync(string key, Func<string, Task<object>> factory);
 
         /// <summary>
+        /// Gets items from the cache.
+        /// This method hides cache provider failures (and logs them),
+        /// uses the factory method to get the object if cache provider fails.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <param name="factory">Factory method to create cache item if not exists</param>
+        /// <returns>Cached items</returns>
+        Task<object[]> GetAsync(string[] keys, Func<string, Task<object>> factory);
+
+        /// <summary>
         /// Gets an item from the cache or null if not found.
         /// </summary>
         /// <param name="key">Key</param>
@@ -54,11 +75,25 @@ namespace Abp.Runtime.Caching
         object GetOrDefault(string key);
 
         /// <summary>
+        /// Gets items from the cache. For every key that is not found, the null is returned.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <returns>Cached items</returns>
+        object[] GetOrDefault(string[] keys);
+
+        /// <summary>
         /// Gets an item from the cache or null if not found.
         /// </summary>
         /// <param name="key">Key</param>
         /// <returns>Cached item or null if not found</returns>
         Task<object> GetOrDefaultAsync(string key);
+
+        /// <summary>
+        /// Gets items from the cache. For every key that is not found, the null is returned.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <returns>Cached items</returns>
+        Task<object[]> GetOrDefaultAsync(string[] keys);
 
         /// <summary>
         /// Saves/Overrides an item in the cache by a key.
@@ -74,6 +109,18 @@ namespace Abp.Runtime.Caching
         void Set(string key, object value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
+        /// Saves/Overrides items in the cache by the pairs.
+        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
+        /// If none of them is specified, then
+        /// <see cref="DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="DefaultSlidingExpireTime"/>
+        /// will be used.
+        /// </summary>
+        /// <param name="pairs">Pairs</param>
+        /// <param name="slidingExpireTime">Sliding expire time</param>
+        /// <param name="absoluteExpireTime">Absolute expire time</param>
+        void Set(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        /// <summary>
         /// Saves/Overrides an item in the cache by a key.
         /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
         /// If none of them is specified, then
@@ -87,16 +134,40 @@ namespace Abp.Runtime.Caching
         Task SetAsync(string key, object value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
+        /// Saves/Overrides items in the cache by the pairs.
+        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
+        /// If none of them is specified, then
+        /// <see cref="DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="DefaultSlidingExpireTime"/>
+        /// will be used.
+        /// </summary>
+        /// <param name="pairs">Pairs</param>
+        /// <param name="slidingExpireTime">Sliding expire time</param>
+        /// <param name="absoluteExpireTime">Absolute expire time</param>
+        Task SetAsync(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        /// <summary>
         /// Removes a cache item by it's key.
         /// </summary>
         /// <param name="key">Key</param>
         void Remove(string key);
 
         /// <summary>
+        /// Removes cache items by their keys.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        void Remove(string[] keys);
+
+        /// <summary>
         /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
         /// </summary>
         /// <param name="key">Key</param>
         Task RemoveAsync(string key);
+
+        /// <summary>
+        /// Removes cache items by their keys (does nothing if given key does not exists in the cache).
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        Task RemoveAsync(string[] keys);
 
         /// <summary>
         /// Clears all items in this cache.

--- a/src/Abp/Runtime/Caching/ITypedCache.cs
+++ b/src/Abp/Runtime/Caching/ITypedCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Abp.Runtime.Caching
@@ -36,12 +37,28 @@ namespace Abp.Runtime.Caching
         TValue Get(TKey key, Func<TKey, TValue> factory);
 
         /// <summary>
+        /// Gets items from the cache.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <param name="factory">Factory method to create cache item if not exists</param>
+        /// <returns>Cached items</returns>
+        TValue[] Get(TKey[] keys, Func<TKey, TValue> factory);
+
+        /// <summary>
         /// Gets an item from the cache.
         /// </summary>
         /// <param name="key">Key</param>
         /// <param name="factory">Factory method to create cache item if not exists</param>
         /// <returns>Cached item</returns>
         Task<TValue> GetAsync(TKey key, Func<TKey, Task<TValue>> factory);
+
+        /// <summary>
+        /// Gets items from the cache.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <param name="factory">Factory method to create cache item if not exists</param>
+        /// <returns>Cached item</returns>
+        Task<TValue[]> GetAsync(TKey[] keys, Func<TKey, Task<TValue>> factory);
 
         /// <summary>
         /// Gets an item from the cache or null if not found.
@@ -51,11 +68,25 @@ namespace Abp.Runtime.Caching
         TValue GetOrDefault(TKey key);
 
         /// <summary>
+        /// Gets items from the cache. For every key that is not found, a null value is returned.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <returns>Cached items</returns>
+        TValue[] GetOrDefault(TKey[] keys);
+
+        /// <summary>
         /// Gets an item from the cache or null if not found.
         /// </summary>
         /// <param name="key">Key</param>
         /// <returns>Cached item or null if not found</returns>
         Task<TValue> GetOrDefaultAsync(TKey key);
+
+        /// <summary>
+        /// Gets items from the cache. For every key that is not found, a null value is returned.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <returns>Cached items</returns>
+        Task<TValue[]> GetOrDefaultAsync(TKey[] keys);
 
         /// <summary>
         /// Saves/Overrides an item in the cache by a key.
@@ -67,6 +98,14 @@ namespace Abp.Runtime.Caching
         void Set(TKey key, TValue value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
+        /// Saves/Overrides items in the cache by the pairs.
+        /// </summary>
+        /// <param name="pairs">Pairs</param>
+        /// <param name="slidingExpireTime">Sliding expire time</param>
+        /// <param name="absoluteExpireTime">Absolute expire time</param>
+        void Set(KeyValuePair<TKey, TValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        /// <summary>
         /// Saves/Overrides an item in the cache by a key.
         /// </summary>
         /// <param name="key">Key</param>
@@ -76,16 +115,36 @@ namespace Abp.Runtime.Caching
         Task SetAsync(TKey key, TValue value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
+        /// Saves/Overrides items in the cache by the pairs.
+        /// </summary>
+        /// <param name="pairs">Pairs</param>
+        /// <param name="slidingExpireTime">Sliding expire time</param>
+        /// <param name="absoluteExpireTime">Absolute expire time</param>
+        Task SetAsync(KeyValuePair<TKey, TValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        /// <summary>
         /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
         /// </summary>
         /// <param name="key">Key</param>
         void Remove(TKey key);
 
         /// <summary>
-        /// Removes a cache item by it's key.
+        /// Removes cache items by their keys.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        void Remove(TKey[] keys);
+
+        /// <summary>
+        /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
         /// </summary>
         /// <param name="key">Key</param>
         Task RemoveAsync(TKey key);
+
+        /// <summary>
+        /// Removes cache items by their keys.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        Task RemoveAsync(TKey[] keys);
 
         /// <summary>
         /// Clears all items in this cache.

--- a/src/Abp/Runtime/Caching/TypedCacheWrapper.cs
+++ b/src/Abp/Runtime/Caching/TypedCacheWrapper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Abp.Runtime.Caching
@@ -57,9 +59,19 @@ namespace Abp.Runtime.Caching
             return InternalCache.Get(key, factory);
         }
 
+        public TValue[] Get(TKey[] keys, Func<TKey, TValue> factory)
+        {
+            return InternalCache.Get(keys, factory);
+        }
+
         public Task<TValue> GetAsync(TKey key, Func<TKey, Task<TValue>> factory)
         {
             return InternalCache.GetAsync(key, factory);
+        }
+
+        public Task<TValue[]> GetAsync(TKey[] keys, Func<TKey, Task<TValue>> factory)
+        {
+            return InternalCache.GetAsync(keys, factory);
         }
 
         public TValue GetOrDefault(TKey key)
@@ -67,9 +79,19 @@ namespace Abp.Runtime.Caching
             return InternalCache.GetOrDefault<TKey, TValue>(key);
         }
 
+        public TValue[] GetOrDefault(TKey[] keys)
+        {
+            return InternalCache.GetOrDefault<TKey, TValue>(keys);
+        }
+
         public Task<TValue> GetOrDefaultAsync(TKey key)
         {
             return InternalCache.GetOrDefaultAsync<TKey, TValue>(key);
+        }
+
+        public Task<TValue[]> GetOrDefaultAsync(TKey[] keys)
+        {
+            return InternalCache.GetOrDefaultAsync<TKey, TValue>(keys);
         }
 
         public void Set(TKey key, TValue value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null)
@@ -77,9 +99,21 @@ namespace Abp.Runtime.Caching
             InternalCache.Set(key.ToString(), value, slidingExpireTime, absoluteExpireTime);
         }
 
+        public void Set(KeyValuePair<TKey, TValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null)
+        {
+            var stringPairs = pairs.Select(p => new KeyValuePair<string, object>(p.Key.ToString(), p.Value));
+            InternalCache.Set(stringPairs.ToArray(), slidingExpireTime, absoluteExpireTime);
+        }
+
         public Task SetAsync(TKey key, TValue value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null)
         {
             return InternalCache.SetAsync(key.ToString(), value, slidingExpireTime, absoluteExpireTime);
+        }
+
+        public Task SetAsync(KeyValuePair<TKey, TValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null)
+        {
+            var stringPairs = pairs.Select(p => new KeyValuePair<string, object>(p.Key.ToString(), p.Value));
+            return InternalCache.SetAsync(stringPairs.ToArray(), slidingExpireTime, absoluteExpireTime);
         }
 
         public void Remove(TKey key)
@@ -87,9 +121,19 @@ namespace Abp.Runtime.Caching
             InternalCache.Remove(key.ToString());
         }
 
+        public void Remove(TKey[] keys)
+        {
+            InternalCache.Remove(keys.Select(key => key.ToString()).ToArray());
+        }
+
         public Task RemoveAsync(TKey key)
         {
             return InternalCache.RemoveAsync(key.ToString());
+        }
+
+        public Task RemoveAsync(TKey[] keys)
+        {
+            return InternalCache.RemoveAsync(keys.Select(key => key.ToString()).ToArray());
         }
     }
 }


### PR DESCRIPTION
Close #3884 

Implemented Multi-keys actions for `ICache` as well as `CacheBase` and `AbpRedisCache`

However, there isn't any redis command available for bulk insert of key/value pair along with **expiry time**.

See [StackExchange.Redis#IDatabase](https://github.com/StackExchange/StackExchange.Redis/blob/master/src/StackExchange.Redis/Interfaces/IDatabase.cs#L1924)

Not sure if keeping the interface consistent across other multi-keys actions (e.g Get/Set/Remove with multi-keys) is better, ~~or design the interface around redis will be sufficient~~.

#### Update 13 OCT 2018
Included testing for default cache implementaion. Redis test is currently skipped as we should not be testing against redis integration (instead we test for abp memory cache)