### PR TITLE
fix #4481 Add unique index to Setting(TenantID, Name, UserId)

### DIFF
--- a/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
+++ b/src/Abp.Zero.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
@@ -299,6 +299,9 @@ namespace Abp.Zero.EntityFramework
 
             #endregion
 
+            modelBuilder.Entity<Setting>()
+                .HasIndex(e => new { e.TenantId, e.Name, e.UserId })
+                .IsUnique();
         }
     }
 }

--- a/src/Abp.Zero.EntityFrameworkCore/Zero/EntityFrameworkCore/AbpZeroCommonDbContext.cs
+++ b/src/Abp.Zero.EntityFrameworkCore/Zero/EntityFrameworkCore/AbpZeroCommonDbContext.cs
@@ -148,6 +148,11 @@ namespace Abp.Zero.EntityFrameworkCore
                     .WithMany()
                     .HasForeignKey(p => p.LastModifierUserId);
             });
+
+            modelBuilder.Entity<Setting>(b =>
+            {
+                b.HasIndex(e => new { e.TenantId, e.Name, e.UserId }).IsUnique().HasFilter(null);
+            });
         }
     }
 }

--- a/src/Abp.ZeroCore.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
+++ b/src/Abp.ZeroCore.EntityFramework/Zero/EntityFramework/AbpZeroCommonDbContext.cs
@@ -551,6 +551,10 @@ namespace Abp.Zero.EntityFramework
                 .Property(e => e.UserId)
                 .CreateIndex("IX_TenantId_UserId", 2);
 
+            modelBuilder.Entity<Setting>()
+                .HasIndex(e => new { e.TenantId, e.Name, e.UserId })
+                .IsUnique();
+
             #endregion
 
             #region UserRole.IX_TenantId_RoleId

--- a/src/Abp.ZeroCore.EntityFrameworkCore/Zero/EntityFrameworkCore/AbpZeroCommonDbContext.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/Zero/EntityFrameworkCore/AbpZeroCommonDbContext.cs
@@ -279,7 +279,7 @@ namespace Abp.Zero.EntityFrameworkCore
 
             modelBuilder.Entity<Setting>(b =>
             {
-                b.HasIndex(e => new { e.TenantId, e.Name });
+                b.HasIndex(e => new { e.TenantId, e.Name, e.UserId }).IsUnique().HasFilter(null);
             });
 
             modelBuilder.Entity<TenantNotificationInfo>(b =>


### PR DESCRIPTION
The default filter for EF Core is `[TenantId] IS NOT NULL AND [UserId] IS NOT NULL`.  So need to set the filter parameters.