### PR TITLE
fix #4174 EntityHistoryInterceptor handle async methods.

### DIFF
--- a/src/Abp/EntityHistory/EntityHistoryInterceptor.cs
+++ b/src/Abp/EntityHistory/EntityHistoryInterceptor.cs
@@ -1,5 +1,7 @@
 ﻿using Castle.DynamicProxy;
 using System.Linq;
+using System.Threading.Tasks;
+using Abp.Threading;
 
 namespace Abp.EntityHistory
 {
@@ -24,9 +26,50 @@ namespace Abp.EntityHistory
                 return;
             }
 
+            if (invocation.Method.IsAsync())
+            {
+                PerformAsyncUow(invocation, useCaseAttribute);
+            }
+            else
+            {
+                PerformSyncUow(invocation, useCaseAttribute);
+            }
+        }
+
+        private void PerformSyncUow(IInvocation invocation, UseCaseAttribute useCaseAttribute)
+        {
             using (ReasonProvider.Use(useCaseAttribute.Description))
             {
                 invocation.Proceed();
+            }
+        }
+
+        private void PerformAsyncUow(IInvocation invocation, UseCaseAttribute useCaseAttribute)
+        {
+            if (invocation.Method.ReturnType == typeof(Task))
+            {
+                invocation.ReturnValue = InternalAsyncHelper.AwaitTaskWithUsingActionAndFinally(
+                    () => ReasonProvider.Use(useCaseAttribute.Description),
+                    () =>
+                    {
+                        invocation.Proceed();
+                        return (Task) invocation.ReturnValue;
+                    },
+                    exception => { }
+                );
+            }
+            else //Task<TResult>
+            {
+                invocation.ReturnValue = InternalAsyncHelper.CallAwaitTaskWithUsingActionAndFinallyAndGetResult(
+                    invocation.Method.ReturnType.GenericTypeArguments[0],
+                    () => ReasonProvider.Use(useCaseAttribute.Description),
+                    () =>
+                    {
+                        invocation.Proceed();
+                        return invocation.ReturnValue;
+                    },
+                    exception => { }
+                );
             }
         }
     }

--- a/src/Abp/Threading/InternalAsyncHelper.cs
+++ b/src/Abp/Threading/InternalAsyncHelper.cs
@@ -174,5 +174,58 @@ namespace Abp.Threading
                 .MakeGenericMethod(taskReturnType)
                 .Invoke(null, new object[] { actualReturnValue, preAction, postAction, finalAction });
         }
+
+        public static async Task AwaitTaskWithUsingActionAndFinally(Func<IDisposable> usingAction, Func<Task> action, Action<Exception> finalAction)
+        {
+            Exception exception = null;
+
+            try
+            {
+                using (usingAction())
+                {
+                    await action();
+                }
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+                throw;
+            }
+            finally
+            {
+                finalAction(exception);
+            }
+        }
+
+
+        public static async Task<T> AwaitTaskWithUsingActionAndFinallyAndGetResult<T>(Func<IDisposable> usingAction, Func<object> action, Action<Exception> finalAction)
+        {
+            Exception exception = null;
+
+            try
+            {
+                using (usingAction())
+                {
+                    return await (Task<T>)action();
+                }
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+                throw;
+            }
+            finally
+            {
+                finalAction(exception);
+            }
+        }
+
+        public static object CallAwaitTaskWithUsingActionAndFinallyAndGetResult(Type taskReturnType, Func<IDisposable> usingAction, Func<object> action, Action<Exception> finalAction)
+        {
+            return typeof(InternalAsyncHelper)
+                .GetMethod("AwaitTaskWithUsingActionAndFinallyAndGetResult", BindingFlags.Public | BindingFlags.Static)
+                .MakeGenericMethod(taskReturnType)
+                .Invoke(null, new object[] { usingAction, action, finalAction });
+        }
     }
 }

--- a/test/Abp.AspNetCore.Tests/Tests/EntityHistory_Reason_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/EntityHistory_Reason_Tests.cs
@@ -1,4 +1,5 @@
-﻿using Abp.AspNetCore.EntityHistory;
+﻿using System.Threading.Tasks;
+using Abp.AspNetCore.EntityHistory;
 using Abp.Dependency;
 using Abp.EntityHistory;
 using Shouldly;
@@ -42,6 +43,19 @@ namespace Abp.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task Should_Intercept_UseCase_Marked_Async_Methods()
+        {
+            await _nonUseCaseMarkedClass.UseCaseMarkedAsyncMethod();
+        }
+
+
+        [Fact]
+        public async Task Should_Intercept_UseCase_Marked_Async_Methods_WithResult()
+        {
+            await _nonUseCaseMarkedClass.UseCaseMarkedAsyncMethodWithResult();
+        }
+
+        [Fact]
         public void Should_Not_Intercept_No_UseCase_Marked_Method()
         {
             _nonUseCaseMarkedClass.AnotherMethod();
@@ -66,6 +80,21 @@ namespace Abp.AspNetCore.Tests
         public virtual void UseCaseMarkedMethod()
         {
             ReasonProvider.Reason.ShouldBe(Consts.UseCaseDescription);
+        }
+
+        [UseCase(Description = Consts.UseCaseDescription)]
+        public virtual async Task UseCaseMarkedAsyncMethod()
+        {
+            ReasonProvider.Reason.ShouldBe(Consts.UseCaseDescription);
+
+            await Task.CompletedTask;
+        }
+
+        [UseCase(Description = Consts.UseCaseDescription)]
+        public virtual async Task<string> UseCaseMarkedAsyncMethodWithResult()
+        {
+            ReasonProvider.Reason.ShouldBe(Consts.UseCaseDescription);
+            return await Task.FromResult("");
         }
 
         public virtual void AnotherMethod()


### PR DESCRIPTION
Using `ReasonProvider.Use` with an asynchronous method in an interceptor may not work.
The asynchronous method may not have been executed yet, and the scope is over.
```c#
Using (ReasonProvider.Use(useCaseAttribute.Description))
{
    //...
}
```

So I made the asynchronous method execute in the `ReasonProvider.Use` scope with some workarounds.