### PR TITLE
Added OnlineClientStore for OnlineClientManager

### DIFF
--- a/src/Abp/AbpKernelModule.cs
+++ b/src/Abp/AbpKernelModule.cs
@@ -212,6 +212,7 @@ namespace Abp
             IocManager.RegisterIfNot<ITenantStore, NullTenantStore>(DependencyLifeStyle.Singleton);
             IocManager.RegisterIfNot<ITenantResolverCache, NullTenantResolverCache>(DependencyLifeStyle.Singleton);
             IocManager.RegisterIfNot<IEntityHistoryStore, NullEntityHistoryStore>(DependencyLifeStyle.Singleton);
+            IocManager.RegisterIfNot<IOnlineClientStore, InMemoryOnlineClientStore>(DependencyLifeStyle.Singleton);
 
             if (Configuration.BackgroundJobs.IsJobExecutionEnabled)
             {

--- a/src/Abp/Data/ConditionalValue.cs
+++ b/src/Abp/Data/ConditionalValue.cs
@@ -1,0 +1,28 @@
+﻿namespace Abp.Data
+{
+    public struct ConditionalValue<TValue>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <cref name="ConditionalValue{TValue}"/> class with the given value.
+        /// </summary>
+        /// <param name="hasValue">Indicates whether the value is valid.</param>
+        /// <param name="value">The value.</param>
+        public ConditionalValue(bool hasValue, TValue value)
+        {
+            HasValue = hasValue;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current <cref name="ConditionalValue{TValue}"/> object has a valid value of its underlying type.
+        /// </summary>
+        /// <returns>true: Value is valid, false otherwise.</returns>
+        public bool HasValue { get; }
+
+        /// <summary>
+        /// Gets the value of the current <cref name="ConditionalValue{TValue}"/> object if it has been assigned a valid underlying value.
+        /// </summary>
+        /// <returns>The value of the object. If HasValue is false, returns the default value for type of the TValue parameter.</returns>
+        public TValue Value { get; }
+    }
+}

--- a/src/Abp/RealTime/IOnlineClientManager.cs
+++ b/src/Abp/RealTime/IOnlineClientManager.cs
@@ -47,6 +47,10 @@ namespace Abp.RealTime
         /// </summary>
         IReadOnlyList<IOnlineClient> GetAllClients();
 
+        /// <summary>
+        /// Gets all online clients by user id.
+        /// </summary>
+        /// <param name="user">user identifier</param>
         IReadOnlyList<IOnlineClient> GetAllByUserId([NotNull] IUserIdentifier user);
     }
 }

--- a/src/Abp/RealTime/IOnlineClientStore.cs
+++ b/src/Abp/RealTime/IOnlineClientStore.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using Abp.Data;
+
+namespace Abp.RealTime
+{
+    public interface IOnlineClientStore
+    {
+        /// <summary>
+        /// Adds a client.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        void Add(IOnlineClient client);
+
+        /// <summary>
+        /// Removes a client by connection id.
+        /// </summary>
+        /// <param name="connectionId">The connection id.</param>
+        /// <returns>Tuple indicating whether the client was removed and if so, the value</returns>
+        ConditionalValue<IOnlineClient> Remove(string connectionId);
+
+        /// <summary>
+        /// Get's a client by connection id.
+        /// </summary>
+        /// <param name="connectionId">The connection id.</param>
+        ConditionalValue<IOnlineClient> Get(string connectionId);
+
+        /// <summary>
+        /// Determines if store contains client with connection id.
+        /// </summary>
+        /// <param name="connectionId">The connection id.</param>
+        bool Contains(string connectionId);
+
+        /// <summary>
+        /// Gets all online clients.
+        /// </summary>
+        IReadOnlyList<IOnlineClient> GetAll();
+    }
+}

