### PR TITLE
Add AbpExceptionPageFilter and AbpResultPageFilter for Razor Page.

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/AbpMvcOptionsExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/AbpMvcOptionsExtensions.cs
@@ -40,6 +40,8 @@ namespace Abp.AspNetCore.Mvc
         {
             options.Filters.AddService(typeof(AbpUowPageFilter));
             options.Filters.AddService(typeof(AbpAuditPageFilter));
+            options.Filters.AddService(typeof(AbpResultPageFilter));
+            options.Filters.AddService(typeof(AbpExceptionPageFilter));
         }
 
         private static void AddModelBinders(MvcOptions options)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/AbpAuditPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/AbpAuditPageFilter.cs
@@ -21,9 +21,9 @@ namespace Abp.AspNetCore.Mvc.Auditing
             _auditingHelper = auditingHelper;
         }
 
-        public async Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+        public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
@@ -1,0 +1,120 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Abp.AspNetCore.Configuration;
+using Abp.AspNetCore.Mvc.Results;
+using Abp.Authorization;
+using Abp.Dependency;
+using Abp.Domain.Entities;
+using Abp.Events.Bus;
+using Abp.Events.Bus.Exceptions;
+using Abp.Logging;
+using Abp.Reflection;
+using Abp.Runtime;
+using Abp.Runtime.Validation;
+using Abp.Web.Models;
+using Castle.Core.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Abp.AspNetCore.Mvc.ExceptionHandling
+{
+    public class AbpExceptionPageFilter : IAsyncPageFilter, ITransientDependency
+    {
+        public ILogger Logger { get; set; }
+
+        public IEventBus EventBus { get; set; }
+
+        private readonly IErrorInfoBuilder _errorInfoBuilder;
+        private readonly IAbpAspNetCoreConfiguration _configuration;
+
+        public AbpExceptionPageFilter(IErrorInfoBuilder errorInfoBuilder, IAbpAspNetCoreConfiguration configuration)
+        {
+            _errorInfoBuilder = errorInfoBuilder;
+            _configuration = configuration;
+
+            Logger = NullLogger.Instance;
+            EventBus = NullEventBus.Instance;
+        }
+
+        public async Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+            var pageHandlerExecutedContext = await next();
+
+            if (pageHandlerExecutedContext.Exception == null)
+            {
+                return;;
+            }
+
+            var wrapResultAttribute =
+                ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
+                    context.HandlerMethod.MethodInfo,
+                    _configuration.DefaultWrapResultAttribute
+                );
+
+            if (wrapResultAttribute.LogError)
+            {
+                LogHelper.LogException(Logger, pageHandlerExecutedContext.Exception);
+            }
+
+            HandleAndWrapException(pageHandlerExecutedContext, wrapResultAttribute);
+        }
+
+        protected virtual void HandleAndWrapException(PageHandlerExecutedContext context, WrapResultAttribute wrapResultAttribute)
+        {
+            if (!ActionResultHelper.IsObjectResult(context.HandlerMethod.MethodInfo.ReturnType))
+            {
+                return;
+            }
+
+            context.HttpContext.Response.StatusCode = GetStatusCode(context, wrapResultAttribute.WrapOnError);
+
+            if (!wrapResultAttribute.WrapOnError)
+            {
+                return;
+            }
+
+            context.Result = new ObjectResult(
+                new AjaxResponse(
+                    _errorInfoBuilder.BuildForException(context.Exception),
+                    context.Exception is AbpAuthorizationException
+                )
+            );
+
+            EventBus.Trigger(this, new AbpHandledExceptionData(context.Exception));
+
+            context.Exception = null; //Handled!
+        }
+
+        protected virtual int GetStatusCode(PageHandlerExecutedContext context, bool wrapOnError)
+        {
+            if (context.Exception is AbpAuthorizationException)
+            {
+                return context.HttpContext.User.Identity.IsAuthenticated
+                    ? (int)HttpStatusCode.Forbidden
+                    : (int)HttpStatusCode.Unauthorized;
+            }
+
+            if (context.Exception is AbpValidationException)
+            {
+                return (int)HttpStatusCode.BadRequest;
+            }
+
+            if (context.Exception is EntityNotFoundException)
+            {
+                return (int)HttpStatusCode.NotFound;
+            }
+
+            if (wrapOnError)
+            {
+                return (int)HttpStatusCode.InternalServerError;
+            }
+
+            return context.HttpContext.Response.StatusCode;
+        }
+    }
+}

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
@@ -36,9 +36,9 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
             EventBus = NullEventBus.Instance;
         }
 
