### PR TITLE
Fix TryGetValue() in DictionaryExtensions

### DIFF
--- a/src/Abp/Collections/Extensions/DictionaryExtensions.cs
+++ b/src/Abp/Collections/Extensions/DictionaryExtensions.cs
@@ -19,7 +19,7 @@ namespace Abp.Collections.Extensions
         internal static bool TryGetValue<T>(this IDictionary<string, object> dictionary, string key, out T value)
         {
             object valueObj;
-            if (dictionary.TryGetValue(key, out valueObj) && valueObj is T)
+            if (dictionary.ContainsKey(key) && dictionary.TryGetValue(key, out valueObj) && valueObj is T)
             {
                 value = (T)valueObj;
                 return true;


### PR DESCRIPTION
> <param name="value">Value of the key (or default value if key not exists)</param>
`TryGetValue()` should check for key existence to reflect it's description.
To ensure default value is return even if key does not exist.