--- a/src/Abp/RealTime/InMemoryOnlineClientStore.cs
+++ b/src/Abp/RealTime/InMemoryOnlineClientStore.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Abp.Data;
+
+namespace Abp.RealTime
+{
+    public class InMemoryOnlineClientStore : IOnlineClientStore
+    {
+        /// <summary>
+        /// Online clients.
+        /// </summary>
+        protected ConcurrentDictionary<string, IOnlineClient> Clients { get; }
+
+        public InMemoryOnlineClientStore()
+        {
+            Clients = new ConcurrentDictionary<string, IOnlineClient>();
+        }
+
+        public void Add(IOnlineClient client)
+        {
+            Clients.AddOrUpdate(client.ConnectionId, client, (s, o) => client);
+        }
+
+        public ConditionalValue<IOnlineClient> Remove(string connectionId)
+        {
+           return Clients.TryRemove(connectionId, out IOnlineClient removed) ? new ConditionalValue<IOnlineClient>(true, removed) : new ConditionalValue<IOnlineClient>(false, null);
+        }
+
+        public ConditionalValue<IOnlineClient> Get(string connectionId)
+        {
+            return Clients.TryGetValue(connectionId, out IOnlineClient found) ? new ConditionalValue<IOnlineClient>(true, found) : new ConditionalValue<IOnlineClient>(false, null);
+        }
+
+        public bool Contains(string connectionId)
+        {
+            return Clients.ContainsKey(connectionId);
+        }
+
+        public IReadOnlyList<IOnlineClient> GetAll()
+        {
+            return Clients.Values.ToImmutableList();
+        }
+    }
+}

--- a/src/Abp/RealTime/OnlineClientManager.cs
+++ b/src/Abp/RealTime/OnlineClientManager.cs
@@ -1,18 +1,17 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Abp.Collections.Extensions;
 using Abp.Dependency;
-using Abp.Extensions;
 using JetBrains.Annotations;
 
 namespace Abp.RealTime
 {
     public class OnlineClientManager<T> : OnlineClientManager, IOnlineClientManager<T>
     {
-
+        public OnlineClientManager(IOnlineClientStore store) : base(store)
+        {
+        }
     }
 
     /// <summary>
@@ -26,18 +25,19 @@ namespace Abp.RealTime
         public event EventHandler<OnlineUserEventArgs> UserDisconnected;
 
         /// <summary>
-        /// Online clients.
+        /// Online clients Store.
         /// </summary>
-        protected ConcurrentDictionary<string, IOnlineClient> Clients { get; }
+        protected IOnlineClientStore Store { get; }
 
+        //TODO:do we need SyncObj, default store is thread safe?
         protected readonly object SyncObj = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OnlineClientManager"/> class.
         /// </summary>
-        public OnlineClientManager()
+        public OnlineClientManager(IOnlineClientStore store)
         {
-            Clients = new ConcurrentDictionary<string, IOnlineClient>();
+            Store = store;
         }
 
         public virtual void Add(IOnlineClient client)
@@ -52,13 +52,13 @@ namespace Abp.RealTime
                     userWasAlreadyOnline = this.IsOnline(user);
                 }
 
-                Clients[client.ConnectionId] = client;
+                Store.Add(client);
 
-                ClientConnected.InvokeSafely(this, new OnlineClientEventArgs(client));
+                ClientConnected?.Invoke(this, new OnlineClientEventArgs(client));
 
                 if (user != null && !userWasAlreadyOnline)
                 {
-                    UserConnected.InvokeSafely(this, new OnlineUserEventArgs(user, client));
+                    UserConnected?.Invoke(this, new OnlineUserEventArgs(user, client));
                 }
             }
         }
@@ -67,22 +67,26 @@ namespace Abp.RealTime
         {
             lock (SyncObj)
             {
-                IOnlineClient client;
-                var isRemoved = Clients.TryRemove(connectionId, out client);
+                var result = Store.Remove(connectionId);
 
-                if (isRemoved)
+                if (result.HasValue)
                 {
-                    var user = client.ToUserIdentifierOrNull();
+                    IOnlineClient client = result.Value;
 
-                    if (user != null && !this.IsOnline(user))
+                    if (UserDisconnected != null)
                     {
-                        UserDisconnected.InvokeSafely(this, new OnlineUserEventArgs(user, client));
+                        var user = client.ToUserIdentifierOrNull();
+
+                        if (user != null && !this.IsOnline(user))
+                        {
+                            UserDisconnected.Invoke(this, new OnlineUserEventArgs(user, client));
+                        }
                     }
 
-                    ClientDisconnected.InvokeSafely(this, new OnlineClientEventArgs(client));
+                    ClientDisconnected?.Invoke(this, new OnlineClientEventArgs(client));
                 }
 
-                return isRemoved;
+                return result.HasValue;
             }
         }
 