-        public async Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+        public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
@@ -43,6 +43,12 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
 
         public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
         {
+            if (context.HandlerMethod == null)
+            {
+                await next();
+                return;
+            }
+
             var pageHandlerExecutedContext = await next();
 
             if (pageHandlerExecutedContext.Exception == null)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultPageFilter.cs
@@ -28,9 +28,9 @@ namespace Abp.AspNetCore.Mvc.Results
             _actionResultWrapperFactory = actionResultWrapperFactory;
         }
 
-        public async Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+        public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultPageFilter.cs
@@ -1,0 +1,58 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Abp.AspNetCore.Configuration;
+using Abp.AspNetCore.Mvc.Results.Wrapping;
+using Abp.Authorization;
+using Abp.Dependency;
+using Abp.Domain.Entities;
+using Abp.Events.Bus;
+using Abp.Events.Bus.Exceptions;
+using Abp.Logging;
+using Abp.Reflection;
+using Abp.Runtime.Validation;
+using Abp.Web.Models;
+using Castle.Core.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Abp.AspNetCore.Mvc.Results
+{
+    public class AbpResultPageFilter : IAsyncPageFilter, ITransientDependency
+    {
+        private readonly IAbpAspNetCoreConfiguration _configuration;
+        private readonly IAbpActionResultWrapperFactory _actionResultWrapperFactory;
+
+        public AbpResultPageFilter(IAbpAspNetCoreConfiguration configuration, IAbpActionResultWrapperFactory actionResultWrapperFactory)
+        {
+            _configuration = configuration;
+            _actionResultWrapperFactory = actionResultWrapperFactory;
+        }
+
+        public async Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+            var pageHandlerExecutedContext = await next();
+
+            var methodInfo = context.HandlerMethod.MethodInfo;
+
+            var wrapResultAttribute =
+                ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
+                    methodInfo,
+                    _configuration.DefaultWrapResultAttribute
+                );
+
+            if (!wrapResultAttribute.WrapOnSuccess)
+            {
+                return;
+            }
+
+            _actionResultWrapperFactory.CreateFor(pageHandlerExecutedContext).Wrap(pageHandlerExecutedContext);
+        }
+
+    }
+}
+

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultPageFilter.cs
@@ -35,6 +35,12 @@ namespace Abp.AspNetCore.Mvc.Results
 
         public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
         {
+            if (context.HandlerMethod == null)
+            {
+                await next();
+                return;
+            }
+
             var pageHandlerExecutedContext = await next();
 
             var methodInfo = context.HandlerMethod.MethodInfo;

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpActionResultWrapperFactory.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpActionResultWrapperFactory.cs
@@ -5,48 +5,33 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
 {
     public class AbpActionResultWrapperFactory : IAbpActionResultWrapperFactory
     {
-        public IAbpActionResultWrapper CreateFor(ResultExecutingContext actionResult)
+        public IAbpActionResultWrapper CreateFor(FilterContext context)
         {
-            Check.NotNull(actionResult, nameof(actionResult));
+            Check.NotNull(context, nameof(context));
 
-            if (actionResult.Result is ObjectResult)
+            switch (context)
             {
-                return new AbpObjectActionResultWrapper();
+                case ResultExecutingContext resultExecutingContext when resultExecutingContext.Result is ObjectResult:
+                    return new AbpObjectActionResultWrapper();
+
+                case ResultExecutingContext resultExecutingContext when resultExecutingContext.Result is JsonResult:
+                    return new AbpJsonActionResultWrapper();
+
+                case ResultExecutingContext resultExecutingContext when resultExecutingContext.Result is EmptyResult:
+                    return new AbpEmptyActionResultWrapper();
+
+                case PageHandlerExecutedContext pageHandlerExecutedContext when pageHandlerExecutedContext.Result is ObjectResult:
+                    return new AbpObjectActionResultWrapper();
+
+                case PageHandlerExecutedContext pageHandlerExecutedContext when pageHandlerExecutedContext.Result is JsonResult:
+                    return new AbpJsonActionResultWrapper();
+
+                case PageHandlerExecutedContext pageHandlerExecutedContext when pageHandlerExecutedContext.Result is EmptyResult:
+                    return new AbpEmptyActionResultWrapper();
+
+                default:
+                    return new NullAbpActionResultWrapper();
             }
-
-            if (actionResult.Result is JsonResult)
-            {
-                return new AbpJsonActionResultWrapper();
-            }
-
-            if (actionResult.Result is EmptyResult)
-            {
-                return new AbpEmptyActionResultWrapper();
-            }
-
-            return new NullAbpActionResultWrapper();
-        }
-
-        public IAbpActionResultWrapper CreateFor(PageHandlerExecutedContext actionResult)
-        {
-            Check.NotNull(actionResult, nameof(actionResult));
-
-            if (actionResult.Result is ObjectResult)
-            {
-                return new AbpObjectActionResultWrapper();
-            }
-
-            if (actionResult.Result is JsonResult)
-            {
-                return new AbpJsonActionResultWrapper();
-            }
-
-            if (actionResult.Result is EmptyResult)
-            {
-                return new AbpEmptyActionResultWrapper();
-            }
-
-            return new NullAbpActionResultWrapper();
         }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpActionResultWrapperFactory.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpActionResultWrapperFactory.cs
@@ -26,5 +26,27 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
 
             return new NullAbpActionResultWrapper();
         }
+
+        public IAbpActionResultWrapper CreateFor(PageHandlerExecutedContext actionResult)
+        {
+            Check.NotNull(actionResult, nameof(actionResult));
+
+            if (actionResult.Result is ObjectResult)
+            {
+                return new AbpObjectActionResultWrapper();
+            }
+
+            if (actionResult.Result is JsonResult)
+            {
+                return new AbpJsonActionResultWrapper();
+            }
+
+            if (actionResult.Result is EmptyResult)
+            {
+                return new AbpEmptyActionResultWrapper();
+            }
+
+            return new NullAbpActionResultWrapper();
+        }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpEmptyActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpEmptyActionResultWrapper.cs
@@ -10,5 +10,10 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
         {
             actionResult.Result = new ObjectResult(new AjaxResponse());
         }
+
+        public void Wrap(PageHandlerExecutedContext actionResult)
+        {
+            actionResult.Result = new ObjectResult(new AjaxResponse());
+        }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpEmptyActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpEmptyActionResultWrapper.cs
@@ -6,14 +6,18 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
 {
     public class AbpEmptyActionResultWrapper : IAbpActionResultWrapper
     {
-        public void Wrap(ResultExecutingContext actionResult)
+        public void Wrap(FilterContext context)
         {
-            actionResult.Result = new ObjectResult(new AjaxResponse());
-        }
+            switch (context)
+            {
+                case ResultExecutingContext resultExecutingContext:
+                    resultExecutingContext.Result = new ObjectResult(new AjaxResponse());
+                    return;
 
-        public void Wrap(PageHandlerExecutedContext actionResult)
-        {
-            actionResult.Result = new ObjectResult(new AjaxResponse());
+                case PageHandlerExecutedContext pageHandlerExecutedContext:
+                    pageHandlerExecutedContext.Result = new ObjectResult(new AjaxResponse());
+                    return;
+            }
         }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpJsonActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpJsonActionResultWrapper.cs
@@ -7,26 +7,24 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
 {
     public class AbpJsonActionResultWrapper : IAbpActionResultWrapper
     {
-        public void Wrap(ResultExecutingContext actionResult)
+        public void Wrap(FilterContext context)
         {
-            var jsonResult = actionResult.Result as JsonResult;
-            if (jsonResult == null)
+            JsonResult jsonResult = null;
+
+            switch (context)
             {
-                throw new ArgumentException($"{nameof(actionResult)} should be JsonResult!");
+                case ResultExecutingContext resultExecutingContext:
+                    jsonResult = resultExecutingContext.Result as JsonResult;
+                    break;
+
+                case PageHandlerExecutedContext pageHandlerExecutedContext:
+                    jsonResult = pageHandlerExecutedContext.Result as JsonResult;
+                    break;
             }
 
-            if (!(jsonResult.Value is AjaxResponseBase))
-            {
-                jsonResult.Value = new AjaxResponse(jsonResult.Value);
-            }
-        }
-
-        public void Wrap(PageHandlerExecutedContext actionResult)
-        {
-            var jsonResult = actionResult.Result as JsonResult;
             if (jsonResult == null)
             {
-                throw new ArgumentException($"{nameof(actionResult)} should be JsonResult!");
+                throw new ArgumentException("Action Result should be JsonResult!");
             }
 
             if (!(jsonResult.Value is AjaxResponseBase))

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpJsonActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpJsonActionResultWrapper.cs
@@ -20,5 +20,19 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
                 jsonResult.Value = new AjaxResponse(jsonResult.Value);
             }
         }
+
+        public void Wrap(PageHandlerExecutedContext actionResult)
+        {
+            var jsonResult = actionResult.Result as JsonResult;
+            if (jsonResult == null)
+            {
+                throw new ArgumentException($"{nameof(actionResult)} should be JsonResult!");
+            }
+
+            if (!(jsonResult.Value is AjaxResponseBase))
+            {
+                jsonResult.Value = new AjaxResponse(jsonResult.Value);
+            }
+        }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpObjectActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpObjectActionResultWrapper.cs
@@ -21,5 +21,20 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
                 objectResult.DeclaredType = typeof(AjaxResponse);
             }
         }
+
+        public void Wrap(PageHandlerExecutedContext actionResult)
+        {
+            var objectResult = actionResult.Result as ObjectResult;
+            if (objectResult == null)
+            {
+                throw new ArgumentException($"{nameof(actionResult)} should be ObjectResult!");
+            }
+
+            if (!(objectResult.Value is AjaxResponseBase))
+            {
+                objectResult.Value = new AjaxResponse(objectResult.Value);
+                objectResult.DeclaredType = typeof(AjaxResponse);
+            }
+        }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpObjectActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/AbpObjectActionResultWrapper.cs
@@ -7,27 +7,24 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
 {
     public class AbpObjectActionResultWrapper : IAbpActionResultWrapper
     {
-        public void Wrap(ResultExecutingContext actionResult)
+        public void Wrap(FilterContext context)
         {
-            var objectResult = actionResult.Result as ObjectResult;
-            if (objectResult == null)
+            ObjectResult objectResult = null;
+
+            switch (context)
             {
-                throw new ArgumentException($"{nameof(actionResult)} should be ObjectResult!");
+                case ResultExecutingContext resultExecutingContext:
+                    objectResult = resultExecutingContext.Result as ObjectResult;
+                    break;
+
+                case PageHandlerExecutedContext pageHandlerExecutedContext:
+                    objectResult = pageHandlerExecutedContext.Result as ObjectResult;
+                    break;
             }
 
-            if (!(objectResult.Value is AjaxResponseBase))
-            {
-                objectResult.Value = new AjaxResponse(objectResult.Value);
-                objectResult.DeclaredType = typeof(AjaxResponse);
-            }
-        }
-
-        public void Wrap(PageHandlerExecutedContext actionResult)
-        {
-            var objectResult = actionResult.Result as ObjectResult;
             if (objectResult == null)
             {
-                throw new ArgumentException($"{nameof(actionResult)} should be ObjectResult!");
+                throw new ArgumentException("Action Result should be JsonResult!");
             }
 
             if (!(objectResult.Value is AjaxResponseBase))

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/IAbpActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/IAbpActionResultWrapper.cs
@@ -5,5 +5,7 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
     public interface IAbpActionResultWrapper
     {
         void Wrap(ResultExecutingContext actionResult);
+
+        void Wrap(PageHandlerExecutedContext actionResult);
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/IAbpActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/IAbpActionResultWrapper.cs
@@ -4,8 +4,6 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
 {
     public interface IAbpActionResultWrapper
     {
-        void Wrap(ResultExecutingContext actionResult);
-
-        void Wrap(PageHandlerExecutedContext actionResult);
+        void Wrap(FilterContext context);
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/IAbpActionResultWrapperFactory.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/IAbpActionResultWrapperFactory.cs
@@ -7,5 +7,7 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
     public interface IAbpActionResultWrapperFactory : ITransientDependency
     {
         IAbpActionResultWrapper CreateFor([NotNull] ResultExecutingContext actionResult);
+
+        IAbpActionResultWrapper CreateFor([NotNull] PageHandlerExecutedContext actionResult);
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/IAbpActionResultWrapperFactory.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/IAbpActionResultWrapperFactory.cs
@@ -1,13 +1,10 @@
 ﻿using Abp.Dependency;
-using JetBrains.Annotations;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Abp.AspNetCore.Mvc.Results.Wrapping
 {
     public interface IAbpActionResultWrapperFactory : ITransientDependency
     {
-        IAbpActionResultWrapper CreateFor([NotNull] ResultExecutingContext actionResult);
-
-        IAbpActionResultWrapper CreateFor([NotNull] PageHandlerExecutedContext actionResult);
+        IAbpActionResultWrapper CreateFor(FilterContext context);
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/NullAbpActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/NullAbpActionResultWrapper.cs
@@ -8,5 +8,10 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
         {
             
         }
+
+        public void Wrap(PageHandlerExecutedContext actionResult)
+        {
+            
+        }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/NullAbpActionResultWrapper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Wrapping/NullAbpActionResultWrapper.cs
@@ -4,14 +4,10 @@ namespace Abp.AspNetCore.Mvc.Results.Wrapping
 {
     public class NullAbpActionResultWrapper : IAbpActionResultWrapper
     {
-        public void Wrap(ResultExecutingContext actionResult)
+        public void Wrap(FilterContext context)
         {
             
         }
 
-        public void Wrap(PageHandlerExecutedContext actionResult)
-        {
-            
-        }
     }
 }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Uow/AbpUowPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Uow/AbpUowPageFilter.cs
@@ -22,9 +22,9 @@ namespace Abp.AspNetCore.Mvc.Uow
             _unitOfWorkDefaultOptions = unitOfWorkDefaultOptions;
         }
 
-        public async Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+        public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/RazorExceptionPageFilterTests.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/RazorExceptionPageFilterTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Abp.Web.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Shouldly;
+using Xunit;
+
+namespace AbpAspNetCoreDemo.IntegrationTests.Tests
+{
+    public class RazorExceptionPageFilterTests : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        public RazorExceptionPageFilterTests(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task RazorPage_RazorExceptionPageFilter_Get_Test()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/ExceptionFilterPageDemo");
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+
+            var result = JsonConvert.DeserializeObject<AjaxResponse>(await response.Content.ReadAsStringAsync());
+
+            result.ShouldNotBeNull();
+            result.Error.Message.ShouldBe("OnGet");
+         }
+
+        [Fact]
+        public async Task RazorPage_RazorExceptionPageFilter_Post_Test()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.PostAsync("/ExceptionFilterPageDemo", new StringContent(""));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            result.IndexOf("<h2 class=\"stackerror\">UserFriendlyException: OnPost</h2>",
+                StringComparison.InvariantCultureIgnoreCase).ShouldNotBe(-1);
+        }
+    }
+}

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/RazorResultPageFilterTests.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/RazorResultPageFilterTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Abp.Web.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Shouldly;
+using Xunit;
+
+namespace AbpAspNetCoreDemo.IntegrationTests.Tests
+{
+    public class RazorResultPageFilterTests : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        public RazorResultPageFilterTests(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task RazorPage_RazorResultPageFilter_Get_Test()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/ResultFilterPageDemo");
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            result.ShouldBe("OnGet");
+        }
+
+        [Fact]
+        public async Task RazorPage_RazorResultPageFilter_Post_Test()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.PostAsync("/ResultFilterPageDemo", new StringContent(""));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            var result = JsonConvert.DeserializeObject<AjaxResponse>(await response.Content.ReadAsStringAsync());
+
+            result.ShouldNotBeNull();
+            result.Success.ShouldBeTrue();
+
+            result.Result.ShouldBe("OnPost");
+        }
+    }
+}

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/Pages/ExceptionFilterPageDemo.cshtml
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/Pages/ExceptionFilterPageDemo.cshtml
@@ -1,0 +1,16 @@
+﻿@page
+@model AbpAspNetCoreDemo.Pages.ExceptionFilterPageDemoModel
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <title>ExceptionFilterPageDemo</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/Pages/ExceptionFilterPageDemo.cshtml.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/Pages/ExceptionFilterPageDemo.cshtml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.AspNetCore.Mvc.RazorPages;
+using Abp.UI;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AbpAspNetCoreDemo.Pages
+{
+    public class ExceptionFilterPageDemoModel : AbpPageModel
+    {
+        public JsonResult OnGet()
+        {
+            throw new UserFriendlyException("OnGet");
+        }
+
+        public IActionResult OnPost()
+        {
+            throw new UserFriendlyException("OnPost");
+        }
+    }
+}

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/Pages/ResultFilterPageDemo.cshtml
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/Pages/ResultFilterPageDemo.cshtml
@@ -1,0 +1,16 @@
+﻿@page
+@model AbpAspNetCoreDemo.Pages.ResultFilterPageDemoModel
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <title>ResultFilterPageDemo</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/Pages/ResultFilterPageDemo.cshtml.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/Pages/ResultFilterPageDemo.cshtml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.AspNetCore.Mvc.RazorPages;
+using Abp.UI;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AbpAspNetCoreDemo.Pages
+{
+    public class ResultFilterPageDemoModel : AbpPageModel
+    {
+        public IActionResult OnGet()
+        {
+            return Content("OnGet");
+        }
+
+        public JsonResult OnPost()
+        {
+            return new JsonResult("OnPost");
+        }
+    }
+}


### PR DESCRIPTION
fix #4448,  related: #2464

Authorize is temporarily unable to be implemented like MVC. https://github.com/aspnet/AspNetCore/issues/8737

**It may cause a Break change of the user's existing Razor Page code.**