### PR TITLE
Entity History Support for EF6

### DIFF
--- a/doc/WebSite/Entity-History.md
+++ b/doc/WebSite/Entity-History.md
@@ -1,4 +1,4 @@
-### Introduction
+## Introduction
 
 ASP.NET Boilerplate provides an infrastructure to automatically log all
 entity and property changes.
@@ -24,13 +24,13 @@ get the current UserId and TenantId.
 
 No entities are automatically tracked by default. You should configure entities either by using the startup configuration or via attributes.
 
-#### About IEntityHistoryStore
+## About IEntityHistoryStore
 
 The Entity History tracking system uses **IEntityHistoryStore** to
 save change information. While you can implement it in your own way,
 it's fully implemented in the **Module Zero** project.
 
-### Configuration
+## Configuration
 
 To configure Entity History, you can use the
 **Configuration.EntityHistory** property
@@ -38,6 +38,7 @@ in your [module](/Pages/Documents/Module-System)'s PreInitialize method.
 Entity History is **enabled by default**.
 You can disable it as shown below:
 
+```csharp
     public class MyModule : AbpModule
     {
         public override void PreInitialize()
@@ -47,6 +48,7 @@ You can disable it as shown below:
 
         //...
     }
+```
 
 Here are the Entity History configuration properties:
 
@@ -56,20 +58,40 @@ Here are the Entity History configuration properties:
     are saved for users that are not logged in to the application.
     Default: **false**.
 -   **Selectors**: Used to select entities to save change logs.
+-   **IgnoredTypes**: Used to skip entities when saving change logs.
 
 **Selectors** is a list of predicates to select entities to save
 change logs. A selector has a unique **name** and a **predicate**.
 For example, a selector can be used to select **full audited entities**.
 It's defined as shown below:
 
+```csharp
     Configuration.EntityHistory.Selectors.Add(
         new NamedTypeSelector(
             "Abp.FullAuditedEntities",
             type => typeof (IFullAudited).IsAssignableFrom(type)
         )
     );
+```
 
 You can add your selectors in your module's PreInitialize method.
+
+**IgnoredTypes** is a list of entity types to be ignored when saving
+change logs.
+For example, we configured all entities that implements **ISetting** to be tracked by the Entity History system.
+In order to skip entity history for **SecretSetting** which implements **ISetting**.
+It can be defined as shown below:
+
+```csharp
+    Configuration.EntityHistory.IgnoredTypes.AddIfNotContains(typeof(SecretSetting));
+```
+
+You can add your ignored types in your module's PreInitialize method.
+
+#### Notes
+-   **IgnoredTypes** takes priority over the **Selectors** when saving change log for the entities.
+-   **EntityChangeSet**, **EntityChange**, **EntityPropertyChange** are added to **IgnoredTypes** by **default** in the Entity History system.
+-   **AuditLog** is added to **IgnoredTypes** by **default** in Module Zero project.
 
 ### Enable/Disable by attributes
 
@@ -77,6 +99,7 @@ While you can select tracked entities by configuration, you can use the
 **Audited** and **DisableAuditing** attributes for a single
 **entity** or an individual **property**. Example:
 
+```csharp
     [Audited]
     public class MyEntity : Entity
     {
@@ -87,6 +110,7 @@ While you can select tracked entities by configuration, you can use the
 
         public long MyProperty3 { get; set; }
     }
+```
 
 All properties of MyEntity are tracked except MyProperty2 since it's
 explicitly disabled. The Audited attribute can be used to
@@ -109,10 +133,11 @@ why these changes were made.
 The **Abp.AspNetCore** package implements **HttpRequestEntityChangeSetReasonProvider**,
 which returns the HttpContext.Request's URL as the Reason.
 
-#### UseCase Attribute
+### UseCase Attribute
 
 The preferred approach is using the **UseCase** attribute. Example:
 
+```csharp
     [UseCase(Description = "Assign an issue to a user")]
     public virtual async Task AssignIssueAsync(AssignIssueInput input)
     {
@@ -120,8 +145,9 @@ The preferred approach is using the **UseCase** attribute. Example:
 
         await _unitOfWorkManager.Current.SaveChangesAsync();
     }
+```
 
-##### UseCase Attribute Restrictions
+#### UseCase Attribute Restrictions
 
 You can use the UseCase attribute for:
 
@@ -131,11 +157,12 @@ You can use the UseCase attribute for:
     Controllers**.
 -   All **protected virtual** methods.
 
-#### IEntityChangeSetReasonProvider
+### IEntityChangeSetReasonProvider
 
 In some cases, you may need to change/override the Reason value for a limited scope.
 You can use the **IEntityChangeSetReasonProvider.Use(...)** method as shown below:
 
+```csharp
     public class MyService
     {
         private readonly IEntityChangeSetReasonProvider _reasonProvider;
@@ -156,19 +183,49 @@ You can use the **IEntityChangeSetReasonProvider.Use(...)** method as shown belo
             }
         }
     }
+```
 
 The Use method returns an IDisposable and it **must be disposed**. Once the return
 value is disposed, the Reason is automatically restored to the previous value.
+
+## ORM Integrations
+
+Entity History in **Module Zero** project is implemented for
+[Entity Framework](EntityFramework-Integration.md) 6.x and
+[Entity Framework Core](Entity-Framework-Core.md) with the following logics:
+
+### Entity Changes
+
+-   An entity must not be one of the **IgnoredTypes**.
+-   An entity must be **public** in order to be saved in the change logs.
+    **private**, **protected**, **internal** entities are ignored.
+-   **DisableAuditing** takes priority over the **Audited** attribute when saving entity changes.
+-   An entity must satisfy one of the predicates from **Selectors**.
+
+### Property Changes
+
+-   Primary key properties are excluded from an entitiy's property changes.
+-   **DisableAuditing** takes priority over the **Audited** attribute when saving property changes.
+-   Property changes would only be saved if there are changes between original/new values.
+    **Audited** attribute will make property changes being saved even if there is no change between original/new values.
+
+## Entity Framework Core
+
+-   Entity changes only work for entities and owned entities.
+-   Property changes only work for shadow properties and scalar properties (e.g. string, int, bool...)
 
 ### Owned Entities
 
 Entity History tracks changes to owned entities as entity changes.
 The primary key of the owner entity is saved as the **entity id**.
 
-### Notes
+## Entity Framework 6.x
 
--   A property must be **public** in order to be saved in the change logs.
-    Private and protected properties are ignored.
--   DisableAuditing takes priority over the Audited attribute.
--   Entity History only works for entities and owned entities.
--   Entity History only works for scalar properties, e.g. string, int, bool...
+-   Entity changes only work for all entities.
+-   Property changes only work for complex type properties and scalar properties (e.g. string, int, bool...)
+
+### Complex Type Properties
+
+Entity History tracks changes to complex type properties as property changes.
+The original/new values of a complex type property will be a serialized JSON string of the complex type property
+

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -184,7 +184,7 @@ namespace Abp.EntityHistory
                 ChangeType = changeType,
                 EntityEntry = entityEntry, // [NotMapped]
                 EntityId = entityId,
-                EntityTypeFullName = entityType.FullName,
+                EntityTypeFullName = GetEntityBaseType(entityEntry).FullName,
                 TenantId = AbpSession.TenantId
             };
 
@@ -310,14 +310,13 @@ namespace Abp.EntityHistory
                 return false;
             }
 
-            var entityType = entityEntry.Entity.GetType();
-
-            if (!EntityHelper.IsEntity(entityType))
+            var entityBaseType = GetEntityBaseType(entityEntry);
+            if (!EntityHelper.IsEntity(entityBaseType))
             {
                 return false;
             }
 
