### PR TITLE
Use setting for IsLockoutEnabled by default and stricter value if set

### DIFF
--- a/src/Abp.Zero.Common/Authorization/Users/AbpUserBase.cs
+++ b/src/Abp.Zero.Common/Authorization/Users/AbpUserBase.cs
@@ -232,7 +232,6 @@ namespace Abp.Authorization.Users
         protected AbpUserBase()
         {
             IsActive = true;
-            IsLockoutEnabled = true;
             SecurityStamp = SequentialGuidGenerator.Instance.Create().ToString();
         }
 

--- a/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
@@ -121,17 +121,9 @@ namespace Abp.Authorization.Users
                 user.TenantId = tenantId.Value;
             }
 
-            var isLockoutEnabled = user.IsLockoutEnabled;
+            InitializeLockoutSettings(user.TenantId);
 
-            var identityResult = await base.CreateAsync(user);
-
-            if (identityResult.Succeeded)
-            {
-                await _unitOfWorkManager.Current.SaveChangesAsync();
-                await SetLockoutEnabledAsync(user.Id, isLockoutEnabled);
-            }
-
-            return identityResult;
+            return await base.CreateAsync(user);
         }
 
         /// <summary>

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
@@ -125,15 +125,9 @@ namespace Abp.Authorization.Users
                 user.TenantId = tenantId.Value;
             }
 
-            var isLockoutEnabled = user.IsLockoutEnabled;
+            await InitializeOptionsAsync(user.TenantId);
 
-            var identityResult = await base.CreateAsync(user);
-            if (identityResult.Succeeded)
-            {
-                await SetLockoutEnabledAsync(user, isLockoutEnabled);
-            }
-
-            return identityResult;
+            return await base.CreateAsync(user);
         }
 
         /// <summary>

--- a/test/Abp.Zero.SampleApp.Tests/Users/UserManager_Lockout_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Users/UserManager_Lockout_Tests.cs
@@ -87,17 +87,7 @@ namespace Abp.Zero.SampleApp.Tests.Users
         {
             // Arrange
 
-            LocalIocManager.Using<ISettingManager>(async settingManager =>
-            {
-                if (AbpSession.TenantId is int tenantId)
-                {
-                    await settingManager.ChangeSettingForTenantAsync(tenantId, AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
-                }
-                else
-                {
-                    await settingManager.ChangeSettingForApplicationAsync(AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
-                }
-            });
+            ChangeLockoutEnabledSetting(isLockoutEnabledByDefault);
 
             // Act
 
@@ -119,5 +109,57 @@ namespace Abp.Zero.SampleApp.Tests.Users
 
             (await _userManager.GetLockoutEnabledAsync(user.Id)).ShouldBe(isLockoutEnabledByDefault);
         }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, false)]
+        public async Task Test_IsLockoutEnabled_On_User_Creation_Should_Use_Stricter_Value_If_Set(bool isLockoutEnabledByDefault, bool isLockoutEnabled, bool isLockoutEnabledExpected)
+        {
+            // Arrange
+
+            ChangeLockoutEnabledSetting(isLockoutEnabledByDefault);
+
+            // Act
+
+            var user = new User
+            {
+                TenantId = AbpSession.TenantId,
+                UserName = "user1",
+                Name = "John",
+                Surname = "Doe",
+                EmailAddress = "user1@aspnetboilerplate.com",
+                IsEmailConfirmed = true,
+                Password = "AM4OLBpptxBYmM79lGOX9egzZk3vIQU3d/gFCJzaBjAPXzYIK3tQ2N7X4fcrHtElTw==", //123qwe
+                IsLockoutEnabled = isLockoutEnabled
+            };
+
+            await WithUnitOfWorkAsync(async () => await _userManager.CreateAsync(user));
+
+            // Assert
+
+            (await _userManager.GetLockoutEnabledAsync(user.Id)).ShouldBe(isLockoutEnabledExpected);
+        }
+
+        #region Helpers
+
+        private void ChangeLockoutEnabledSetting(bool isLockoutEnabledByDefault)
+        {
+
+            LocalIocManager.Using<ISettingManager>(settingManager =>
+            {
+                if (AbpSession.TenantId is int tenantId)
+                {
+                    settingManager.ChangeSettingForTenant(tenantId, AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
+                }
+                else
+                {
+                    settingManager.ChangeSettingForApplication(AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
+                }
+            });
+        }
+
+        #endregion
     }
 }

--- a/test/Abp.Zero.SampleApp.Tests/Users/UserManager_Lockout_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Users/UserManager_Lockout_Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Abp.Authorization;
-using Abp.Authorization.Users;
 using Abp.Configuration;
 using Abp.Dependency;
 using Abp.Threading;

