### PR TITLE
Fixed failing AutoMapper tests

### DIFF
--- a/src/Abp.AutoMapper/AutoMapper/AutoMapperConfigurationExtensions.cs
+++ b/src/Abp.AutoMapper/AutoMapper/AutoMapperConfigurationExtensions.cs
@@ -9,16 +9,21 @@ namespace Abp.AutoMapper
 {
     internal static class AutoMapperConfigurationExtensions
     {
+        private static readonly object SyncObj = new object();
+
         public static void CreateAutoAttributeMaps(this IMapperConfigurationExpression configuration, Type type)
         {
-            foreach (var autoMapAttribute in type.GetTypeInfo().GetCustomAttributes<AutoMapAttributeBase>())
+            lock (SyncObj)
             {
-                autoMapAttribute.CreateMap(configuration, type);
+                foreach (var autoMapAttribute in type.GetTypeInfo().GetCustomAttributes<AutoMapAttributeBase>())
+                {
+                    autoMapAttribute.CreateMap(configuration, type);
+                }   
             }
         }
+
         public static void CreateAutoAttributeMaps(this IMapperConfigurationExpression configuration, Type type, Type[] targetTypes, MemberList memberList)
         {
-
             //Get all the properties in the source that have the AutoMapKeyAttribute
             var sourceKeysPropertyInfo = type.GetProperties()
                                              .Where(w => w.GetCustomAttribute<AutoMapKeyAttribute>() != null)

--- a/test/Abp.Zero.SampleApp.EntityFrameworkCore/Abp.Zero.SampleApp.EntityFrameworkCore.csproj
+++ b/test/Abp.Zero.SampleApp.EntityFrameworkCore/Abp.Zero.SampleApp.EntityFrameworkCore.csproj
@@ -33,8 +33,4 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.3" />
-  </ItemGroup>
-
 </Project>

--- a/test/Abp.ZeroCore.SampleApp/Abp.ZeroCore.SampleApp.csproj
+++ b/test/Abp.ZeroCore.SampleApp/Abp.ZeroCore.SampleApp.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Abp.AutoMapper\Abp.AutoMapper.csproj" />
     <ProjectReference Include="..\..\src\Abp.ZeroCore.EntityFrameworkCore\Abp.ZeroCore.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Abp.ZeroCore.IdentityServer4.EntityFrameworkCore\Abp.ZeroCore.IdentityServer4.EntityFrameworkCore.csproj" />

--- a/test/aspnet-mvc-demo/AbpAspNetMvcDemo/AbpAspNetMvcDemo.csproj
+++ b/test/aspnet-mvc-demo/AbpAspNetMvcDemo/AbpAspNetMvcDemo.csproj
@@ -471,7 +471,7 @@
     <Error Condition="!Exists('..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v15.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
- Fixes failing AutoMapper tests
- Removed DotNetCliToolReference from csproj files since it is included in the .Net Core SDK, See https://aka.ms/dotnetclitools-in-box