### PR TITLE
Update AutoMapper and AutoMapper.Collection packages

### DIFF
--- a/src/Abp.AutoMapper/Abp.AutoMapper.csproj
+++ b/src/Abp.AutoMapper/Abp.AutoMapper.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Collection" Version="4.0.0" />
     <PackageReference Include="AutoMapper" Version="8.0.0" />
+    <PackageReference Include="AutoMapper.Collection" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Abp.AutoMapper/Abp.AutoMapper.csproj
+++ b/src/Abp.AutoMapper/Abp.AutoMapper.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Collection" Version="4.0.0" />
-    <PackageReference Include="AutoMapper" Version="7.0.1" />
+    <PackageReference Include="AutoMapper" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Abp.AutoMapper/AutoMapper/AbpAutoMapperModule.cs
+++ b/src/Abp.AutoMapper/AutoMapper/AbpAutoMapperModule.cs
@@ -102,7 +102,7 @@ namespace Abp.AutoMapper
         {
             var localizationContext = IocManager.Resolve<ILocalizationContext>();
 
-            configuration.CreateMap<ILocalizableString, string>().ConvertUsing(ls => ls?.Localize(localizationContext));
+            configuration.CreateMap<ILocalizableString, string>().ConvertUsing(ls => ls == null ? null : ls.Localize(localizationContext));
             configuration.CreateMap<LocalizableString, string>().ConvertUsing(ls => ls == null ? null : localizationContext.LocalizationManager.GetString(ls));
         }
     }

--- a/test/Abp.AutoMapper.Tests/Abp.AutoMapper.Tests.csproj
+++ b/test/Abp.AutoMapper.Tests/Abp.AutoMapper.Tests.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Collection" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/test/Abp.AutoMapper.Tests/AutoMapper_Inheritance_Tests.cs
+++ b/test/Abp.AutoMapper.Tests/AutoMapper_Inheritance_Tests.cs
@@ -51,7 +51,7 @@ namespace Abp.AutoMapper.Tests
             public string Value { get; set; }
         }
 
-        //[Fact] //TODO: That's a problem but related to AutoMapper rather than ABP.
+        [Fact]
         public void Should_Map_EntityProxy_To_EntityDto_And_To_DrivedEntityDto()
         {
             var proxy = new EntityProxy() { Value = "42" };

--- a/test/Abp.AutoMapper.Tests/AutoMapping_Tests.cs
+++ b/test/Abp.AutoMapper.Tests/AutoMapping_Tests.cs
@@ -56,7 +56,7 @@ namespace Abp.AutoMapper.Tests
         }
 
         [Fact]
-        public void Should_Map_Two_Way_When_AutoMAp_Attribute_Is_Used()
+        public void Should_Map_Two_Way_When_AutoMap_Attribute_Is_Used()
         {
             MyClass3 obj2 = new MyClass3
             {


### PR DESCRIPTION
Referred to [**AutoMapper**/docs/8.0-Upgrade-Guide.md](https://github.com/AutoMapper/AutoMapper/blob/1ae2032dda6485e916c2b62c8234ee86690e26a9/docs/8.0-Upgrade-Guide.md).
- [AutoMapper](https://www.nuget.org/packages/AutoMapper) 8.0.0 was released 4 days ago.
- [AutoMapper.Collection](https://www.nuget.org/packages/AutoMapper.Collection) 5.0.0 was released 1 day ago.
- Required for new package [AutoMapper.Collection.EntityFrameworkCore](https://www.nuget.org/packages/AutoMapper.Collection.EntityFrameworkCore/) 0.1.0, released 2 hours ago.

With **AutoMapper.Collection.EntityFrameworkCore**, `AutoMapKeyAttribute` is unnecessary for entities.
`AutoMapKeyAttribute` can be useful for classes that are not in `DbContext`, like in [Abp.AutoMapper.Tests](https://github.com/aspnetboilerplate/aspnetboilerplate/tree/2ce8a838316bcb7203811656bba6d685ea0c5dda/test/Abp.AutoMapper.Tests).

Related issues: #3393, #3470 
Related PRs: #3439, #3709 