--- a/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Lockout_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Lockout_Tests.cs
@@ -1,0 +1,60 @@
+﻿using System.Threading.Tasks;
+using Abp.Configuration;
+using Abp.Dependency;
+using Abp.Zero.Configuration;
+using Abp.ZeroCore.SampleApp.Core;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Zero.Users
+{
+    public class UserManager_Lockout_Tests : AbpZeroTestBase
+    {
+        private readonly UserManager _userManager;
+
+        public UserManager_Lockout_Tests()
+        {
+            _userManager = Resolve<UserManager>();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Test_IsLockoutEnabled_On_User_Creation_Should_Use_Setting_By_Default(bool isLockoutEnabledByDefault)
+        {
+            // Arrange
+
+            LocalIocManager.Using<ISettingManager>(async settingManager =>
+            {
+                if (AbpSession.TenantId is int tenantId)
+                {
+                    await settingManager.ChangeSettingForTenantAsync(tenantId, AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
+                }
+                else
+                {
+                    await settingManager.ChangeSettingForApplicationAsync(AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
+                }
+            });
+
+            // Act
+
+            var user = new User
+            {
+                TenantId = AbpSession.TenantId,
+                UserName = "user1",
+                Name = "John",
+                Surname = "Doe",
+                EmailAddress = "user1@aspnetboilerplate.com",
+                IsEmailConfirmed = true,
+                Password = "AM4OLBpptxBYmM79lGOX9egzZk3vIQU3d/gFCJzaBjAPXzYIK3tQ2N7X4fcrHtElTw==", //123qwe
+                // IsLockoutEnabled = isLockoutEnabled
+            };
+
+            await WithUnitOfWorkAsync(async () => await _userManager.CreateAsync(user));
+
+            // Assert
+
+            (await _userManager.GetLockoutEnabledAsync(user)).ShouldBe(isLockoutEnabledByDefault);
+        }
+    }
+}

--- a/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Lockout_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Lockout_Tests.cs
@@ -24,17 +24,7 @@ namespace Abp.Zero.Users
         {
             // Arrange
 
-            LocalIocManager.Using<ISettingManager>(async settingManager =>
-            {
-                if (AbpSession.TenantId is int tenantId)
-                {
-                    await settingManager.ChangeSettingForTenantAsync(tenantId, AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
-                }
-                else
-                {
-                    await settingManager.ChangeSettingForApplicationAsync(AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
-                }
-            });
+            ChangeLockoutEnabledSetting(isLockoutEnabledByDefault);
 
             // Act
 
@@ -56,5 +46,57 @@ namespace Abp.Zero.Users
 
             (await _userManager.GetLockoutEnabledAsync(user)).ShouldBe(isLockoutEnabledByDefault);
         }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, false)]
+        public async Task Test_IsLockoutEnabled_On_User_Creation_Should_Use_Stricter_Value_If_Set(bool isLockoutEnabledByDefault, bool isLockoutEnabled, bool isLockoutEnabledExpected)
+        {
+            // Arrange
+
+            ChangeLockoutEnabledSetting(isLockoutEnabledByDefault);
+
+            // Act
+
+            var user = new User
+            {
+                TenantId = AbpSession.TenantId,
+                UserName = "user1",
+                Name = "John",
+                Surname = "Doe",
+                EmailAddress = "user1@aspnetboilerplate.com",
+                IsEmailConfirmed = true,
+                Password = "AM4OLBpptxBYmM79lGOX9egzZk3vIQU3d/gFCJzaBjAPXzYIK3tQ2N7X4fcrHtElTw==", //123qwe
+                IsLockoutEnabled = isLockoutEnabled
+            };
+
+            await WithUnitOfWorkAsync(async () => await _userManager.CreateAsync(user));
+
+            // Assert
+
+            (await _userManager.GetLockoutEnabledAsync(user)).ShouldBe(isLockoutEnabledExpected);
+        }
+
+        #region Helpers
+
+        private void ChangeLockoutEnabledSetting(bool isLockoutEnabledByDefault)
+        {
+
+            LocalIocManager.Using<ISettingManager>(settingManager =>
+            {
+                if (AbpSession.TenantId is int tenantId)
+                {
+                    settingManager.ChangeSettingForTenant(tenantId, AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
+                }
+                else
+                {
+                    settingManager.ChangeSettingForApplication(AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
+                }
+            });
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Resolves #4029 (ASP.NET Core)
Resolves #4032 (ASP.NET MVC 5)

Reverts https://github.com/aspnetboilerplate/module-zero-forsaken/commit/919e8f0b3f13109a722e9e750850189e2cca7519
Reverts  fe4ef91 (ASP.NET Core)
Partially reverts #3410 (ASP.NET MVC 5)

Updates test case:
- `Test_IsLockoutEnabled_On_User_Creation` → `Test_IsLockoutEnabled_On_User_Creation_Should_Use_Stricter_Value_If_Set` ⚠️

Includes a new test case:
- `Test_IsLockoutEnabled_On_User_Creation_Should_Use_Setting_By_Default`

### Note (for reviewers)

The main change is calling `InitializeLockoutSettings` (ASP.NET MVC 5) and `InitializeOptionsAsync` (ASP.NET Core) in `CreateAsync` to configure the settings that will be used by ASP.NET (Core) Identity.

### Breaking change

⚠️ Setting `IsLockoutEnabled` to `false` when the setting is `true` will result in `true`, which is stricter.
This is consistent with ASP.NET (Core) Identity's behaviour, checked by the `_Use_Stricter_Value_` test.
Applications that do not want this more secure behaviour should explicitly set it **after** calling `CreateUser`.
**Impact: LOW**