### PR TITLE
fix #4166 Allow an assembly to create multiple dynamic API modules based on type

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Configuration/ControllerAssemblySettingList.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/ControllerAssemblySettingList.cs
@@ -8,10 +8,9 @@ namespace Abp.AspNetCore.Configuration
 {
     public class ControllerAssemblySettingList : List<AbpControllerAssemblySetting>
     {
-        [CanBeNull]
-        public AbpControllerAssemblySetting GetSettingOrNull(Type controllerType)
+        public List<AbpControllerAssemblySetting> GetSettings(Type controllerType)
         {
-            return this.FirstOrDefault(controllerSetting => controllerSetting.Assembly == controllerType.GetAssembly());
+            return this.Where(controllerSetting => controllerSetting.Assembly == controllerType.GetAssembly()).ToList();
         }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Conventions/AbpAppServiceConvention.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Conventions/AbpAppServiceConvention.cs
@@ -255,7 +255,8 @@ namespace Abp.AspNetCore.Mvc.Conventions
         [CanBeNull]
         private AbpControllerAssemblySetting GetControllerSettingOrNull(Type controllerType)
         {
-            return _configuration.Value.ControllerAssemblySettings.GetSettingOrNull(controllerType);
+            var settings = _configuration.Value.ControllerAssemblySettings.GetSettings(controllerType);
+            return settings.FirstOrDefault(setting => setting.TypePredicate(controllerType));
         }
 
         private static AttributeRouteModel CreateAbpServiceAttributeRouteModel(string moduleName, string controllerName, ActionModel action)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Providers/AbpAppServiceControllerFeatureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Providers/AbpAppServiceControllerFeatureProvider.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Reflection;
 using Abp.Application.Services;
 using Abp.AspNetCore.Configuration;
+using Abp.Collections.Extensions;
 using Abp.Dependency;
 using Abp.Reflection;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -37,8 +38,8 @@ namespace Abp.AspNetCore.Mvc.Providers
                 return false;
             }
 
-            var configuration = _iocResolver.Resolve<AbpAspNetCoreConfiguration>().ControllerAssemblySettings.GetSettingOrNull(type);
-            return configuration != null && configuration.TypePredicate(type);
+            var settings = _iocResolver.Resolve<AbpAspNetCoreConfiguration>().ControllerAssemblySettings.GetSettings(type);
+            return settings.Any(setting => setting.TypePredicate(type));
         }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Proxying/AspNetCoreApiDescriptionModelProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Proxying/AspNetCoreApiDescriptionModelProvider.cs
@@ -163,7 +163,7 @@ namespace Abp.AspNetCore.Mvc.Proxying
                 return AbpControllerAssemblySetting.DefaultServiceModuleName;
             }
 
-            foreach (var controllerSetting in _configuration.ControllerAssemblySettings)
+            foreach (var controllerSetting in _configuration.ControllerAssemblySettings.Where(setting => setting.TypePredicate(controllerType)))
             {
                 if (Equals(controllerType.GetAssembly(), controllerSetting.Assembly))
                 {


### PR DESCRIPTION
fix #4166 Allow an assembly to create multiple dynamic API modules based on type.

If `TypePredicate `gets multiple `AbpControllerAssemblySetting`, The first one is used by default.
The same applies to generating proxy scripts.