### PR TITLE
fix #4083  the method “AbpAppServiceConvention.GetControllerSettingOrNull ”  may return a incorrect value.

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Configuration/ControllerAssemblySettingList.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/ControllerAssemblySettingList.cs
@@ -11,7 +11,10 @@ namespace Abp.AspNetCore.Configuration
         [CanBeNull]
         public AbpControllerAssemblySetting GetSettingOrNull(Type controllerType)
         {
-            return this.FirstOrDefault(controllerSetting => controllerSetting.Assembly == controllerType.GetAssembly());
+            return this.FirstOrDefault(
+                controllerSetting => controllerSetting.Assembly == controllerType.GetAssembly()
+                 && controllerSetting.TypePredicate(controllerType)
+                );
         }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Providers/AbpAppServiceControllerFeatureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Providers/AbpAppServiceControllerFeatureProvider.cs
@@ -38,7 +38,7 @@ namespace Abp.AspNetCore.Mvc.Providers
             }
 
             var configuration = _iocResolver.Resolve<AbpAspNetCoreConfiguration>().ControllerAssemblySettings.GetSettingOrNull(type);
-            return configuration != null && configuration.TypePredicate(type);
+            return configuration != null;
         }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Proxying/AspNetCoreApiDescriptionModelProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Proxying/AspNetCoreApiDescriptionModelProvider.cs
@@ -165,7 +165,7 @@ namespace Abp.AspNetCore.Mvc.Proxying
 
             foreach (var controllerSetting in _configuration.ControllerAssemblySettings)
             {
-                if (Equals(controllerType.GetAssembly(), controllerSetting.Assembly))
+                if (Equals(controllerType.GetAssembly(), controllerSetting.Assembly) && controllerSetting.TypePredicate(controllerType))
                 {
                     return controllerSetting.ModuleName;
                 }


### PR DESCRIPTION
Fixes #4083