### PR TITLE
Fix #4212

### DIFF
--- a/src/Abp.Web.Common/Web/Api/ProxyScripting/Generators/ProxyScriptingJsFuncHelper.cs
+++ b/src/Abp.Web.Common/Web/Api/ProxyScripting/Generators/ProxyScriptingJsFuncHelper.cs
@@ -125,7 +125,7 @@ namespace Abp.Web.Api.ProxyScripting.Generators
 
             foreach (var prm in parameters)
             {
-                sb.AppendLine($"{new string(' ', indent)}  '{prm.Name}': {GetParamNameInJsFunc(prm)}");
+                sb.AppendLine($"{new string(' ', indent)}  '{prm.Name}': {GetParamNameInJsFunc(prm)},");
             }
 
             sb.Append(new string(' ', indent) + "}");


### PR DESCRIPTION
Leaves a trailing comma at the end of the object literal's definition, so the generated output requires support for ECMAScript 5 or later.