### PR TITLE
Handle entity history for owned entities

### DIFF
--- a/doc/WebSite/Entity-History.md
+++ b/doc/WebSite/Entity-History.md
@@ -160,10 +160,15 @@ You can use the **IEntityChangeSetReasonProvider.Use(...)** method as shown belo
 The Use method returns an IDisposable and it **must be disposed**. Once the return
 value is disposed, the Reason is automatically restored to the previous value.
 
+### Owned Entities
+
+Entity History tracks changes to owned entities as entity changes.
+The primary key of the owner entity is saved as the **entity id**.
+
 ### Notes
 
 -   A property must be **public** in order to be saved in the change logs.
     Private and protected properties are ignored.
 -   DisableAuditing takes priority over the Audited attribute.
--   Entity History only works for entities.
+-   Entity History only works for entities and owned entities.
 -   Entity History only works for scalar properties, e.g. string, int, bool...

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -250,7 +250,7 @@ namespace Abp.EntityHistory
             return entity is ISoftDelete && entity.As<ISoftDelete>().IsDeleted;
         }
 
-        private bool ShouldSaveEntityHistory(EntityEntry entityEntry, bool defaultValue = false)
+        private bool ShouldSaveEntityHistory(EntityEntry entityEntry)
         {
             if (entityEntry.State == EntityState.Detached ||
                 entityEntry.State == EntityState.Unchanged)
@@ -289,7 +289,7 @@ namespace Abp.EntityHistory
                 return true;
             }
 
-            return defaultValue;
+            return false;
         }
 
         private bool ShouldSavePropertyHistory(PropertyEntry propertyEntry, bool shouldSaveEntityHistory, bool defaultValue)

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -275,28 +275,6 @@ namespace Abp.EntityHistory
                 return shouldSaveEntityHistoryForType.Value;
             }
 
-            /*
-            if (!entityType.IsPublic)
-            {
-                return false;
-            }
-
-            if (entityType.GetTypeInfo().IsDefined(typeof(DisableAuditingAttribute), true))
-            {
-                return false;
-            }
-
-            if (entityType.GetTypeInfo().IsDefined(typeof(AuditedAttribute), true))
-            {
-                return true;
-            }
-
-            if (_configuration.Selectors.Any(selector => selector.Predicate(entityType)))
-            {
-                return true;
-            }
-            */
-
             return false;
         }
 
@@ -339,22 +317,6 @@ namespace Abp.EntityHistory
             {
                 return shouldSavePropertyHistoryForInfo.Value;
             }
-
-            /*
-            if (propertyInfo != null && propertyInfo.IsDefined(typeof(DisableAuditingAttribute), true))
-            {
-                return false;
-            }
-
-            if (!shouldSaveEntityHistory)
-            {
-                // Should not save property history if property is not audited
-                if (propertyInfo == null || !propertyInfo.IsDefined(typeof(AuditedAttribute), true))
-                {
-                    return false;
-                }
-            }
-            */
 
             var isModified = !(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null);
             if (isModified)

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -150,7 +150,7 @@ namespace Abp.EntityHistory
                     return null;
             }
 
-            var entityId = GetEntityId(entity);
+            var entityId = GetEntityId(entityEntry);
             if (entityId == null && changeType != EntityChangeType.Created)
             {
                 Logger.Error("Unexpected null value for entityId!");
@@ -193,12 +193,10 @@ namespace Abp.EntityHistory
             }
         }
 
-        private string GetEntityId(object entityAsObj)
+        private string GetEntityId(EntityEntry entry)
         {
-            return entityAsObj
-                .GetType().GetProperty("Id")?
-                .GetValue(entityAsObj)?
-                .ToJsonString();
+            var primaryKeys = entry.Properties.Where(p => p.Metadata.IsPrimaryKey());
+            return primaryKeys.First().CurrentValue?.ToJsonString();
         }
 
         /// <summary>
@@ -296,7 +294,7 @@ namespace Abp.EntityHistory
 
         private bool ShouldSavePropertyHistory(PropertyEntry propertyEntry, bool shouldSaveEntityHistory, bool defaultValue)
         {
-            if (propertyEntry.Metadata.Name == "Id")
+            if (propertyEntry.Metadata.IsPrimaryKey())
             {
                 return false;
             }
@@ -339,7 +337,7 @@ namespace Abp.EntityHistory
                 /* Update entity id */
 
                 var entityEntry = entityChange.EntityEntry.As<EntityEntry>();
-                entityChange.EntityId = GetEntityId(entityEntry.Entity);
+                entityChange.EntityId = GetEntityId(entityEntry);
 
                 /* Update foreign keys */
 

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -269,6 +269,39 @@ namespace Abp.EntityHistory
                 return false;
             }
 
