### PR TITLE
Fix ContainsKey called with null if cookie auth not used

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Antiforgery/AbpAutoValidateAntiforgeryTokenAuthorizationFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Antiforgery/AbpAutoValidateAntiforgeryTokenAuthorizationFilter.cs
@@ -32,7 +32,8 @@ namespace Abp.AspNetCore.Mvc.Antiforgery
             }
 
             //Always perform antiforgery validation when request contains authentication cookie
-            if (context.HttpContext.Request.Cookies.ContainsKey(_cookieAuthenticationOptions.Cookie.Name))
+            if (_cookieAuthenticationOptions.Cookie.Name != null &&
+                context.HttpContext.Request.Cookies.ContainsKey(_cookieAuthenticationOptions.Cookie.Name))
             {
                 return true;
             }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Antiforgery/AbpValidateAntiforgeryTokenAuthorizationFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Antiforgery/AbpValidateAntiforgeryTokenAuthorizationFilter.cs
@@ -31,7 +31,8 @@ namespace Abp.AspNetCore.Mvc.Antiforgery
             }
 
             //Always perform antiforgery validation when request contains authentication cookie
-            if (context.HttpContext.Request.Cookies.ContainsKey(_cookieAuthenticationOptions.Cookie.Name))
+            if (_cookieAuthenticationOptions.Cookie.Name != null &&
+                context.HttpContext.Request.Cookies.ContainsKey(_cookieAuthenticationOptions.Cookie.Name))
             {
                 return true;
             }


### PR DESCRIPTION
Fixes https://github.com/aspnetboilerplate/aspnetboilerplate-samples/issues/61

`_cookieAuthenticationOptions.Cookie.Name` is `null` if [cookie authentication](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/cookie?view=aspnetcore-2.1&tabs=aspnetcore2x#configuration) (or [Identity](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?view=aspnetcore-2.1&tabs=visual-studio)) is not used.