### PR TITLE
Remove expired user tokens in AbpUserStore 

### DIFF
--- a/doc/WebSite/Background-Jobs-And-Workers.md
+++ b/doc/WebSite/Background-Jobs-And-Workers.md
@@ -54,19 +54,19 @@ queue:
     {
         private readonly IRepository<User, long> _userRepository;
         private readonly IEmailSender _emailSender;
-
+    
         public SimpleSendEmailJob(IRepository<User, long> userRepository, IEmailSender emailSender)
         {
             _userRepository = userRepository;
             _emailSender = emailSender;
         }
-
+    
         [UnitOfWork]
         public override void Execute(SimpleSendEmailJobArgs args)
         {
             var senderUser = _userRepository.Get(args.SenderUserId);
             var targetUser = _userRepository.Get(args.TargetUserId);
-
+    
             _emailSender.Send(senderUser.EmailAddress, targetUser.EmailAddress, args.Subject, args.Body);
         }
     }
@@ -82,11 +82,11 @@ below:
     public class SimpleSendEmailJobArgs
     {
         public long SenderUserId { get; set; }
-
+    
         public long TargetUserId { get; set; }
-
+    
         public string Subject { get; set; }
-
+    
         public string Body { get; set; }
     }
 
@@ -112,12 +112,12 @@ TestJob as defined above:
     public class MyService
     {
         private readonly IBackgroundJobManager _backgroundJobManager;
-
+    
         public MyService(IBackgroundJobManager backgroundJobManager)
         {
             _backgroundJobManager = backgroundJobManager;
         }
-
+    
         public void Test()
         {
             _backgroundJobManager.Enqueue<TestJob, int>(42);
@@ -133,12 +133,12 @@ Let's add a new job for SimpleSendEmailJob, as we defined before:
     public class MyEmailAppService : ApplicationService, IMyEmailAppService
     {
         private readonly IBackgroundJobManager _backgroundJobManager;
-
+    
         public MyEmailAppService(IBackgroundJobManager backgroundJobManager)
         {
             _backgroundJobManager = backgroundJobManager;
         }
-
+    
         public async Task SendEmail(SendEmailInput input)
         {
                 await _backgroundJobManager.EnqueueAsync<SimpleSendEmailJob, SimpleSendEmailJobArgs>(
@@ -205,7 +205,7 @@ You may want to disable background job execution for your application:
         {
             Configuration.BackgroundJobs.IsJobExecutionEnabled = false;
         }
-
+    
         //...
     }
 
@@ -221,6 +221,19 @@ other problems. To prevent it, you have two options:
     application and create a separated, standalone application (example:
     a Windows Service) that executes background jobs.
 
+#### User token removal period
+
+ABP Framework defines a background worker named UserTokenExpirationWorker which cleans the records in table AbpUserTokens. If you disable background job execution, this worker will not run. By default, UserTokenExpirationWorker runs every one hour. If you want to change this period, you can configure it like below:
+
+    public class MyProjectWebModule : AbpModule
+    {
+        public override void PreInitialize()
+        {
+            Configuration.BackgroundJobs.CleanUserTokenPeriod = 1 * 60 * 60 * 1000; // 1 hour
+        }
+    
+        //...
+    }
 #### Exception Handling
 
 Since the default background job manager should re-try failed jobs, it
@@ -258,32 +271,32 @@ application in last 30 days. See the code:
     public class MakeInactiveUsersPassiveWorker : PeriodicBackgroundWorkerBase, ISingletonDependency
     {
         private readonly IRepository<User, long> _userRepository;
-
+    
         public MakeInactiveUsersPassiveWorker(AbpTimer timer, IRepository<User, long> userRepository)
             : base(timer)
         {
             _userRepository = userRepository;
             Timer.Period = 5000; //5 seconds (good for tests, but normally will be more)
         }
-
+    
         [UnitOfWork]
         protected override void DoWork()
         {
             using (CurrentUnitOfWork.DisableFilter(AbpDataFilters.MayHaveTenant))
             {
                 var oneMonthAgo = Clock.Now.Subtract(TimeSpan.FromDays(30));
-
+    
                 var inactiveUsers = _userRepository.GetAllList(u =>
                     u.IsActive &&
                     ((u.LastLoginTime < oneMonthAgo && u.LastLoginTime != null) || (u.CreationTime < oneMonthAgo && u.LastLoginTime == null))
                     );
-
+    
                 foreach (var inactiveUser in inactiveUsers)
                 {
                     inactiveUser.IsActive = false;
                     Logger.Info(inactiveUser + " made passive since he/she did not login in last 30 days.");
                 }
-
+    
                 CurrentUnitOfWork.SaveChanges();
             }
         }
@@ -310,7 +323,7 @@ method of your module:
     public class MyProjectWebModule : AbpModule
     {
         //...
-
+    
         public override void PostInitialize()
         {
             var workManager = IocManager.Resolve<IBackgroundWorkerManager>();

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserStore.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserStore.cs
@@ -1320,13 +1320,10 @@ namespace Abp.Authorization.Users
             Check.NotNull(user, nameof(user));
 
             await UserRepository.EnsureCollectionLoadedAsync(user, u => u.Tokens, cancellationToken);
-            var isValidityKeyValid = user.Tokens.Any(t => t.LoginProvider == TokenValidityKeyProvider &&
-                                               t.Name == tokenValidityKey &&
-                                               t.ExpireDate > DateTime.UtcNow);
-            
-            user.Tokens.RemoveAll(t => t.LoginProvider == TokenValidityKeyProvider && t.ExpireDate <= DateTime.UtcNow);
 
-            return isValidityKeyValid;
+            return user.Tokens.Any(t => t.LoginProvider == TokenValidityKeyProvider &&
+                                        t.Name == tokenValidityKey &&
+                                        t.ExpireDate > DateTime.UtcNow);
         }
 
         public virtual async Task RemoveTokenValidityKeyAsync([NotNull] TUser user, string tokenValidityKey, CancellationToken cancellationToken = default(CancellationToken))
@@ -1337,8 +1334,7 @@ namespace Abp.Authorization.Users
 
             await UserRepository.EnsureCollectionLoadedAsync(user, u => u.Tokens, cancellationToken);
 
-            user.Tokens.Remove(user.Tokens.FirstOrDefault(t =>
-                t.LoginProvider == TokenValidityKeyProvider && t.Name == tokenValidityKey));
+            user.Tokens.RemoveAll(t => t.LoginProvider == TokenValidityKeyProvider && t.Name == tokenValidityKey);
         }
 
         protected virtual string NormalizeKey(string key)

--- a/src/Abp.ZeroCore/Authorization/Users/UserTokenExpirationWorker.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/UserTokenExpirationWorker.cs
@@ -1,0 +1,31 @@
+﻿using Abp.Dependency;
+using Abp.Domain.Repositories;
+using Abp.Threading.BackgroundWorkers;
+using Abp.Threading.Timers;
+using Abp.Timing;
+
+namespace Abp.Authorization.Users
+{
+    public class UserTokenExpirationWorker : PeriodicBackgroundWorkerBase, ISingletonDependency
+    {
+        private const int IntervalInMilliseconds = 1 * 60 * 60 * 1000; // 1 hour
+
+        private readonly IRepository<UserToken, long> _userTokenRepository;
+
+        public UserTokenExpirationWorker(
+            AbpTimer timer,
+            IRepository<UserToken, long> userTokenRepository)
+            : base(timer)
+        {
+            _userTokenRepository = userTokenRepository;
+
+            Timer.Period = IntervalInMilliseconds;
+        }
+
+        protected override void DoWork()
+        {
+            var utcNow = Clock.Now.ToUniversalTime();
+            _userTokenRepository.Delete(t => t.ExpireDate <= utcNow);
+        }
+    }
+}

--- a/src/Abp.ZeroCore/Authorization/Users/UserTokenExpirationWorker.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/UserTokenExpirationWorker.cs
@@ -1,4 +1,5 @@
-﻿using Abp.Dependency;
+﻿using Abp.BackgroundJobs;
+using Abp.Dependency;
 using Abp.Domain.Repositories;
 using Abp.Threading.BackgroundWorkers;
 using Abp.Threading.Timers;
@@ -11,15 +12,28 @@ namespace Abp.Authorization.Users
         private const int IntervalInMilliseconds = 1 * 60 * 60 * 1000; // 1 hour
 
         private readonly IRepository<UserToken, long> _userTokenRepository;
+        private readonly IBackgroundJobConfiguration _backgroundJobConfiguration;
 
         public UserTokenExpirationWorker(
             AbpTimer timer,
-            IRepository<UserToken, long> userTokenRepository)
+            IRepository<UserToken, long> userTokenRepository,
+            IBackgroundJobConfiguration backgroundJobConfiguration)
             : base(timer)
         {
             _userTokenRepository = userTokenRepository;
+            _backgroundJobConfiguration = backgroundJobConfiguration;
 
-            Timer.Period = IntervalInMilliseconds;
+            Timer.Period = GetTimerPeriod();
+        }
+
+        private int GetTimerPeriod()
+        {
+            if (_backgroundJobConfiguration.CleanUserTokenPeriod.HasValue)
+            {
+                return _backgroundJobConfiguration.CleanUserTokenPeriod.Value;
+            }
+
+            return IntervalInMilliseconds;
         }
 
         protected override void DoWork()

--- a/src/Abp.ZeroCore/Zero/AbpZeroCoreModule.cs
+++ b/src/Abp.ZeroCore/Zero/AbpZeroCoreModule.cs
@@ -1,7 +1,9 @@
-﻿using Abp.Localization.Dictionaries.Xml;
+﻿using Abp.Authorization.Users;
+using Abp.Localization.Dictionaries.Xml;
 using Abp.Localization.Sources;
 using Abp.Modules;
 using Abp.Reflection.Extensions;
+using Abp.Threading.BackgroundWorkers;
 
 namespace Abp.Zero
 {
@@ -23,6 +25,15 @@ namespace Abp.Zero
         public override void Initialize()
         {
             IocManager.RegisterAssemblyByConvention(typeof(AbpZeroCoreModule).GetAssembly());
+        }
+
+        public override void PostInitialize()
+        {
+            if (Configuration.BackgroundJobs.IsJobExecutionEnabled)
+            {
+                var workerManager = IocManager.Resolve<IBackgroundWorkerManager>();
+                workerManager.Add(IocManager.Resolve<UserTokenExpirationWorker>());
+            }
         }
     }
 }

--- a/src/Abp/BackgroundJobs/BackgroundJobConfiguration.cs
+++ b/src/Abp/BackgroundJobs/BackgroundJobConfiguration.cs
@@ -5,7 +5,9 @@ namespace Abp.BackgroundJobs
     internal class BackgroundJobConfiguration : IBackgroundJobConfiguration
     {
         public bool IsJobExecutionEnabled { get; set; }
-        
+
+        public int? CleanUserTokenPeriod { get; set; }
+
         public IAbpStartupConfiguration AbpConfiguration { get; private set; }
 
         public BackgroundJobConfiguration(IAbpStartupConfiguration abpConfiguration)

--- a/src/Abp/BackgroundJobs/IBackgroundJobConfiguration.cs
+++ b/src/Abp/BackgroundJobs/IBackgroundJobConfiguration.cs
@@ -13,6 +13,11 @@ namespace Abp.BackgroundJobs
         bool IsJobExecutionEnabled { get; set; }
 
         /// <summary>
+        /// Period in milliseconds.
+        /// </summary>
+        int? CleanUserTokenPeriod { get; set; }
+
+        /// <summary>
         /// Gets the ABP configuration object.
         /// </summary>
         IAbpStartupConfiguration AbpConfiguration { get; }

--- a/src/Abp/Threading/BackgroundWorkers/PeriodicBackgroundWorkerBase.cs
+++ b/src/Abp/Threading/BackgroundWorkers/PeriodicBackgroundWorkerBase.cs
@@ -41,7 +41,7 @@ namespace Abp.Threading.BackgroundWorkers
         /// <summary>
         /// Handles the Elapsed event of the Timer.
         /// </summary>
-        private void Timer_Elapsed(object sender, System.EventArgs e)
+        private void Timer_Elapsed(object sender, EventArgs e)
         {
             try
             {

--- a/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Tokens_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Tokens_Tests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Abp.Authorization.Users;
 using Abp.Domain.Repositories;
@@ -25,7 +24,7 @@ namespace Abp.Zero.Users
         }
 
         [Fact]
-        public async Task Should_Add_TokenValidityKey()
+        public async Task Should_Valid_Non_Expired_TokenValidityKey()
         {
             using (var uow = Resolve<IUnitOfWorkManager>().Begin())
             {
@@ -49,34 +48,6 @@ namespace Abp.Zero.Users
                 var isTokenValidityKeyValid = await _abpUserManager.IsTokenValidityKeyValidAsync(user, tokenValidityKey);
 
                 isTokenValidityKeyValid.ShouldBeFalse();
-            }
-        }
-
-        [Fact]
-        public async Task Should_Remove_Expired_TokenValidityKeys()
-        {
-            using (_unitOfWorkManager.Begin())
-            {
-                var user = await _abpUserManager.GetUserByIdAsync(AbpSession.GetUserId());
-
-                await _abpUserManager.AddTokenValidityKeyAsync(user, Guid.NewGuid().ToString(), DateTime.UtcNow);
-                await _abpUserManager.AddTokenValidityKeyAsync(user, Guid.NewGuid().ToString(), DateTime.UtcNow.AddDays(1));
-                await _abpUserManager.AddTokenValidityKeyAsync(user, Guid.NewGuid().ToString(), DateTime.UtcNow.AddDays(1));
-                _unitOfWorkManager.Current.SaveChanges();
-
-                var allTokens = _userTokenRepository.GetAllList(t => t.UserId == user.Id);
-                allTokens.Count.ShouldBe(3);
-            }
-
-            using (_unitOfWorkManager.Begin())
-            {
-                var user = await _abpUserManager.GetUserByIdAsync(AbpSession.GetUserId());
-
-                await _abpUserManager.IsTokenValidityKeyValidAsync(user, Guid.NewGuid().ToString());
-                _unitOfWorkManager.Current.SaveChanges();
-
-                var allTokens = _userTokenRepository.GetAllList(t => t.UserId == user.Id);
-                allTokens.Count.ShouldBe(2);
             }
         }
 

--- a/test/Abp.ZeroCore.Tests/Zero/Users/UserTokenExpirationWorker_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Users/UserTokenExpirationWorker_Tests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading.Tasks;
+using Abp.Authorization.Users;
+using Abp.Domain.Repositories;
+using Abp.Domain.Uow;
+using Abp.Runtime.Session;
+using Abp.Threading.Timers;
+using Abp.ZeroCore.SampleApp.Core;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Zero.Users
+{
+    public class UserTokenExpirationWorker_Tests : AbpZeroTestBase
+    {
+        private readonly UserTokenExpirationWorker _userTokenExpirationWorker;
+        private readonly IRepository<UserToken, long> _userTokenRepository;
+        private readonly AbpUserManager<Role, User> _abpUserManager;
+        private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+        public UserTokenExpirationWorker_Tests()
+        {
+            _userTokenExpirationWorker = Resolve<MyUserTokenExpirationWorker>();
+            _userTokenRepository = Resolve<IRepository<UserToken, long>>();
+            _abpUserManager = Resolve<AbpUserManager<Role, User>>();
+            _unitOfWorkManager = Resolve<IUnitOfWorkManager>();
+        }
+
+        [Fact]
+        public async Task Should_Remove_Expired_TokenValidityKeys()
+        {
+            //Arrange
+            using (_unitOfWorkManager.Begin())
+            {
+                var user = await _abpUserManager.GetUserByIdAsync(AbpSession.GetUserId());
+
+                await _abpUserManager.AddTokenValidityKeyAsync(user, Guid.NewGuid().ToString(), DateTime.UtcNow);
+                await _abpUserManager.AddTokenValidityKeyAsync(user, Guid.NewGuid().ToString(), DateTime.UtcNow.AddDays(1));
+                await _abpUserManager.AddTokenValidityKeyAsync(user, Guid.NewGuid().ToString(), DateTime.UtcNow.AddDays(1));
+                _unitOfWorkManager.Current.SaveChanges();
+
+                var allTokens = _userTokenRepository.GetAllList(t => t.UserId == user.Id);
+                allTokens.Count.ShouldBe(3);
+            }
+
+            //Act
+            _userTokenExpirationWorker.Start();
+
+            //Assert
+            using (_unitOfWorkManager.Begin())
+            {
+                var user = await _abpUserManager.GetUserByIdAsync(AbpSession.GetUserId());
+                var allTokens = _userTokenRepository.GetAllList(t => t.UserId == user.Id);
+                allTokens.Count.ShouldBe(2);
+            }
+        }
+    }
+
+    internal class MyUserTokenExpirationWorker : UserTokenExpirationWorker
+    {
+        public MyUserTokenExpirationWorker(AbpTimer timer, IRepository<UserToken, long> userTokenRepository)
+            : base(timer, userTokenRepository)
+        {   
+        }
+
+        public override void Start()
+        {
+            DoWork();
+        }
+    }
+}

--- a/test/Abp.ZeroCore.Tests/Zero/Users/UserTokenExpirationWorker_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Users/UserTokenExpirationWorker_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Abp.Authorization.Users;
+using Abp.BackgroundJobs;
 using Abp.Domain.Repositories;
 using Abp.Domain.Uow;
 using Abp.Runtime.Session;
@@ -58,8 +59,11 @@ namespace Abp.Zero.Users
 
     internal class MyUserTokenExpirationWorker : UserTokenExpirationWorker
     {
-        public MyUserTokenExpirationWorker(AbpTimer timer, IRepository<UserToken, long> userTokenRepository)
-            : base(timer, userTokenRepository)
+        public MyUserTokenExpirationWorker(
+            AbpTimer timer, 
+            IRepository<UserToken, long> userTokenRepository, 
+            IBackgroundJobConfiguration backgroundJobConfiguration)
+            : base(timer, userTokenRepository, backgroundJobConfiguration)
         {   
         }
 


### PR DESCRIPTION
Fixes #4367

- Make `RemoveTokenValidityKeyAsync` delete **ALL** keys from the same TokenValidityKeyProvider
- Remove auto clean up when calling `IsTokenValidityKeyValidAsync`
- Introduce `UserTokenExpirationWorker` periodic job (1 hour) that start in `PostInitialize` of `AbpZeroCoreModlue`
- ~Introduce clean up method `RemoveTokenValidityKeysAsync` that delete **ALL** keys that are older than the given `expireDateTime`~

#### Impact
- ~Expired `User.Tokens` will no longer be removed automatically when calling `IsTokenValidityKeyValidAsync`~
- ~Expired `User.Tokens` can be removed by calling `RemoveTokenValidityKeysAsync(user)`~

#### Pending
- [x] Fix tests
