### PR TITLE
Remove the JsonOutputFormatter from the AbpObjectActionResult wrapper class.

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpActionResultWrapperFactory.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpActionResultWrapperFactory.cs
@@ -11,7 +11,7 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
 
             if (actionResult.Result is ObjectResult)
             {
-                return new AbpObjectActionResultWrapper(actionResult.HttpContext.RequestServices);
+                return new AbpObjectActionResultWrapper();
             }
 
             if (actionResult.Result is JsonResult)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpObjectActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpObjectActionResultWrapper.cs
@@ -1,24 +1,12 @@
 using System;
-using System.Buffers;
-using System.Linq;
 using Abp.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Mvc.Formatters;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace Abp.AspNetCore.Mvc.Results.Wrapping
 {
     public class AbpObjectActionResultWrapper : IAbpActionResultWrapper
     {
-        private readonly IServiceProvider _serviceProvider;
-
-        public AbpObjectActionResultWrapper(IServiceProvider serviceProvider)
-        {
-            _serviceProvider = serviceProvider;
-        }
-
         public void Wrap(ResultExecutingContext actionResult)
         {
             var objectResult = actionResult.Result as ObjectResult;
@@ -30,15 +18,7 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
             if (!(objectResult.Value is AjaxResponseBase))
             {
                 objectResult.Value = new AjaxResponse(objectResult.Value);
-                if (!objectResult.Formatters.Any(f => f is JsonOutputFormatter))
-                {
-                    objectResult.Formatters.Add(
-                        new JsonOutputFormatter(
-                            _serviceProvider.GetRequiredService<IOptions<MvcJsonOptions>>().Value.SerializerSettings,
-                            _serviceProvider.GetRequiredService<ArrayPool<char>>()
-                        )
-                    );
-                }
+                objectResult.DeclaredType = typeof(AjaxResponse);
             }
         }
     }

--- a/test/Abp.AspNetCore.Tests/Abp.AspNetCore.Tests.csproj
+++ b/test/Abp.AspNetCore.Tests/Abp.AspNetCore.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/test/Abp.AspNetCore.Tests/App/Controllers/WrapResultTestController.cs
+++ b/test/Abp.AspNetCore.Tests/App/Controllers/WrapResultTestController.cs
@@ -20,5 +20,13 @@ namespace Abp.AspNetCore.App.Controllers
         {
             return 42;
         }
+
+        [HttpGet]
+        [Route("WrapResultTest/GetXml")]
+        [Produces("application/xml")]
+        public int GetXml()
+        {
+            return 42;
+        }
     }
 }

--- a/test/Abp.AspNetCore.Tests/App/Startup.cs
+++ b/test/Abp.AspNetCore.Tests/App/Startup.cs
@@ -15,7 +15,7 @@ namespace Abp.AspNetCore.App
     {
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
-            var mvc = services.AddMvc();
+            var mvc = services.AddMvc().AddXmlSerializerFormatters();
 
             mvc.PartManager.ApplicationParts.Add(new AssemblyPart(typeof(AbpAspNetCoreModule).GetAssembly()));
 

--- a/test/Abp.AspNetCore.Tests/Tests/WrapResultTestController_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/WrapResultTestController_Tests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Abp.AspNetCore.App.Controllers;
 using Shouldly;
 using Xunit;
@@ -33,6 +36,23 @@ namespace Abp.AspNetCore.Tests
 
             // Assert
             response.ShouldBe("42");
+        }
+
+        [Fact]
+        public async Task WrapResultTestControllerTests_Xml_Test()
+        {
+            // Act
+            var response = await GetResponseAsStringAsync(
+                GetUrl<WrapResultTestController>(
+                    nameof(WrapResultTestController.GetXml)
+                )
+            );
+
+            // Assert
+            var result = XElement.Parse(response).Elements().FirstOrDefault(x =>
+                string.Equals(x.Name.ToString(), "result", StringComparison.InvariantCultureIgnoreCase));
+            result.ShouldNotBeNull();
+            result.Value.ShouldBe("42"); 
         }
     }
 }


### PR DESCRIPTION
fix #4343 
Remove the JsonOutputFormatter from the AbpObjectActionResult wrapper class.