### PR TITLE
fix #4130 UserStore Normalize user name and email address.

### DIFF
--- a/src/Abp.Zero/Authorization/Roles/AbpRoleStore.cs
+++ b/src/Abp.Zero/Authorization/Roles/AbpRoleStore.cs
@@ -66,7 +66,7 @@ namespace Abp.Authorization.Roles
         public virtual async Task<TRole> FindByNameAsync(string roleName)
         {
             return await _roleRepository.FirstOrDefaultAsync(
-                role => role.Name == roleName
+                role => role.Name.ToUpper() == roleName.ToUpper()
                 );
         }
 

--- a/src/Abp.Zero/Authorization/Users/AbpUserStore.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUserStore.cs
@@ -99,14 +99,14 @@ namespace Abp.Authorization.Users
         public virtual async Task<TUser> FindByNameAsync(string userName)
         {
             return await _userRepository.FirstOrDefaultAsync(
-                user => user.UserName == userName
+                user => user.UserName.ToUpper() == userName.ToUpper()
             );
         }
 
         public virtual async Task<TUser> FindByEmailAsync(string email)
         {
             return await _userRepository.FirstOrDefaultAsync(
-                user => user.EmailAddress == email
+                user => user.EmailAddress.ToUpper() == email.ToUpper()
             );
         }
 
@@ -118,7 +118,7 @@ namespace Abp.Authorization.Users
         public virtual async Task<TUser> FindByNameOrEmailAsync(string userNameOrEmailAddress)
         {
             return await _userRepository.FirstOrDefaultAsync(
-                user => (user.UserName == userNameOrEmailAddress || user.EmailAddress == userNameOrEmailAddress)
+                user => (user.UserName.ToUpper() == userNameOrEmailAddress.ToUpper() || user.EmailAddress.ToUpper() == userNameOrEmailAddress.ToUpper())
                 );
         }
 

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
@@ -316,7 +316,7 @@ namespace Abp.Authorization.Users
 
         public virtual Task<TUser> FindByNameOrEmailAsync(string userNameOrEmailAddress)
         {
-            return AbpUserStore.FindByNameOrEmailAsync(userNameOrEmailAddress);
+            return AbpUserStore.FindByNameOrEmailAsync(NormalizeKey(userNameOrEmailAddress));
         }
 
         public virtual Task<List<TUser>> FindAllAsync(UserLoginInfo login)
@@ -331,7 +331,7 @@ namespace Abp.Authorization.Users
 
         public virtual Task<TUser> FindByNameOrEmailAsync(int? tenantId, string userNameOrEmailAddress)
         {
-            return AbpUserStore.FindByNameOrEmailAsync(tenantId, userNameOrEmailAddress);
+            return AbpUserStore.FindByNameOrEmailAsync(tenantId, NormalizeKey(userNameOrEmailAddress));
         }
 
         /// <summary>

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserStore.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserStore.cs
@@ -1153,29 +1153,30 @@ namespace Abp.Authorization.Users
         }
 
         /// <summary>
-        /// Tries to find a user with user name or email address in current tenant.
+        /// Tries to find a user with normalized user name or normalized email address in current tenant.
         /// </summary>
-        /// <param name="userNameOrEmailAddress">User name or email address</param>
+        /// <param name="normalizedUserNameOrEmailAddress">Normalized user name or normalized email address</param>
         /// <returns>User or null</returns>
-        public virtual async Task<TUser> FindByNameOrEmailAsync(string userNameOrEmailAddress)
+        public virtual async Task<TUser> FindByNameOrEmailAsync(string normalizedUserNameOrEmailAddress)
         {
             return await UserRepository.FirstOrDefaultAsync(
-                user => (user.UserName == userNameOrEmailAddress || user.EmailAddress == userNameOrEmailAddress)
-                );
+                user => (user.NormalizedUserName == normalizedUserNameOrEmailAddress ||
+                         user.NormalizedEmailAddress == normalizedUserNameOrEmailAddress)
+            );
         }
 
         /// <summary>
-        /// Tries to find a user with user name or email address in given tenant.
+        /// Tries to find a user with normalized user name or normalized email address in given tenant.
         /// </summary>
         /// <param name="tenantId">Tenant Id</param>
-        /// <param name="userNameOrEmailAddress">User name or email address</param>
+        /// <param name="normalizedUserNameOrEmailAddress">Normalized user name or normalized email address</param>
         /// <returns>User or null</returns>
         [UnitOfWork]
-        public virtual async Task<TUser> FindByNameOrEmailAsync(int? tenantId, string userNameOrEmailAddress)
+        public virtual async Task<TUser> FindByNameOrEmailAsync(int? tenantId, string normalizedUserNameOrEmailAddress)
         {
             using (_unitOfWorkManager.Current.SetTenantId(tenantId))
             {
-                return await FindByNameOrEmailAsync(userNameOrEmailAddress);
+                return await FindByNameOrEmailAsync(normalizedUserNameOrEmailAddress);
             }
         }
 


### PR DESCRIPTION
https://github.com/aspnet/AspNetIdentity/blob/master/src/Microsoft.AspNet.Identity.EntityFramework/UserStore.cs#L265
According to the implementation of identity2, directly convert the user name or email address to uppercase.

For the identity core, we use `normalizedUserName `and `normalizedEmailAddress `in the `UserStore`.
Normalizing parameters in the `UserManager`

**Both include Role**