### PR TITLE
Create and use IndexingPropertyConvention for TenantId, IsDeleted fields in EF 6.x

### DIFF
--- a/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroDbContext.cs
+++ b/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroDbContext.cs
@@ -2,12 +2,14 @@ using System.Data.Common;
 using System.Data.Entity;
 using System.Data.Entity.Core.Objects;
 using System.Data.Entity.Infrastructure;
+using System.Data.Entity.ModelConfiguration.Conventions;
 using Abp.Application.Editions;
 using Abp.Application.Features;
 using Abp.Auditing;
 using Abp.Authorization.Roles;
 using Abp.Authorization.Users;
 using Abp.BackgroundJobs;
+using Abp.Domain.Entities;
 using Abp.EntityFramework.Extensions;
 using Abp.MultiTenancy;
 using Abp.Notifications;
@@ -212,6 +214,13 @@ namespace Abp.Zero.EntityFramework
 
             #endregion
 
+            #region Common Indexes
+
+            modelBuilder.Conventions.AddAfter<IndexAttributeConvention>(new IndexingPropertyConvention<ISoftDelete, bool>(m => m.IsDeleted));
+            modelBuilder.Conventions.AddAfter<IndexAttributeConvention>(new IndexingPropertyConvention<IMayHaveTenant, int?>(m => m.TenantId));
+            modelBuilder.Conventions.AddAfter<IndexAttributeConvention>(new IndexingPropertyConvention<IMustHaveTenant, int>(m => m.TenantId));
+
+            #endregion
         }
     }
 }

--- a/src/Abp.Zero.EntityFramework/Zero/EntityFramework/IndexingPropertyConvention.cs
+++ b/src/Abp.Zero.EntityFramework/Zero/EntityFramework/IndexingPropertyConvention.cs
@@ -1,0 +1,23 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity.Infrastructure.Annotations;
+using System.Data.Entity.ModelConfiguration.Conventions;
+using System.Linq.Expressions;
+
+namespace Abp.Zero.EntityFramework
+{
+    public class IndexingPropertyConvention<T, TProperty> : Convention where T : class
+    {
+        public IndexingPropertyConvention(Expression<Func<T, TProperty>> propertyExpression, Func<Type, bool> predicate = null)
+        {
+            predicate = predicate ?? (t => true);
+            Types<T>()
+                .Where(t => predicate(t))
+                .Configure(e => e.Property(propertyExpression).HasColumnAnnotation(IndexAnnotation.AnnotationName, new IndexAnnotation(new IndexAttribute
+                {
+                    IsClustered = false,
+                    IsUnique = false
+                })));
+        }
+    }
+}


### PR DESCRIPTION
Resolves #696 