### PR TITLE
Deprecate ToMimeMessage extension

### DIFF
--- a/src/Abp.MailKit/EmailExtensions.cs
+++ b/src/Abp.MailKit/EmailExtensions.cs
@@ -10,10 +10,11 @@ namespace Abp.MailKit
     public static class EmailExtensions
     {
         /// <summary>
-        /// A modified version of CreateFromMailMessage() method in https://github.com/jstedfast/MimeKit/blob/master/MimeKit/MimeMessage.cs
+        /// Use MimeMessage.CreateFromMailMessage() instead
         /// </summary>
         /// <param name="mail"></param>
         /// <returns></returns>
+        [Obsolete]
         public static MimeMessage ToMimeMessage(this MailMessage mail)
         {
             if (mail == null)

--- a/src/Abp.MailKit/MailKitEmailSender.cs
+++ b/src/Abp.MailKit/MailKitEmailSender.cs
@@ -43,7 +43,7 @@ namespace Abp.MailKit
         {
             using (var client = BuildSmtpClient())
             {
-                var message = mail.ToMimeMessage();
+                var message = MimeMessage.CreateFromMailMessage(mail);
                 await client.SendAsync(message);
                 await client.DisconnectAsync(true);
             }
@@ -53,7 +53,7 @@ namespace Abp.MailKit
         {
             using (var client = BuildSmtpClient())
             {
-                var message = mail.ToMimeMessage();
+                var message = MimeMessage.CreateFromMailMessage(mail);
                 client.Send(message);
                 client.Disconnect(true);
             }


### PR DESCRIPTION
As mentioned in https://github.com/aspnetboilerplate/aspnetboilerplate/pull/2590, back then MailKit does not support **MailMessage** to **MimeMessage** conversion well. Hence, we did a workaround for it.

Since now **MailMessage** to **MimeMessage** conversion is supported by MailKit with netstandard2.0, we should leverage on the library.