+            var shouldSaveEntityHistoryForType = ShouldSaveEntityHistoryForType(entityType);
+            if (shouldSaveEntityHistoryForType.HasValue)
+            {
+                return shouldSaveEntityHistoryForType.Value;
+            }
+
+            /*
+            if (!entityType.IsPublic)
+            {
+                return false;
+            }
+
+            if (entityType.GetTypeInfo().IsDefined(typeof(DisableAuditingAttribute), true))
+            {
+                return false;
+            }
+
+            if (entityType.GetTypeInfo().IsDefined(typeof(AuditedAttribute), true))
+            {
+                return true;
+            }
+
+            if (_configuration.Selectors.Any(selector => selector.Predicate(entityType)))
+            {
+                return true;
+            }
+            */
+
+            return false;
+        }
+
+        private bool? ShouldSaveEntityHistoryForType(Type entityType)
+        {
             if (!entityType.IsPublic)
             {
                 return false;
@@ -289,7 +322,7 @@ namespace Abp.EntityHistory
                 return true;
             }
 
-            return false;
+            return null;
         }
 
         private bool ShouldSavePropertyHistory(PropertyEntry propertyEntry, bool shouldSaveEntityHistory, bool defaultValue)
@@ -300,6 +333,40 @@ namespace Abp.EntityHistory
             }
 
             var propertyInfo = propertyEntry.Metadata.PropertyInfo;
+
+            var shouldSavePropertyHistoryForInfo = ShouldSavePropertyHistoryForInfo(propertyInfo, shouldSaveEntityHistory);
+            if (shouldSavePropertyHistoryForInfo.HasValue)
+            {
+                return shouldSavePropertyHistoryForInfo.Value;
+            }
+
+            /*
+            if (propertyInfo != null && propertyInfo.IsDefined(typeof(DisableAuditingAttribute), true))
+            {
+                return false;
+            }
+
+            if (!shouldSaveEntityHistory)
+            {
+                // Should not save property history if property is not audited
+                if (propertyInfo == null || !propertyInfo.IsDefined(typeof(AuditedAttribute), true))
+                {
+                    return false;
+                }
+            }
+            */
+
+            var isModified = !(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null);
+            if (isModified)
+            {
+                return true;
+            }
+
+            return defaultValue;
+        }
+
+        private bool? ShouldSavePropertyHistoryForInfo(PropertyInfo propertyInfo, bool shouldSaveEntityHistory)
+        {
             if (propertyInfo != null && propertyInfo.IsDefined(typeof(DisableAuditingAttribute), true))
             {
                 return false;
@@ -314,13 +381,7 @@ namespace Abp.EntityHistory
                 }
             }
 
-            var isModified = !(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null);
-            if (isModified)
-            {
-                return true;
-            }
-
-            return defaultValue;
+            return null;
         }
 
         /// <summary>

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -129,8 +129,6 @@ namespace Abp.EntityHistory
         [CanBeNull]
         private EntityChange CreateEntityChange(EntityEntry entityEntry, bool shouldSaveEntityHistory)
         {
-            var entity = entityEntry.Entity;
-
             EntityChangeType changeType;
             switch (entityEntry.State)
             {
@@ -157,7 +155,7 @@ namespace Abp.EntityHistory
                 return null;
             }
 
-            var entityType = entity.GetType();
+            var entityType = entityEntry.Entity.GetType();
             var entityChange = new EntityChange
             {
                 ChangeType = changeType,

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Blog.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Blog.cs
@@ -16,6 +16,8 @@ namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
 
         public DateTime CreationTime { get; set; }
 
+        public BlogEx More { get; set; }
+
         public ICollection<Post> Posts { get; set; }
 
         public Blog()
@@ -23,7 +25,7 @@ namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
             
         }
 
-        public Blog(string name, string url)
+        public Blog(string name, string url, string bloggerName)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -37,6 +39,7 @@ namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
 
             Name = name;
             Url = url;
+            More = new BlogEx { BloggerName = bloggerName };
         }
 
         public void ChangeUrl(string url)
@@ -49,5 +52,10 @@ namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
             var oldUrl = Url;
             Url = url;
         }