@@ -90,7 +94,7 @@ namespace Abp.RealTime
         {
             lock (SyncObj)
             {
-                return Clients.GetOrDefault(connectionId);
+                return Store.Get(connectionId).Value;
             }
         }
         
@@ -98,7 +102,7 @@ namespace Abp.RealTime
         {
             lock (SyncObj)
             {
-                return Clients.Values.ToImmutableList();
+                return Store.GetAll();
             }
         }
 
@@ -108,7 +112,7 @@ namespace Abp.RealTime
             Check.NotNull(user, nameof(user));
 
             return GetAllClients()
-                 .Where(c => (c.UserId == user.UserId && c.TenantId == user.TenantId))
+                 .Where(c => c.UserId == user.UserId && c.TenantId == user.TenantId)
                  .ToImmutableList();
         }
     }

--- a/test/Abp.Tests/RealTime/InMemoryOnlineClientManager_Tests.cs
+++ b/test/Abp.Tests/RealTime/InMemoryOnlineClientManager_Tests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using Abp.RealTime;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Tests.RealTime
+{
+    public class InMemoryOnlineClientManager_Tests
+    {
+        private readonly IOnlineClientManager _clientManager;
+        private static readonly RNGCryptoServiceProvider _keyGenerator = new RNGCryptoServiceProvider();
+
+        public InMemoryOnlineClientManager_Tests()
+        {
+            _clientManager = new OnlineClientManager(new InMemoryOnlineClientStore());
+        }
+
+        [Fact]
+        public void Test_All()
+        {
+            int tenantId = 1;
+
+            Dictionary<string, int> connections = new Dictionary<string, int>();
+
+            for (int i = 0; i < 100; i++)
+                connections.Add(MakeNewConnectionId(), i + 1);
+
+            foreach (var pair in connections)
+                _clientManager.Add(new OnlineClient(pair.Key, "127.0.0.1", tenantId, pair.Value));
+
+            var testId = connections.Keys.ToList()[5];
+
+            _clientManager.GetAllClients().Count.ShouldBe(connections.Count);
+            _clientManager.GetAllByUserId(new UserIdentifier(tenantId, connections[testId])).Count.ShouldBe(1);
+            _clientManager.GetByConnectionIdOrNull(testId).ShouldNotBeNull();
+            _clientManager.Remove(testId).ShouldBeTrue();
+            _clientManager.GetAllClients().Count.ShouldBe(connections.Count - 1);
+            _clientManager.GetByConnectionIdOrNull(testId).ShouldBeNull();
+            _clientManager.GetAllByUserId(new UserIdentifier(tenantId, connections[testId])).Count.ShouldBe(0);
+        }
+
+        private static string MakeNewConnectionId()
+        {
+            var buffer = new byte[16];
+            _keyGenerator.GetBytes(buffer);
+            return Convert.ToBase64String(buffer);
+        }
+    }
+}

--- a/test/Abp.Tests/RealTime/InMemoryOnlineClientStore_Tests.cs
+++ b/test/Abp.Tests/RealTime/InMemoryOnlineClientStore_Tests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Abp.RealTime;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Tests.RealTime
+{
+    public class InMemoryOnlineClientStore_Tests
+    {
+        private readonly InMemoryOnlineClientStore _store;
+
+        public InMemoryOnlineClientStore_Tests()
+        {
+            _store = new InMemoryOnlineClientStore();
+        }
+
+        [Fact]
+        public void Test_All()
+        {
+            var connectionId = Guid.NewGuid().ToString("N");
+
+            _store.Add(new OnlineClient(connectionId, "127.0.0.1", 1, 2));
+            _store.Get(connectionId).HasValue.ShouldBeTrue();
+
+            _store.Contains(connectionId).ShouldBeTrue();
+            _store.GetAll().Count.ShouldBe(1);
+            _store.Remove(connectionId).HasValue.ShouldBeTrue();
+            _store.GetAll().Count.ShouldBe(0);
+        }
+    }
+}


### PR DESCRIPTION
Hi,

This is a PR proposing to extend OnlineClientManager to use store like it was done in BackgroundJob
default inmemory store can be replace by any other implementation, like redis, sql etc... for user to decided or create it's own.

this was done because of signalr scaleout

Issues
https://github.com/aspnetboilerplate/aspnetboilerplate/issues/4385
https://support.aspnetzero.com/QA/Questions/6425
https://support.aspnetzero.com/QA/Questions/4337
 