### PR TITLE
Fix URL about the documentation of IdentityServerConfig Class

### DIFF
--- a/doc/WebSite/Zero/Identity-Server.md
+++ b/doc/WebSite/Zero/Identity-Server.md
@@ -92,7 +92,7 @@ We added **services.AddIdentityServer()** just after
 We have used the IdentityServerConfig class to get identity resources, api
 resources and clients. You can find more information about this class in
 its own
-[documentation](https://identityserver4.readthedocs.io/en/release/quickstarts/1_client_credentials.html).
+[documentation](http://docs.identityserver.io/en/latest/quickstarts/1_client_credentials.html).
 For the simplest case, it can be a static class like below:
 
     public static class IdentityServerConfig


### PR DESCRIPTION
SORRY
This page does not exist yet. https://identityserver4.readthedocs.io/en/release/quickstarts/1_client_credentials.html