+    }
+
+    public class BlogEx
+    {
+        public string BloggerName { get; set; }
     }
 }

--- a/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
+++ b/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
@@ -44,6 +44,8 @@ namespace Abp.ZeroCore.SampleApp.EntityFramework
 
             modelBuilder.ConfigurePersistedGrantEntity();
 
+            modelBuilder.Entity<Blog>().OwnsOne(x => x.More);
+
             modelBuilder.Entity<Book>().ToTable("Books");
             modelBuilder.Entity<Book>().Property(e => e.Id).ValueGeneratedNever();
 

--- a/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestBase.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestBase.cs
@@ -49,7 +49,7 @@ namespace Abp.Zero
             UsingDbContext(
                 context =>
                 {
-                    var blog1 = new Blog("test-blog-1", "http://testblog1.myblogs.com");
+                    var blog1 = new Blog("test-blog-1", "http://testblog1.myblogs.com", "blogger-1");
 
                     context.Blogs.Add(blog1);
                     context.SaveChanges();

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -56,12 +56,17 @@ namespace Abp.Zero.EntityHistory
             var blog2Id = CreateBlogAndGetId();
 
             _entityHistoryStore.Received().SaveAsync(Arg.Is<EntityChangeSet>(
-                s => s.EntityChanges.Count == 1 &&
+                s => s.EntityChanges.Count == 2 &&
                      s.EntityChanges[0].ChangeTime == s.EntityChanges[0].EntityEntry.As<EntityEntry>().Entity.As<IHasCreationTime>().CreationTime &&
                      s.EntityChanges[0].ChangeType == EntityChangeType.Created &&
                      s.EntityChanges[0].EntityId == blog2Id.ToJsonString(false, false) &&
                      s.EntityChanges[0].EntityTypeFullName == typeof(Blog).FullName &&
                      s.EntityChanges[0].PropertyChanges.Count == 2 && // Blog.Name, Blog.Url
+
+                     s.EntityChanges[1].ChangeType == EntityChangeType.Created &&
+                     s.EntityChanges[1].EntityId == blog2Id.ToJsonString(false, false) &&
+                     s.EntityChanges[1].EntityTypeFullName == typeof(BlogEx).FullName &&
+                     s.EntityChanges[1].PropertyChanges.Count == 1 && // BlogEx.BloggerName
 
                      // Check "who did this change"
                      s.ImpersonatorTenantId == AbpSession.ImpersonatorTenantId &&
@@ -103,7 +108,7 @@ namespace Abp.Zero.EntityHistory
 
             UsingDbContext(tenantId, (context) =>
             {
-                context.EntityChanges.Count(f => f.TenantId == tenantId).ShouldBe(1);
+                context.EntityChanges.Count(f => f.TenantId == tenantId).ShouldBe(2);
             });
 
             UsingDbContext(tenantId, (context) =>
@@ -114,7 +119,7 @@ namespace Abp.Zero.EntityHistory
 
             UsingDbContext(tenantId, (context) =>
             {
-                context.EntityPropertyChanges.Count(f => f.TenantId == tenantId).ShouldBe(2);
+                context.EntityPropertyChanges.Count(f => f.TenantId == tenantId).ShouldBe(3);
             });
         }
 

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -263,7 +263,7 @@ namespace Abp.Zero.EntityHistory
 
             using (var uow = Resolve<IUnitOfWorkManager>().Begin())
             {
-                var blog2 = new Blog("test-blog-2", "http://testblog2.myblogs.com");
+                var blog2 = new Blog("test-blog-2", "http://testblog2.myblogs.com", "blogger-2");
 
                 blog2Id = _blogRepository.InsertAndGetId(blog2);
 


### PR DESCRIPTION
Resolves #3913

Adds support for [Owned Entity Types](https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities), new in EF Core 2.0. Works for plain classes and [`ValueObject<T>`](https://github.com/aspnetboilerplate/aspnetboilerplate/blob/58ec369bca1965771113d6e1b058693cac97f401/src/Abp/Domain/Values/ValueObject.cs).

Also:
- Updates test cases in 7a0a993
  - `Should_Write_History_For_Tracked_Entities_Create`
  - `Should_Write_History_For_Tracked_Entities_Create_To_Database`
- Includes a new test case in 97e6911
  - `Should_Write_History_For_Tracked_Entities_Update_Owned` uses a different format that allows stepping through for easier debugging of test cases.
- Removes hardcoded "Id" for primary key in 4990ec1