### PR TITLE
[ENHANCEMENT] Explicit Exception for RequireFeature attribute during Host User Authorization

### DIFF
--- a/src/Abp/Authorization/AuthorizationHelper.cs
+++ b/src/Abp/Authorization/AuthorizationHelper.cs
@@ -66,6 +66,11 @@ namespace Abp.Authorization
                 return;
             }
 
+            if (AbpSession.UserId.HasValue && !AbpSession.TenantId.HasValue)
+            {
+                throw new AbpException("RequiresFeatureAttribute should not be used during host user authorization");
+            }
+
             foreach (var featureAttribute in featureAttributes)
             {
                 await _featureChecker.CheckEnabledAsync(featureAttribute.RequiresAll, featureAttribute.Features);


### PR DESCRIPTION
> **Scope**: A value in the FeatureScopes enum. It can be Edition (if this feature can be set only for edition level), Tenant (if this feature can be set only for tenant level) or All (if this feature can be set for editions and tenants, where a tenant setting overrides its edition's setting). Default value is All.

~Since https://aspnetboilerplate.com/Pages/Documents/Feature-Management#other-feature-properties indicates that `Scope` is only supporting `Edition` or `Tenant`, we should assume that Feature System is only applicable to Tenant side.~

Unlike `Permission`, `Feature` does not come with `MultiTenancySides`, therefore, we should not check for feature during host user authorization.

#### Update: 
We should explicitly throw Exception when such usage is detected.

