### PR TITLE
Configurable MvcOptions.Filters

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/AbpMvcOptionsExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/AbpMvcOptionsExtensions.cs
@@ -2,6 +2,7 @@
 using Abp.AspNetCore.Mvc.Authorization;
 using Abp.AspNetCore.Mvc.Conventions;
 using Abp.AspNetCore.Mvc.ExceptionHandling;
+using Abp.AspNetCore.Mvc.Filters;
 using Abp.AspNetCore.Mvc.ModelBinding;
 using Abp.AspNetCore.Mvc.Results;
 using Abp.AspNetCore.Mvc.Uow;
@@ -16,23 +17,13 @@ namespace Abp.AspNetCore.Mvc
         public static void AddAbp(this MvcOptions options, IServiceCollection services)
         {
             AddConventions(options, services);
-            AddFilters(options);
+            AbpMvcFilters.Register(options.Filters);
             AddModelBinders(options);
         }
 
         private static void AddConventions(MvcOptions options, IServiceCollection services)
         {
             options.Conventions.Add(new AbpAppServiceConvention(services));
-        }
-
-        private static void AddFilters(MvcOptions options)
-        {
-            options.Filters.AddService(typeof(AbpAuthorizationFilter));
-            options.Filters.AddService(typeof(AbpAuditActionFilter));
-            options.Filters.AddService(typeof(AbpValidationActionFilter));
-            options.Filters.AddService(typeof(AbpUowActionFilter));
-            options.Filters.AddService(typeof(AbpExceptionFilter));
-            options.Filters.AddService(typeof(AbpResultFilter));
         }
 
         private static void AddModelBinders(MvcOptions options)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Filters/AbpMvcFilters.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Filters/AbpMvcFilters.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Abp.AspNetCore.Mvc.Auditing;
+using Abp.AspNetCore.Mvc.Authorization;
+using Abp.AspNetCore.Mvc.ExceptionHandling;
+using Abp.AspNetCore.Mvc.Results;
+using Abp.AspNetCore.Mvc.Uow;
+using Abp.AspNetCore.Mvc.Validation;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Abp.AspNetCore.Mvc.Filters
+{
+    public class AbpMvcFilters
+    {
+        public static void Register(FilterCollection filterCollection)
+        {
+            foreach (var filter in Filters)
+            {
+                filterCollection.AddService(filter);
+            }
+        }
+
+        public static IList<Type> Filters = new List<Type>()
+        {
+            typeof(AbpAuthorizationFilter),
+            typeof(AbpAuditActionFilter),
+            typeof(AbpValidationActionFilter),
+            typeof(AbpUowActionFilter),
+            typeof(AbpExceptionFilter),
+            typeof(AbpResultFilter)
+        };
+
+    }
+}


### PR DESCRIPTION
This is a PR proposing a way to configure the MvcFilters.

Currently, there is no way to remove / change a given MVC Filter. 

This is a proposal that would allow one to modify the AbpMvcFilters.Filters collection before it gets registered.