-            var shouldSaveEntityHistoryForType = ShouldSaveEntityHistoryForType(entityType);
+            var shouldSaveEntityHistoryForType = ShouldSaveEntityHistoryForType(entityBaseType);
             if (shouldSaveEntityHistoryForType.HasValue)
             {
                 return shouldSaveEntityHistoryForType.Value;
@@ -416,11 +415,12 @@ namespace Abp.EntityHistory
                 /* Update entity id */
 
                 var entityEntry = entityChange.EntityEntry.As<DbEntityEntry>();
-                entityChange.EntityId = GetEntityId(entityEntry, GetEntityType(context, entityEntry));
+                var entityType = GetEntityType(context.As<ObjectContext>(), GetEntityBaseType(entityEntry));
+                entityChange.EntityId = GetEntityId(entityEntry, entityType);
 
                 /* Update foreign keys */
 
-                var entityType = GetEntityType(context, entityEntry);
+                
                 var foreignKeys = entityType.NavigationProperties;
 
                 foreach (var foreignKey in foreignKeys)

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -1,0 +1,428 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Data.Entity.Core;
+using System.Data.Entity.Core.Metadata.Edm;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Transactions;
+using Abp.Auditing;
+using Abp.Dependency;
+using Abp.Domain.Entities;
+using Abp.Domain.Entities.Auditing;
+using Abp.Domain.Uow;
+using Abp.Events.Bus.Entities;
+using Abp.Extensions;
+using Abp.Json;
+using Abp.Runtime.Session;
+using Abp.Timing;
+using Castle.Core.Logging;
+using JetBrains.Annotations;
+
+namespace Abp.EntityHistory
+{
+    public class EntityHistoryHelper : IEntityHistoryHelper, ITransientDependency
+    {
+        public ILogger Logger { get; set; }
+        public IAbpSession AbpSession { get; set; }
+        public IClientInfoProvider ClientInfoProvider { get; set; }
+        public IEntityChangeSetReasonProvider EntityChangeSetReasonProvider { get; set; }
+        public IEntityHistoryStore EntityHistoryStore { get; set; }
+
+        private readonly IEntityHistoryConfiguration _configuration;
+        private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+        private bool IsEntityHistoryEnabled
+        {
+            get
+            {
+                if (!_configuration.IsEnabled)
+                {
+                    return false;
+                }
+
+                if (!_configuration.IsEnabledForAnonymousUsers && (AbpSession?.UserId == null))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        public EntityHistoryHelper(
+            IEntityHistoryConfiguration configuration,
+            IUnitOfWorkManager unitOfWorkManager)
+        {
+            _configuration = configuration;
+            _unitOfWorkManager = unitOfWorkManager;
+
+            AbpSession = NullAbpSession.Instance;
+            Logger = NullLogger.Instance;
+            ClientInfoProvider = NullClientInfoProvider.Instance;
+            EntityChangeSetReasonProvider = NullEntityChangeSetReasonProvider.Instance;
+            EntityHistoryStore = NullEntityHistoryStore.Instance;
+        }
+
+        public virtual EntityChangeSet CreateEntityChangeSet(DbContext context)
+        {
+            var changeSet = new EntityChangeSet
+            {
+                Reason = EntityChangeSetReasonProvider.Reason.TruncateWithPostfix(EntityChangeSet.MaxReasonLength),
+
+                // Fill "who did this change"
+                BrowserInfo = ClientInfoProvider.BrowserInfo.TruncateWithPostfix(EntityChangeSet.MaxBrowserInfoLength),
+                ClientIpAddress = ClientInfoProvider.ClientIpAddress.TruncateWithPostfix(EntityChangeSet.MaxClientIpAddressLength),
+                ClientName = ClientInfoProvider.ComputerName.TruncateWithPostfix(EntityChangeSet.MaxClientNameLength),
+                ImpersonatorTenantId = AbpSession.ImpersonatorTenantId,
+                ImpersonatorUserId = AbpSession.ImpersonatorUserId,
+                TenantId = AbpSession.TenantId,
+                UserId = AbpSession.UserId
+            };
+
+            if (!IsEntityHistoryEnabled)
+            {
+                return changeSet;
+            }
+
+            foreach (var entry in context.ChangeTracker.Entries())
+            {
+                var shouldSaveEntityHistory = ShouldSaveEntityHistory(entry);
+                if (!shouldSaveEntityHistory && !HasAuditedProperties(entry))
+                {
+                    continue;
+                }
+
+                var entityChange = CreateEntityChange(entry, GetEntityKey(context, entry), shouldSaveEntityHistory);
+                if (entityChange == null)
+                {
+                    continue;
+                }
+
+                changeSet.EntityChanges.Add(entityChange);
+            }
+
+            return changeSet;
+        }
+
+        public virtual async Task SaveAsync(DbContext context, EntityChangeSet changeSet)
+        {
+            if (!IsEntityHistoryEnabled)
+            {
+                return;
+            }
+
+            if (changeSet.EntityChanges.Count == 0)
+            {
+                return;
+            }
+
+            UpdateChangeSet(context, changeSet);
+
+            using (var uow = _unitOfWorkManager.Begin(TransactionScopeOption.Suppress))
+            {
+                await EntityHistoryStore.SaveAsync(changeSet);
+                await uow.CompleteAsync();
+            }
+        }
+
+        [CanBeNull]
+        private EntityChange CreateEntityChange(DbEntityEntry entityEntry, EntityKey entityKey, bool shouldSaveEntityHistory)
+        {
+            EntityChangeType changeType;
+            switch (entityEntry.State)
+            {
+                case EntityState.Added:
+                    changeType = EntityChangeType.Created;
+                    break;
+                case EntityState.Deleted:
+                    changeType = EntityChangeType.Deleted;
+                    break;
+                case EntityState.Modified:
+                    changeType = IsDeleted(entityEntry) ? EntityChangeType.Deleted : EntityChangeType.Updated;
+                    break;
+                case EntityState.Detached:
+                case EntityState.Unchanged:
+                default:
+                    Logger.Error("Unexpected EntityState!");
+                    return null;
+            }
+
+            var entityId = GetEntityId(entityKey);
+            if (entityId == null && changeType != EntityChangeType.Created)
+            {
+                Logger.Error("Unexpected null value for entityId!");
+                return null;
+            }
+
+            var entityType = entityEntry.Entity.GetType();
+            var entityChange = new EntityChange
+            {
+                ChangeType = changeType,
+                EntityEntry = entityEntry, // [NotMapped]
+                EntityId = entityId,
+                EntityTypeFullName = entityType.FullName,
+                PropertyChanges = GetPropertyChanges(entityEntry, entityKey, shouldSaveEntityHistory),
+                TenantId = AbpSession.TenantId
+            };
+
+            if (!shouldSaveEntityHistory && entityChange.PropertyChanges.Count == 0)
+            {
+                return null;
+            }
+
+            return entityChange;
+        }
+
+        private DateTime GetChangeTime(EntityChange entityChange)
+        {
+            var entity = entityChange.EntityEntry.As<DbEntityEntry>().Entity;
+            switch (entityChange.ChangeType)
+            {
+                case EntityChangeType.Created:
+                    return (entity as IHasCreationTime)?.CreationTime ?? Clock.Now;
+                case EntityChangeType.Deleted:
+                    return (entity as IHasDeletionTime)?.DeletionTime ?? Clock.Now;
+                case EntityChangeType.Updated:
+                    return (entity as IHasModificationTime)?.LastModificationTime ?? Clock.Now;
+                default:
+                    Logger.Error("Unexpected EntityState!");
+                    return Clock.Now;
+            }
+        }
+
+        private EntityKey GetEntityKey(DbContext context, DbEntityEntry entry)
+        {
+            var objectStateEntry = ((IObjectContextAdapter)context).ObjectContext.ObjectStateManager.GetObjectStateEntry(entry.Entity);
+            return objectStateEntry.EntityKey;
+        }
+
+        private string GetEntityId(EntityKey entityKey)
+        {
+            var primaryKeys = entityKey.EntityKeyValues;
+            return primaryKeys.First().Value?.ToJsonString();
+        }
+
+        /// <summary>
+        /// Gets the property changes for this entry.
+        /// </summary>
+        private ICollection<EntityPropertyChange> GetPropertyChanges(DbEntityEntry entityEntry, EntityKey entityKey, bool shouldSaveEntityHistory)
+        {
+            var propertyChanges = new List<EntityPropertyChange>();
+            var propertyNames = entityEntry.CurrentValues.PropertyNames;
+            var isCreated = IsCreated(entityEntry);
+            var isDeleted = IsDeleted(entityEntry);
+
+            foreach (var propertyName in propertyNames)
+            {
+                var propertyEntry = entityEntry.Property(propertyName);
+                if (ShouldSavePropertyHistory(propertyEntry, entityKey, shouldSaveEntityHistory, isCreated || isDeleted))
+                {
+                    var propertyInfo = entityEntry.Entity.GetType().GetProperty(propertyEntry.Name);
+                    propertyChanges.Add(new EntityPropertyChange
+                    {
+                        NewValue = isDeleted ? null : propertyEntry.CurrentValue.ToJsonString().TruncateWithPostfix(EntityPropertyChange.MaxValueLength),
+                        OriginalValue = isCreated ? null : propertyEntry.OriginalValue.ToJsonString().TruncateWithPostfix(EntityPropertyChange.MaxValueLength),
+                        PropertyName = propertyEntry.Name,
+                        PropertyTypeFullName = propertyInfo.PropertyType.FullName,
+                        TenantId = AbpSession.TenantId
+                    });
+                }
+            }
+
+            return propertyChanges;
+        }
+
+        private bool HasAuditedProperties(DbEntityEntry entityEntry)
+        {
+            var propertyNames = entityEntry.CurrentValues.PropertyNames;
+            var entityType = entityEntry.Entity.GetType();
+            return propertyNames.Any(p => entityType.GetProperty(p)?.IsDefined(typeof(AuditedAttribute)) ?? false);
+        }
+
+        private bool IsCreated(DbEntityEntry entityEntry)
+        {
+            return entityEntry.State == EntityState.Added;
+        }
+
+        private bool IsDeleted(DbEntityEntry entityEntry)
+        {
+            if (entityEntry.State == EntityState.Deleted)
+            {
+                return true;
+            }
+
+            var entity = entityEntry.Entity;
+            return entity is ISoftDelete && entity.As<ISoftDelete>().IsDeleted;
+        }
+
+        private bool ShouldSaveEntityHistory(DbEntityEntry entityEntry)
+        {
+            if (entityEntry.State == EntityState.Detached ||
+                entityEntry.State == EntityState.Unchanged)
+            {
+                return false;
+            }
+
+            if (_configuration.IgnoredTypes.Any(t => t.IsInstanceOfType(entityEntry.Entity)))
+            {
+                return false;
+            }
+
+            var entityType = entityEntry.Entity.GetType();
+
+            if (!EntityHelper.IsEntity(entityType))
+            {
+                return false;
+            }
+
+            var shouldSaveEntityHistoryForType = ShouldSaveEntityHistoryForType(entityType);
+            if (shouldSaveEntityHistoryForType.HasValue)
+            {
+                return shouldSaveEntityHistoryForType.Value;
+            }
+
+            return false;
+        }
+
+        private bool? ShouldSaveEntityHistoryForType(Type entityType)
+        {
+            if (!entityType.IsPublic)
+            {
+                return false;
+            }
+
+            if (entityType.GetTypeInfo().IsDefined(typeof(DisableAuditingAttribute), true))
+            {
+                return false;
+            }
+
+            if (entityType.GetTypeInfo().IsDefined(typeof(AuditedAttribute), true))
+            {
+                return true;
+            }
+
+            if (_configuration.Selectors.Any(selector => selector.Predicate(entityType)))
+            {
+                return true;
+            }
+
+            return null;
+        }
+
+        private bool ShouldSavePropertyHistory(DbPropertyEntry propertyEntry, EntityKey entityKey, bool shouldSaveEntityHistory, bool defaultValue)
+        {
+            if (entityKey.EntityKeyValues.Any(k => k.Key ==  propertyEntry.Name))
+            {
+                return false;
+            }
+
+            var propertyInfo = propertyEntry.EntityEntry.GetType().GetProperty(propertyEntry.Name);
+
+            var shouldSavePropertyHistoryForInfo = ShouldSavePropertyHistoryForInfo(propertyInfo, shouldSaveEntityHistory);
+            if (shouldSavePropertyHistoryForInfo.HasValue)
+            {
+                return shouldSavePropertyHistoryForInfo.Value;
+            }
+
+            var isModified = !(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null);
+            if (isModified)
+            {
+                return true;
+            }
+
+            return defaultValue;
+        }
+
+        private bool? ShouldSavePropertyHistoryForInfo(PropertyInfo propertyInfo, bool shouldSaveEntityHistory)
+        {
+            if (propertyInfo != null && propertyInfo.IsDefined(typeof(DisableAuditingAttribute), true))
+            {
+                return false;
+            }
+
+            if (!shouldSaveEntityHistory)
+            {
+                // Should not save property history if property is not audited
+                if (propertyInfo == null || !propertyInfo.IsDefined(typeof(AuditedAttribute), true))
+                {
+                    return false;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Updates change time, entity id and foreign keys after SaveChanges is called.
+        /// </summary>
+        private void UpdateChangeSet(DbContext context, EntityChangeSet changeSet)
+        {
+            foreach (var entityChange in changeSet.EntityChanges)
+            {
+                /* Update change time */
+
+                entityChange.ChangeTime = GetChangeTime(entityChange);
+
+                /* Update entity id */
+
+                var entityEntry = entityChange.EntityEntry.As<DbEntityEntry>();
+                entityChange.EntityId = GetEntityId(GetEntityKey(context, entityEntry));
+
+                /* Update foreign keys */
+
+                var metadataWorkspace = ((IObjectContextAdapter)context).ObjectContext.MetadataWorkspace;
+                /* Get the mapping between Clr types and metadata OSpace */
+                var objectItemCollection = ((ObjectItemCollection)metadataWorkspace.GetItemCollection(DataSpace.OSpace));
+                /* Get metadata for given Clr type */
+                var entityMetadata = metadataWorkspace
+                    .GetItems<EntityType>(DataSpace.OSpace)
+                    .Single(e => objectItemCollection.GetClrType(e) == entityEntry.Entity.GetType());
+                var foreignKeys = entityMetadata.NavigationProperties;
+
+                foreach (var foreignKey in foreignKeys)
+                {
+                    foreach (var property in foreignKey.GetDependentProperties())
+                    {
+                        var propertyEntry = entityEntry.Property(property.Name);
+                        var propertyChange = entityChange.PropertyChanges.FirstOrDefault(pc => pc.PropertyName == property.Name);
+
+                        if (propertyChange == null)
+                        {
+                            if (!(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null))
+                            {
+                                // Add foreign key
+                                entityChange.PropertyChanges.Add(new EntityPropertyChange
+                                {
+                                    NewValue = propertyEntry.CurrentValue.ToJsonString(),
+                                    OriginalValue = propertyEntry.OriginalValue.ToJsonString(),
+                                    PropertyName = property.Name,
+                                    PropertyTypeFullName = property.TypeUsage.EdmType.FullName
+                                });
+                            }
+
+                            continue;
+                        }
+
+                        if (propertyChange.OriginalValue == propertyChange.NewValue)
+                        {
+                            var newValue = propertyEntry.CurrentValue.ToJsonString();
+                            if (newValue == propertyChange.NewValue)
+                            {
+                                // No change
+                                entityChange.PropertyChanges.Remove(propertyChange);
+                            }
+                            else
+                            {
+                                // Update foreign key
+                                propertyChange.NewValue = newValue.TruncateWithPostfix(EntityPropertyChange.MaxValueLength);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Core;
 using System.Data.Entity.Core.Metadata.Edm;
+using System.Data.Entity.Core.Objects;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
 using System.Reflection;
@@ -198,9 +199,10 @@ namespace Abp.EntityHistory
             /* Get the mapping between Clr types and metadata OSpace */
             var objectItemCollection = ((ObjectItemCollection)metadataWorkspace.GetItemCollection(DataSpace.OSpace));
             /* Get metadata for given Clr type */
+            var entityBaseType = ObjectContext.GetObjectType(entityEntry.Entity.GetType());
             return metadataWorkspace
                 .GetItems<EntityType>(DataSpace.OSpace)
-                .Single(e => objectItemCollection.GetClrType(e) == entityEntry.Entity.GetType());
+                .Single(e => objectItemCollection.GetClrType(e) == entityBaseType);
         }
 
         private string GetEntityId(DbEntityEntry entityEntry, EntityType entityType)
@@ -377,14 +379,8 @@ namespace Abp.EntityHistory
 
                 /* Update foreign keys */
 
-                var metadataWorkspace = ((IObjectContextAdapter)context).ObjectContext.MetadataWorkspace;
-                /* Get the mapping between Clr types and metadata OSpace */
-                var objectItemCollection = ((ObjectItemCollection)metadataWorkspace.GetItemCollection(DataSpace.OSpace));
-                /* Get metadata for given Clr type */
-                var entityMetadata = metadataWorkspace
-                    .GetItems<EntityType>(DataSpace.OSpace)
-                    .Single(e => objectItemCollection.GetClrType(e) == entityEntry.Entity.GetType());
-                var foreignKeys = entityMetadata.NavigationProperties;
+                var entityType = GetEntityType(context, entityEntry);
+                var foreignKeys = entityType.NavigationProperties;
 
                 foreach (var foreignKey in foreignKeys)
                 {

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -193,16 +193,30 @@ namespace Abp.EntityHistory
             }
         }
 
-        private EntityType GetEntityType(DbContext context, DbEntityEntry entityEntry)
+        private Type GetEntityBaseType(DbEntityEntry entityEntry)
         {
-            var metadataWorkspace = ((IObjectContextAdapter)context).ObjectContext.MetadataWorkspace;
-            /* Get the mapping between Clr types and metadata OSpace */
+            return ObjectContext.GetObjectType(entityEntry.Entity.GetType());
+        }
+
+        private EntityType GetEntityType(ObjectContext context, Type entityClrType)
+        {
+            var metadataWorkspace = context.MetadataWorkspace;
+            /* Get the mapping between Clr types in OSpace */
             var objectItemCollection = ((ObjectItemCollection)metadataWorkspace.GetItemCollection(DataSpace.OSpace));
-            /* Get metadata for given Clr type */
-            var entityBaseType = ObjectContext.GetObjectType(entityEntry.Entity.GetType());
             return metadataWorkspace
                 .GetItems<EntityType>(DataSpace.OSpace)
-                .Single(e => objectItemCollection.GetClrType(e) == entityBaseType);
+                .Single(e => objectItemCollection.GetClrType(e) == entityClrType);
+        }
+
+        private EntitySet GetEntitySet(ObjectContext context, EntityType entityType)
+        {
+            var metadataWorkspace = context.MetadataWorkspace;
+            /* Get the mapping between entity set/type in CSpace */
+            return metadataWorkspace
+                .GetItems<EntityContainer>(DataSpace.CSpace)
+                .Single()
+                .EntitySets
+                .Single(e => e.ElementType.Name == entityType.Name);
         }
 
         private string GetEntityId(DbEntityEntry entityEntry, EntityType entityType)

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -335,12 +335,14 @@ namespace Abp.EntityHistory
                 var propertyInfo = GetEntityBaseType(entityEntry).GetProperty(navigationPropertyName);
                 if (ShouldSaveRelationshipHistory(entityRelationshipChanges, propertyInfo, shouldSaveEntityHistory, isCreated || isDeleted))
                 {
-                    var added = relationship.FirstOrDefault(p => p.Item2 == EntityState.Added);
-                    var deleted = relationship.FirstOrDefault(p => p.Item2 == EntityState.Deleted);
+                    var addedRelationship = relationship.FirstOrDefault(p => p.Item2 == EntityState.Added);
+                    var deletedRelationship = relationship.FirstOrDefault(p => p.Item2 == EntityState.Deleted);
+                    var newValue = addedRelationship?.Item3.EntityKeyValues.ToDictionary(keyValue => keyValue.Key, keyValue => keyValue.Value);
+                    var oldValue = deletedRelationship?.Item3.EntityKeyValues.ToDictionary(keyValue => keyValue.Key, keyValue => keyValue.Value);
                     propertyChanges.Add(new EntityPropertyChange
                     {
-                        NewValue = added?.Item3.EntityKeyValues.ToJsonString().TruncateWithPostfix(EntityPropertyChange.MaxValueLength),
-                        OriginalValue = deleted?.Item3.EntityKeyValues.ToJsonString().TruncateWithPostfix(EntityPropertyChange.MaxValueLength),
+                        NewValue = newValue?.ToJsonString().TruncateWithPostfix(EntityPropertyChange.MaxValueLength),
+                        OriginalValue = oldValue?.ToJsonString().TruncateWithPostfix(EntityPropertyChange.MaxValueLength),
                         PropertyName = navigationPropertyName,
                         PropertyTypeFullName = propertyInfo.PropertyType.FullName,
                         TenantId = AbpSession.TenantId

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -224,6 +224,10 @@ namespace Abp.EntityHistory
             foreach (var propertyName in propertyNames)
             {
                 var propertyEntry = entityEntry.Property(propertyName);
+                if (propertyEntry is DbComplexPropertyEntry)
+                {
+                    continue;
+                }
                 if (ShouldSavePropertyHistory(propertyEntry, entityType, shouldSaveEntityHistory, isCreated || isDeleted))
                 {
                     var propertyInfo = entityEntry.Entity.GetType().GetProperty(propertyEntry.Name);

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -337,7 +337,15 @@ namespace Abp.EntityHistory
                 return shouldSavePropertyHistoryForInfo.Value;
             }
 
-            var isModified = !(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null);
+            var isModified = false;
+            if (propertyEntry.EntityEntry.State == EntityState.Added)
+            {
+                isModified = propertyEntry.CurrentValue != null;
+            }
+            else
+            {
+                isModified = !(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null);
+            }
             if (isModified)
             {
                 return true;

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -103,10 +103,10 @@ namespace Abp.EntityHistory
                 
                 var entityBaseType = GetEntityBaseType(entityEntry);
                 var entityType = GetEntityType(objectContext, entityBaseType);
-                var entitySet = GetEntitySet(objectContext, entityType);
                 var entityChange = CreateEntityChange(entityEntry, entityType);
                 if (entityChange != null)
                 {
+                    var entitySet = GetEntitySet(objectContext, entityType);
                     var propertyChanges = new List<EntityPropertyChange>();
                     propertyChanges.AddRange(GetPropertyChanges(entityEntry, entityType, shouldSaveEntityHistory));
                     propertyChanges.AddRange(GetRelationshipChanges(entityEntry, entityType, entitySet, relationshipChanges, shouldSaveEntityHistory));
@@ -310,7 +310,7 @@ namespace Abp.EntityHistory
                     values.GetValues(valuesChangeSet);
                     
                     return valuesChangeSet
-                        .Select(value => ((EntityKey)value))
+                        .Select(value => value.As<EntityKey>())
                         .Where(value => value.EntitySetName != entitySet.Name)
                         .Select(value => new Tuple<string, EntityState, EntityKey>(change.EntitySet.Name, change.State, value));
                 })

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -429,15 +429,8 @@ namespace Abp.EntityHistory
             return null;
         }
 
-        private bool ShouldSavePropertyHistory(DbPropertyEntry propertyEntry, EntityType entityType, bool shouldSaveEntityHistory, bool defaultValue)
+        private bool ShouldSavePropertyHistory(DbPropertyEntry propertyEntry, PropertyInfo propertyInfo, bool shouldSaveEntityHistory, bool defaultValue)
         {
-            if (entityType.KeyMembers.Any(k => k.Name ==  propertyEntry.Name))
-            {
-                return false;
-            }
-
-            var propertyInfo = propertyEntry.EntityEntry.Entity.GetType().GetProperty(propertyEntry.Name);
-
             var shouldSavePropertyHistoryForInfo = ShouldSavePropertyHistoryForInfo(propertyInfo, shouldSaveEntityHistory);
             if (shouldSavePropertyHistoryForInfo.HasValue)
             {

--- a/src/Abp.Zero.EntityFramework/EntityHistory/IEntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/IEntityHistoryHelper.cs
@@ -1,0 +1,21 @@
+﻿using System.Data.Entity;
+using System.Threading.Tasks;
+using Abp.Threading;
+
+namespace Abp.EntityHistory
+{
+    public interface IEntityHistoryHelper
+    {
+        EntityChangeSet CreateEntityChangeSet(DbContext context);
+
+        Task SaveAsync(DbContext context, EntityChangeSet changeSet);
+    }
+
+    public static class EntityHistoryHelperExtensions
+    {
+        public static void Save(this IEntityHistoryHelper entityHistoryHelper, DbContext context, EntityChangeSet changeSet)
+        {
+            AsyncHelper.RunSync(() => entityHistoryHelper.SaveAsync(context, changeSet));
+        }
+    }
+}

--- a/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
+++ b/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
@@ -15,6 +15,7 @@ using Abp.Organizations;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Abp.EntityFramework.Extensions;
 
 namespace Abp.Zero.EntityFramework
 {
@@ -215,6 +216,90 @@ namespace Abp.Zero.EntityFramework
             }
 
             return result;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="modelBuilder"></param>
+        protected override void OnModelCreating(DbModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<EntityChange>()
+                .HasMany(e => e.PropertyChanges)
+                .WithRequired()
+                .HasForeignKey(e => e.EntityChangeId);
+
+            #region EntityChange.IX_EntityChangeSetId
+
+            modelBuilder.Entity<EntityChange>()
+                .Property(e => e.EntityChangeSetId)
+                .CreateIndex("IX_EntityChangeSetId", 1);
+
+            #endregion
+
+            #region EntityChange.IX_EntityTypeFullName_EntityId
+
+            modelBuilder.Entity<EntityChange>()
+                .Property(e => e.EntityTypeFullName)
+                .CreateIndex("IX_EntityTypeFullName_EntityId", 1);
+
+            modelBuilder.Entity<EntityChange>()
+                .Property(e => e.EntityId)
+                .CreateIndex("IX_EntityTypeFullName_EntityId", 2);
+
+            #endregion
+
+            modelBuilder.Entity<EntityChangeSet>()
+                .HasMany(e => e.EntityChanges)
+                .WithRequired()
+                .HasForeignKey(e => e.EntityChangeSetId);
+
+            #region EntityChangeSet.IX_TenantId_UserId
+            
+            modelBuilder.Entity<EntityChangeSet>()
+                .Property(e => e.TenantId)
+                .CreateIndex("IX_TenantId_UserId", 1);
+
+            modelBuilder.Entity<EntityChangeSet>()
+                .Property(e => e.UserId)
+                .CreateIndex("IX_TenantId_UserId", 2);
+
+            #endregion
+
+            #region EntityChangeSet.IX_TenantId_CreationTime
+
+            modelBuilder.Entity<EntityChangeSet>()
+                .Property(e => e.TenantId)
+                .CreateIndex("IX_TenantId_CreationTime", 1);
+
+            modelBuilder.Entity<EntityChangeSet>()
+                .Property(e => e.CreationTime)
+                .CreateIndex("IX_TenantId_CreationTime", 2);
+
+            #endregion
+
+            #region EntityChangeSet.IX_TenantId_Reason
+
+            modelBuilder.Entity<EntityChangeSet>()
+                .Property(e => e.TenantId)
+                .CreateIndex("IX_TenantId_Reason", 1);
+
+            modelBuilder.Entity<EntityChangeSet>()
+                .Property(e => e.Reason)
+                .CreateIndex("IX_TenantId_Reason", 2);
+
+            #endregion
+
+            #region EntityPropertyChange.IX_EntityChangeId
+
+            modelBuilder.Entity<EntityPropertyChange>()
+                .Property(e => e.EntityChangeId)
+                .CreateIndex("IX_EntityChangeId", 1);
+
+            #endregion
+
         }
     }
 }

--- a/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
+++ b/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
@@ -8,14 +8,13 @@ using Abp.Authorization.Roles;
 using Abp.Authorization.Users;
 using Abp.Configuration;
 using Abp.EntityFramework;
+using Abp.EntityFramework.Extensions;
 using Abp.EntityHistory;
 using Abp.Localization;
 using Abp.Notifications;
 using Abp.Organizations;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Abp.EntityFramework.Extensions;
 
 namespace Abp.Zero.EntityFramework
 {

--- a/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroDbModelBuilderExtensions.cs
+++ b/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroDbModelBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Abp.Auditing;
 using Abp.Authorization;
 using Abp.Authorization.Roles;
 using Abp.Authorization.Users;
+using Abp.EntityHistory;
 using Abp.BackgroundJobs;
 using Abp.Configuration;
 using Abp.Localization;
@@ -38,6 +39,9 @@ namespace Abp.Zero.EntityFramework
             SetTableName<AuditLog>(modelBuilder, prefix + "AuditLogs", schemaName);
             SetTableName<BackgroundJobInfo>(modelBuilder, prefix + "BackgroundJobs", schemaName);
             SetTableName<Edition>(modelBuilder, prefix + "Editions", schemaName);
+            SetTableName<EntityChange>(modelBuilder, prefix + "EntityChanges", schemaName);
+            SetTableName<EntityChangeSet>(modelBuilder, prefix + "EntityChangeSets", schemaName);
+            SetTableName<EntityPropertyChange>(modelBuilder, prefix + "EntityPropertyChanges", schemaName);
             SetTableName<FeatureSetting>(modelBuilder, prefix + "Features", schemaName);
             SetTableName<TenantFeatureSetting>(modelBuilder, prefix + "Features", schemaName);
             SetTableName<EditionFeatureSetting>(modelBuilder, prefix + "Features", schemaName);

--- a/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
+++ b/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Data.Entity;
 using Abp.Zero.EntityFramework;
 using Abp.Zero.SampleApp.BookStore;
+using Abp.Zero.SampleApp.EntityHistory;
 using Abp.Zero.SampleApp.MultiTenancy;
 using Abp.Zero.SampleApp.Roles;
 using Abp.Zero.SampleApp.Users;
@@ -12,6 +13,12 @@ namespace Abp.Zero.SampleApp.EntityFramework
     public class AppDbContext : AbpZeroDbContext<Tenant, Role, User>
     {
         public DbSet<Book> Books { get; set; }
+
+        public DbSet<Comment> Comments { get; set; }
+
+        public DbSet<Blog> Blogs { get; set; }
+
+        public DbSet<Post> Posts { get; set; }
 
         public DbSet<Author> Authors { get; set; }
 

--- a/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
+++ b/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
@@ -34,6 +34,8 @@ namespace Abp.Zero.SampleApp.EntityFramework
         {
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.Entity<Comment>().HasRequired(e => e.Post).WithMany(e => e.Comments);
+
             modelBuilder.Entity<Book>().ToTable("Books");
             modelBuilder.Entity<Book>().Property(e => e.Id).HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
 

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -1,0 +1,306 @@
+﻿using Abp.Domain.Entities;
+using Abp.Domain.Entities.Auditing;
+using Abp.Domain.Repositories;
+using Abp.Domain.Uow;
+using Abp.EntityHistory;
+using Abp.Events.Bus.Entities;
+using Abp.Extensions;
+using Abp.Json;
+using Abp.Threading;
+using Abp.Timing;
+using Abp.Zero.SampleApp.EntityHistory;
+using Castle.MicroKernel.Registration;
+using NSubstitute;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using Xunit;
+
+namespace Abp.Zero.SampleApp.Tests.EntityHistory
+{
+    public class SimpleEntityHistory_Test : SampleAppTestBase
+    {
+        private readonly IRepository<Blog> _blogRepository;
+        private readonly IRepository<Post, Guid> _postRepository;
+        private readonly IRepository<Comment> _commentRepository;
+
+        private IEntityHistoryStore _entityHistoryStore;
+
+        public SimpleEntityHistory_Test()
+        {
+            _blogRepository = Resolve<IRepository<Blog>>();
+            _postRepository = Resolve<IRepository<Post, Guid>>();
+            _commentRepository = Resolve<IRepository<Comment>>();
+
+            Resolve<IEntityHistoryConfiguration>().IsEnabledForAnonymousUsers = true;
+        }
+
+        protected override void PreInitialize()
+        {
+            base.PreInitialize();
+            _entityHistoryStore = Substitute.For<IEntityHistoryStore>();
+            LocalIocManager.IocContainer.Register(
+                Component.For<IEntityHistoryStore>().Instance(_entityHistoryStore).LifestyleSingleton()
+                );
+        }
+
+        #region CASES WRITE HISTORY
+
+        [Fact]
+        public void Should_Write_History_For_Tracked_Entities_Create()
+        {
+            /* Blog has Audited attribute. */
+
+            var blog2Id = CreateBlogAndGetId();
+
+            _entityHistoryStore.Received().SaveAsync(Arg.Is<EntityChangeSet>(
+                s => s.EntityChanges.Count == 1 &&
+                     s.EntityChanges[0].ChangeTime == s.EntityChanges[0].EntityEntry.As<DbEntityEntry>().Entity.As<IHasCreationTime>().CreationTime &&
+                     s.EntityChanges[0].ChangeType == EntityChangeType.Created &&
+                     s.EntityChanges[0].EntityId == blog2Id.ToJsonString(false, false) &&
+                     s.EntityChanges[0].EntityTypeFullName == typeof(Blog).FullName &&
+                     s.EntityChanges[0].PropertyChanges.Count == 2 && // Blog.Name, Blog.Url
+
+                     // Check "who did this change"
+                     s.ImpersonatorTenantId == AbpSession.ImpersonatorTenantId &&
+                     s.ImpersonatorUserId == AbpSession.ImpersonatorUserId &&
+                     s.TenantId == AbpSession.TenantId &&
+                     s.UserId == AbpSession.UserId
+            ));
+        }
+
+        [Fact]
+        public void Should_Write_History_For_Tracked_Entities_Create_To_Database()
+        {
+            // Forward calls from substitute to implementation
+            var entityHistoryStore = Resolve<EntityHistoryStore>();
+            _entityHistoryStore.When(x => x.SaveAsync(Arg.Any<EntityChangeSet>()))
+                .Do(callback => AsyncHelper.RunSync(() =>
+                    entityHistoryStore.SaveAsync(callback.Arg<EntityChangeSet>()))
+                );
+
+            UsingDbContext((context) =>
+            {
+                context.EntityChanges.Count(f => f.TenantId == null).ShouldBe(0);
+            });
+
+            UsingDbContext((context) =>
+            {
+                context.EntityChangeSets.Count(f => f.TenantId == null).ShouldBe(0);
+            });
+
+            UsingDbContext((context) =>
+            {
+                context.EntityPropertyChanges.Count(f => f.TenantId == null).ShouldBe(0);
+            });
+
+            var justNow = Clock.Now;
+            var blog2Id = CreateBlogAndGetId();
+
+            UsingDbContext((context) =>
+            {
+                context.EntityChanges.Count(f => f.TenantId == null).ShouldBe(1);
+            });
+
+            UsingDbContext((context) =>
+            {
+                context.EntityChangeSets.Count(f => f.TenantId == null).ShouldBe(1);
+                context.EntityChangeSets.Single().CreationTime.ShouldBeGreaterThan(justNow);
+            });
+
+            UsingDbContext((context) =>
+            {
+                context.EntityPropertyChanges.Count(f => f.TenantId == null).ShouldBe(2);
+            });
+        }
+
+        [Fact]
+        public void Should_Write_History_For_Tracked_Entities_Update()
+        {
+            /* Blog has Audited attribute. */
+
+            var newValue = "http://testblog1-changed.myblogs.com";
+            var originalValue = UpdateBlogUrlAndGetOriginalValue(newValue);
+
+            _entityHistoryStore.Received().SaveAsync(Arg.Is<EntityChangeSet>(
+                s => s.EntityChanges.Count == 1 &&
+                     s.EntityChanges[0].ChangeType == EntityChangeType.Updated &&
+                     s.EntityChanges[0].EntityId == s.EntityChanges[0].EntityEntry.As<DbEntityEntry>().Entity.As<IEntity>().Id.ToJsonString(false, false) &&
+                     s.EntityChanges[0].EntityTypeFullName == typeof(Blog).FullName &&
+                     s.EntityChanges[0].PropertyChanges.Count == 1 &&
+                     s.EntityChanges[0].PropertyChanges.FirstOrDefault().NewValue == newValue.ToJsonString(false, false) &&
+                     s.EntityChanges[0].PropertyChanges.FirstOrDefault().OriginalValue == originalValue.ToJsonString(false, false) &&
+                     s.EntityChanges[0].PropertyChanges.FirstOrDefault().PropertyName == nameof(Blog.Url) &&
+                     s.EntityChanges[0].PropertyChanges.FirstOrDefault().PropertyTypeFullName == typeof(Blog).GetProperty(nameof(Blog.Url)).PropertyType.FullName
+            ));
+        }
+
+        [Fact]
+        public void Should_Write_History_For_Tracked_Property_Foreign_Key()
+        {
+            /* Post.BlogId has Audited attribute. */
+
+            var blogId = CreateBlogAndGetId();
+            _entityHistoryStore.ClearReceivedCalls();
+
+            Guid post1Id;
+
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                var blog1 = _blogRepository.Single(b => b.Id == 1);
+                var blog2 = _blogRepository.Single(b => b.Id == 2);
+                var post1 = _postRepository.Single(b => b.Body == "test-post-1-body");
+                post1Id = post1.Id;
+
+                // Change foreign key by assigning navigation property
+                post1.Blog = blog2;
+                _postRepository.Update(post1);
+
+                uow.Complete();
+            }
+
+            _entityHistoryStore.Received().SaveAsync(Arg.Is<EntityChangeSet>(
+                s => s.EntityChanges.Count == 1 &&
+                     s.EntityChanges[0].ChangeType == EntityChangeType.Updated &&
+                     s.EntityChanges[0].EntityId == post1Id.ToJsonString(false, false) &&
+                     s.EntityChanges[0].EntityTypeFullName == typeof(Post).FullName &&
+                     s.EntityChanges[0].PropertyChanges.Count == 1 // Post.BlogId
+            ));
+        }
+
+        [Fact]
+        public void Should_Write_History_For_Tracked_Property_Foreign_Key_Shadow()
+        {
+            /* Comment has Audited attribute. */
+
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                var comment1 = _commentRepository.Single(b => b.Content == "test-comment-1-content");
+                var post2 = _postRepository.Single(b => b.Body == "test-post-2-body");
+
+                // Change foreign key by assigning navigation property
+                comment1.Post = post2;
+                _commentRepository.Update(comment1);
+
+                uow.Complete();
+            }
+
+            _entityHistoryStore.Received().SaveAsync(Arg.Is<EntityChangeSet>(
+                s => s.EntityChanges.Count == 1 &&
+                     s.EntityChanges[0].PropertyChanges.Count == 1 &&
+                     s.EntityChanges[0].PropertyChanges.First().PropertyName == "PostId"
+            ));
+        }
+
+        [Fact]
+        public void Should_Write_History_But_Not_For_Property_If_Disabled_History_Tracking()
+        {
+            /* Blog.Name has DisableAuditing attribute. */
+
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
+
+                blog1.Name = null;
+                _blogRepository.Update(blog1);
+
+                uow.Complete();
+            }
+
+            _entityHistoryStore.Received().SaveAsync(Arg.Is<EntityChangeSet>(
+                s => s.EntityChanges.Count == 1 &&
+                     s.EntityChanges[0].ChangeType == EntityChangeType.Updated &&
+                     s.EntityChanges[0].EntityId == s.EntityChanges[0].EntityEntry.As<DbEntityEntry>().Entity.As<IEntity>().Id.ToJsonString(false, false) &&
+                     s.EntityChanges[0].EntityTypeFullName == typeof(Blog).FullName &&
+                     s.EntityChanges[0].PropertyChanges.Count == 0
+            ));
+        }
+
+        #endregion
+
+        #region CASES DON'T WRITE HISTORY
+
+        [Fact]
+        public void Should_Not_Write_History_If_Disabled()
+        {
+            Resolve<IEntityHistoryConfiguration>().IsEnabled = false;
+
+            /* Blog has Audited attribute. */
+
+            var newValue = "http://testblog1-changed.myblogs.com";
+            var originalValue = UpdateBlogUrlAndGetOriginalValue(newValue);
+
+            _entityHistoryStore.DidNotReceive().SaveAsync(Arg.Any<EntityChangeSet>());
+        }
+
+        [Fact]
+        public void Should_Not_Write_History_If_Property_Has_No_Audited_Attribute()
+        {
+            /* Post.Body does not have Audited attribute. */
+
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                var post1 = _postRepository.Single(b => b.Body == "test-post-1-body");
+
+                post1.Body = null;
+                _postRepository.Update(post1);
+
+                uow.Complete();
+            }
+
+            _entityHistoryStore.DidNotReceive().SaveAsync(Arg.Any<EntityChangeSet>());
+        }
+
+        #endregion
+
+        private int CreateBlogAndGetId()
+        {
+            int blog2Id;
+
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                var blog2 = new Blog("test-blog-2", "http://testblog2.myblogs.com");
+
+                blog2Id = _blogRepository.InsertAndGetId(blog2);
+
+                uow.Complete();
+            }
+
+            return blog2Id;
+        }
+
+        private string UpdateBlogUrlAndGetOriginalValue(string newValue)
+        {
+            string originalValue;
+
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
+                originalValue = blog1.Url;
+
+                blog1.ChangeUrl(newValue);
+                _blogRepository.Update(blog1);
+
+                uow.Complete();
+            }
+
+            return originalValue;
+        }
+    }
+
+    #region Helpers
+
+    internal static class IEnumerableExtensions
+    {
+        internal static EntityPropertyChange FirstOrDefault(this IEnumerable<EntityPropertyChange> enumerable)
+        {
+            var enumerator = enumerable.GetEnumerator();
+            enumerator.MoveNext();
+            return enumerator.Current;
+        }
+    }
+
+    #endregion
+}

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -173,10 +173,15 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         {
             /* Comment has Audited attribute. */
 
+            var post1KeyValue = new Dictionary<string, object>();
+            var post2KeyValue = new Dictionary<string, object>();
+
             using (var uow = Resolve<IUnitOfWorkManager>().Begin())
             {
                 var comment1 = _commentRepository.Single(b => b.Content == "test-comment-1-content");
                 var post2 = _postRepository.Single(b => b.Body == "test-post-2-body");
+                post1KeyValue.Add("Id", comment1.Post.Id);
+                post2KeyValue.Add("Id", post2.Id);
 
                 // Change foreign key by assigning navigation property
                 comment1.Post = post2;
@@ -188,7 +193,10 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             _entityHistoryStore.Received().SaveAsync(Arg.Is<EntityChangeSet>(
                 s => s.EntityChanges.Count == 1 &&
                      s.EntityChanges[0].PropertyChanges.Count == 1 &&
-                     s.EntityChanges[0].PropertyChanges.First().PropertyName == "PostId"
+                     s.EntityChanges[0].PropertyChanges.First().PropertyName == "Post" &&
+                     s.EntityChanges[0].PropertyChanges.First().PropertyTypeFullName == typeof(Post).FullName &&
+                     s.EntityChanges[0].PropertyChanges.First().NewValue == post2KeyValue.ToJsonString(false, false) &&
+                     s.EntityChanges[0].PropertyChanges.First().OriginalValue == post1KeyValue.ToJsonString(false, false)
             ));
         }
 

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -143,8 +143,6 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             /* Post.BlogId has Audited attribute. */
 
             var blogId = CreateBlogAndGetId();
-            _entityHistoryStore.ClearReceivedCalls();
-
             Guid post1Id;
 
             using (var uow = Resolve<IUnitOfWorkManager>().Begin())

--- a/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
+++ b/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
@@ -14,7 +14,7 @@ namespace Abp.Zero.SampleApp.Tests.TestDatas
 
         public void Build()
         {
-            var blog1 = new Blog("test-blog-1", "http://testblog1.myblogs.com");
+            var blog1 = new Blog("test-blog-1", "http://testblog1.myblogs.com", "blogger-1");
 
             _context.Blogs.Add(blog1);
             _context.SaveChanges();

--- a/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
+++ b/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
@@ -1,0 +1,34 @@
+﻿using Abp.Zero.SampleApp.EntityFramework;
+using Abp.Zero.SampleApp.EntityHistory;
+
+namespace Abp.Zero.SampleApp.Tests.TestDatas
+{
+    public class InitialTestBlogBuilder
+    {
+        private readonly AppDbContext _context;
+
+        public InitialTestBlogBuilder(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public void Build()
+        {
+            var blog1 = new Blog("test-blog-1", "http://testblog1.myblogs.com");
+
+            _context.Blogs.Add(blog1);
+            _context.SaveChanges();
+
+            var post1 = new Post { Blog = blog1, Title = "test-post-1-title", Body = "test-post-1-body" };
+            var post2 = new Post { Blog = blog1, Title = "test-post-2-title", Body = "test-post-2-body" };
+            var post3 = new Post { Blog = blog1, Title = "test-post-3-title", Body = "test-post-3-body-deleted", IsDeleted = true };
+            var post4 = new Post { Blog = blog1, Title = "test-post-4-title", Body = "test-post-4-body", TenantId = 42 };
+
+            _context.Posts.AddRange(new Post[] { post1, post2, post3, post4 });
+
+            var comment1 = new Comment { Post = post1, Content = "test-comment-1-content" };
+
+            _context.Comments.Add(comment1);
+        }
+    }
+}

--- a/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
+++ b/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
@@ -27,8 +27,9 @@ namespace Abp.Zero.SampleApp.Tests.TestDatas
             _context.Posts.AddRange(new Post[] { post1, post2, post3, post4 });
 
             var comment1 = new Comment { Post = post1, Content = "test-comment-1-content" };
+            var comment2 = new Comment { Post = post2, Content = "test-comment-2-content" };
 
-            _context.Comments.Add(comment1);
+            _context.Comments.AddRange(new Comment[] { comment1, comment2 });
         }
     }
 }

--- a/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestDataBuilder.cs
+++ b/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestDataBuilder.cs
@@ -23,6 +23,7 @@ namespace Abp.Zero.SampleApp.Tests.TestDatas
             new InitialTestOrganizationUnitsBuilder(_context).Build();
             new InitialUserOrganizationUnitsBuilder(_context).Build();
             new InitialOrganizationUnitRolesBuilder(_context).Build();
+            new InitialTestBlogBuilder(_context).Build();
         }
     }
 }

--- a/test/Abp.Zero.SampleApp/EntityHistory/Blog.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Blog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using Abp.Auditing;
 using Abp.Domain.Entities;
 using Abp.Domain.Entities.Auditing;
@@ -16,14 +17,16 @@ namespace Abp.Zero.SampleApp.EntityHistory
 
         public DateTime CreationTime { get; set; }
 
+        public BlogEx More { get; set; }
+
         public virtual ICollection<Post> Posts { get; set; }
 
         public Blog()
         {
-            
+
         }
 
-        public Blog(string name, string url)
+        public Blog(string name, string url, string bloggerName)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -37,6 +40,7 @@ namespace Abp.Zero.SampleApp.EntityHistory
 
             Name = name;
             Url = url;
+            More = new BlogEx { BloggerName = bloggerName };
         }
 
         public void ChangeUrl(string url)
@@ -49,5 +53,11 @@ namespace Abp.Zero.SampleApp.EntityHistory
             var oldUrl = Url;
             Url = url;
         }
+    }
+
+    [ComplexType]
+    public class BlogEx
+    {
+        public string BloggerName { get; set; }
     }
 }

--- a/test/Abp.Zero.SampleApp/EntityHistory/Blog.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Blog.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using Abp.Auditing;
+using Abp.Domain.Entities;
+using Abp.Domain.Entities.Auditing;
+
+namespace Abp.Zero.SampleApp.EntityHistory
+{
+    [Audited]
+    public class Blog : AggregateRoot, IHasCreationTime
+    {
+        [DisableAuditing]
+        public string Name { get; set; }
+
+        public string Url { get; protected set; }
+
+        public DateTime CreationTime { get; set; }
+
+        public virtual ICollection<Post> Posts { get; set; }
+
+        public Blog()
+        {
+            
+        }
+
+        public Blog(string name, string url)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            Name = name;
+            Url = url;
+        }
+
+        public void ChangeUrl(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            var oldUrl = Url;
+            Url = url;
+        }
+    }
+}

--- a/test/Abp.Zero.SampleApp/EntityHistory/Comment.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Comment.cs
@@ -1,0 +1,13 @@
+﻿using Abp.Auditing;
+using Abp.Domain.Entities;
+
+namespace Abp.Zero.SampleApp.EntityHistory
+{
+    [Audited]
+    public class Comment : Entity
+    {
+        public Post Post { get; set; }
+
+        public string Content { get; set; }
+    }
+}

--- a/test/Abp.Zero.SampleApp/EntityHistory/Comment.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Comment.cs
@@ -6,7 +6,7 @@ namespace Abp.Zero.SampleApp.EntityHistory
     [Audited]
     public class Comment : Entity
     {
-        public Post Post { get; set; }
+        public virtual Post Post { get; set; }
 
         public string Content { get; set; }
     }

--- a/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using Abp.Auditing;
+using Abp.Domain.Entities.Auditing;
+using Abp.Domain.Entities;
+
+namespace Abp.Zero.SampleApp.EntityHistory
+{
+    public class Post : AuditedEntity<Guid>, ISoftDelete, IMayHaveTenant
+    {
+        [Required]
+        public virtual Blog Blog { get; set; }
+
+        [Audited]
+        public int BlogId { get; set; }
+
+        public string Title { get; set; }
+
+        public string Body { get; set; }
+
+        public bool IsDeleted { get; set; }
+
+        public int? TenantId { get; set; }
+
+        public Post()
+        {
+            Id = Guid.NewGuid();
+        }
+
+        public Post(Blog blog, string title, string body)
+            : this()
+        {
+            Blog = blog;
+            Title = title;
+            Body = body;
+        }
+    }
+}

--- a/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Abp.Auditing;
 using Abp.Domain.Entities.Auditing;
@@ -10,6 +11,8 @@ namespace Abp.Zero.SampleApp.EntityHistory
     {
         [Required]
         public virtual Blog Blog { get; set; }
+
+        public virtual ICollection<Comment> Comments { get; set; }
 
         [Audited]
         public int BlogId { get; set; }


### PR DESCRIPTION
Resolve #3022 

- [x] Primitive/Scalar Property
- [x] Complex Type Property
- [x] EF6 Lazy Loaded Proxies for Entity
- [x] Navigation property without foreign key (via Fluent API)
- [x] Handles Current/Original values with corresponding EntityState
- [x] Tests
- [x] Documentation

#### To be decided 
1. **Qns: Navigation property without foreign key**
      EF6 conventionally generating relationship with name `[EntityTypeOfProperty]_[EntityTypeOfNavigationProperty]`

    Should `[EntityTypeOfProperty]_[EntityTypeOfNavigationProperty]` be the property name? 

    **Ans**: 
    Will be saving the property name as declared in the entity `[PropertyName]`.

    For example, changing navigation property of entity `Post`
    ```csharp
    _post1.Blog = _blog2;
    ```
    Will result in the following EntityChangeSet
    ```csharp 
    EntityName = "Post"
    PropertyName = "Blog";
    NewValue = { "Id": "2"};
    OldValue = { "Id": "1"};
    ```

2. **Qns: Complex Type Property**
    How will complex type property be saved in entity change set?

    **Ans**:
    Complex type property will be saved as a property change in the parent entity.

    For example, changing a property of the complex type property `More` of the entity `Blog`
    ```csharp
    _blog1.More.BloggerName = "blogger-2";
    ```
    Will result in the following EntityChangeSet
    ```csharp 
    EntityName = "Blog"
    PropertyName = "More";
    NewValue = { "BloggerName": "blogger-2"};
    OldValue = { "BloggerName": "blogger-1"};
    ```
