### PR TITLE
Add dutch localization

### DIFF
--- a/src/Abp.Web.Common/Abp.Web.Common.csproj
+++ b/src/Abp.Web.Common/Abp.Web.Common.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Web\Localization\AbpWebXmlSource\*.xml" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
+    <None Remove="Web\Localization\AbpWebXmlSource\AbpWeb-nl.xml" />
     <None Include="bin\Release\netstandard2.0\Abp.Web.Common.pdb">
       <PackagePath>lib/netstandard2.0/</PackagePath>
       <Pack>true</Pack>

--- a/src/Abp.Web.Common/Web/Localization/AbpWebXmlSource/AbpWeb-nl.xml
+++ b/src/Abp.Web.Common/Web/Localization/AbpWebXmlSource/AbpWeb-nl.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<localizationDictionary culture="nl">
+  <texts>
+    <text name="InternalServerError" value="Er is een interne fout opgetreden tijdens uw aanvraag!" />
+    <text name="ValidationError" value="Uw aanvraag is niet geldig!" />
+    <text name="AreYouSure" value="Weet u het zeker?" />
+    <text name="Cancel" value="Annuleren" />
+    <text name="Yes" value="Ja" />
+    <text name="ValidationNarrativeTitle" value="De volgende fouten zijn gedetecteerd tijdens de validatie." />
+    <text name="DefaultError" value="Er is een fout opgetreden!" />
+    <text name="DefaultErrorDetail" value=" Foutendetail niet verzonden door server." />
+    <text name="DefaultError401" value="Ubent niet geauthenticeerd!" />
+    <text name="DefaultErrorDetail401" value="U moeten worden geauthenticeerd (aanmelden) om deze bewerking uit te voeren." />
+    <text name="DefaultError403" value="Jij bent niet geautoriseerd!" />
+    <text name="DefaultErrorDetail403" value="U mag deze bewerking niet uitvoeren." />
+    <text name="DefaultError404" value="Bron niet gevonden!" />
+    <text name="DefaultErrorDetail404" value="De gevraagde bron kan niet worden gevonden op de server." />
+    <text name="EntityNotFound" value="Er is geen entiteit {0} met id = {1}!" />
+  </texts>
+</localizationDictionary>

--- a/src/Abp.Zero/Abp.Zero.csproj
+++ b/src/Abp.Zero/Abp.Zero.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Zero\Localization\SourceExt\AbpZero-nl.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="bin\Release\net461\Abp.Zero.pdb">
       <PackagePath>lib/net461/</PackagePath>
       <Pack>true</Pack>

--- a/src/Abp.Zero/Zero/Localization/SourceExt/AbpZero-nl.xml
+++ b/src/Abp.Zero/Zero/Localization/SourceExt/AbpZero-nl.xml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<localizationDictionary culture="nl">
+  <texts>
+    <text name="Identity.UserAlreadyInRole" value="Gebruiker al in rol." />
+    <text name="Identity.UserNotInRole" value="Gebruiker is niet in rol." />
+    <text name="Identity.RoleNotFound" value="Rol {0} bestaat niet." />
+    <text name="Identity.PasswordMismatch" value="Incorrect wachtwoord." />
+    <text name="Identity.InvalidUserName" value="Gebruikersnaam {0} is ongeldig, kan alleen letters of cijfers bevatten." />
+    <text name="Identity.PasswordTooShort" value="Het wachtwoord moet uit minimaal {0} tekens bestaan." />
+    <text name="Identity.PropertyTooShort" value="{0} kan niet leeg zijn." />
+    <text name="Identity.DuplicateUserName" value="Gebruikersnaam {0} is al in gebruik." />
+    <text name="Identity.UserAlreadyHasPassword" value="Gebruiker heeft al een wachtwoord ingesteld." />
+    <text name="Identity.PasswordRequireNonLetterOrDigit" value="Wachtwoorden moeten ten minste één niet-letter of cijfer bevatten." />
+    <text name="Identity.UserIdNotFound" value="Gebruikers ID niet gevonden." />
+    <text name="Identity.InvalidToken" value="Ongeldige token." />
+    <text name="Identity.InvalidEmail" value="E-mail '{0}' is ongeldig." />
+    <text name="Identity.UserNameNotFound" value="Gebruiker {0} bestaat neit." />
+    <text name="Identity.LockoutNotEnabled" value="Lockout is niet ingeschakeld voor deze gebruiker." />
+    <text name="Identity.PasswordRequireUpper" value="Wachtwoorden moeten ten minste één hoofdletter hebben ('A'-'Z')." />
+    <text name="Identity.PasswordRequireDigit" value="Wachtwoorden moeten minstens één cijfer hebben ('0'-'9')." />
+    <text name="Identity.PasswordRequireLower" value="Wachtwoorden moeten minstens één kleine letter ('a'-'z') bevatten." />
+    <text name="Identity.DuplicateEmail" value="E-mail '{0}' is al in gebruik." />
+    <text name="Identity.ExternalLoginExists" value="Er bestaat al een gebruiker met die externe login." />
+    <text name="Identity.DefaultError" value="Er is een onbekende fout opgetreden." />
+    <text name="Email">E-mail</text>
+    <text name="EmailSecurityCodeSubject">Beveiligingscode</text>
+    <text name="EmailSecurityCodeBody">Uw beveiligingscode is: {0}</text>
+    <text name="Sms">Sms</text>
+    <text name="SmsSecurityCodeMessage">Uw beveiligingscode is: {0}</text>
+  </texts>
+</localizationDictionary>

--- a/src/Abp.ZeroCore/Abp.ZeroCore.csproj
+++ b/src/Abp.ZeroCore/Abp.ZeroCore.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Zero\Localization\SourceExt\AbpZero-nl.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="bin\Release\netstandard2.0\Abp.ZeroCore.pdb">
       <PackagePath>lib/netstandard2.0/</PackagePath>
       <Pack>true</Pack>

--- a/src/Abp.ZeroCore/Zero/Localization/SourceExt/AbpZero-nl.xml
+++ b/src/Abp.ZeroCore/Zero/Localization/SourceExt/AbpZero-nl.xml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<localizationDictionary culture="nl">
+  <texts>
+    <text name="Identity.ConcurrencyFailure">Optimistische parallelle fout, object is gewijzigd.</text>
+    <text name="Identity.DefaultError">Er is een onbekende fout opgetreden.</text>
+    <text name="Identity.DuplicateEmail">E-mail '{0}' is al in gebruik.</text>
+    <text name="Identity.DuplicateRoleName">Rolnaam '{0}' is al in gebruik.</text>
+    <text name="Identity.DuplicateUserName">Gebruikersnaam '{0}' is al in gebruik.</text>
+    <text name="Identity.InvalidEmail">E-mail '{0}' is ongeldig.</text>
+    <text name="Identity.InvalidPasswordHasherCompatibilityMode">De verstrekte PasswordHasherCompatibilityMode is ongeldig.</text>
+    <text name="Identity.InvalidPasswordHasherIterationCount">Het aantal herhalingen moet een positief geheel getal zijn.</text>
+    <text name="Identity.InvalidRoleName">Rolnaam '{0}' is ongeldig.</text>
+    <text name="Identity.InvalidToken">Ongeldige token.</text>
+    <text name="Identity.InvalidUserName">Gebruikersnaam '{0}' is ongeldig, kan alleen letters of cijfers bevatten.</text>
+    <text name="Identity.LoginAlreadyAssociated">Er bestaat al een gebruiker met deze login.</text>
+    <text name="Identity.PasswordMismatch">Incorrect wachtwoord.</text>
+    <text name="Identity.PasswordRequireDigit">Wachtwoorden moeten minstens één cijfer hebben ('0'-'9').</text>
+    <text name="Identity.PasswordRequireLower">Wachtwoorden moeten minstens één kleine letter ('a'-'z') bevatten.</text>
+    <text name="Identity.PasswordRequireNonAlphanumeric">Wachtwoorden moeten minstens één niet-alfanumeriek teken bevatten.</text>
+    <text name="Identity.PasswordRequireUpper">Wachtwoorden moeten minstens één hoofdletter hebben ('A'-'Z').</text>
+    <text name="Identity.PasswordTooShort">Wachtwoorden moeten ten minste {0} tekens bevatten.</text>
+    <text name="Identity.RoleNotFound">Rol {0} bestaat niet.</text>
+    <text name="Identity.UserAlreadyHasPassword">Gebruiker heeft al een wachtwoord ingesteld.</text>
+    <text name="Identity.UserAlreadyInRole">Gebruiker al in rol '{0}'.</text>
+    <text name="Identity.UserLockedOut">Het gebruikersaccount is geblokkeerd.</text>
+    <text name="Identity.UserLockoutNotEnabled">Vergrendeling is niet ingeschakeld voor deze gebruiker.</text>
+    <text name="Identity.UserNameNotFound">Gebruiker {0} bestaat niet.</text>
+    <text name="Identity.UserNotInRole">Gebruiker bevindt zich niet in rol '{0}'.</text>
+    <text name="Email">E-mail</text>
+    <text name="EmailSecurityCodeSubject">Beveiligingscode</text>
+    <text name="EmailSecurityCodeBody">Uw beveiligingscode is: {0}</text>
+    <text name="Sms">Sms</text>
+    <text name="SmsSecurityCodeMessage">Uw beveiligingscode is: {0}</text>
+  </texts>
+</localizationDictionary>

--- a/src/Abp/Abp.csproj
+++ b/src/Abp/Abp.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Localization\Sources\AbpXmlSource\*.xml;Timing\Timezone\Mapping\*.xml" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
+    <None Remove="Localization\Sources\AbpXmlSource\Abp-nl.xml" />
     <None Include="bin\Release\netstandard2.0\Abp.pdb">
       <PackagePath>lib/netstandard2.0/</PackagePath>
       <Pack>true</Pack>

--- a/src/Abp/Localization/Sources/AbpXmlSource/Abp-nl.xml
+++ b/src/Abp/Localization/Sources/AbpXmlSource/Abp-nl.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<localizationDictionary culture="nl">
+  <texts>
+    <text name="SmtpHost">SMTP host</text>
+    <text name="SmtpPort">SMTP poort</text>
+    <text name="Username">Gebruikersnaam</text>
+    <text name="Password">Wachtwoord</text>
+    <text name="DomainName">Domeinnaam</text>
+    <text name="UseSSL">Gebruik SSL</text>
+    <text name="UseDefaultCredentials">Gebruik standaard referenties</text>
+    <text name="DefaultFromSenderEmailAddress">Standaard van (afzender) emailadres</text>
+    <text name="DefaultFromSenderDisplayName">Standaard van (afzender) weergave naam</text>
+    <text name="DefaultLanguage">Standaard taal</text>
+    <text name="ReceiveNotifications">Ontvang notificaties</text>
+    <text name="CurrentUserDidNotLoginToTheApplication">Huidige gebruiker is niet ingelogd in de applicatie!</text>
+    <text name="TimeZone">Tijdzone</text>
+    <text name="AllOfThesePermissionsMustBeGranted">Verplichte rechten zijn niet toegekend. De volgende rechten dienen alleen toegekend te zijn: {0}</text>
+    <text name="AtLeastOneOfThesePermissionsMustBeGranted">Verplichte rechten zijn niet toegekend. Minimaal één van de volgende rechten dient toegekend te zijn: {0}</text>
+    <text name="FeatureIsNotEnabled">Functie is niet ingeschakeld: {0}</text>
+    <text name="AllOfTheseFeaturesMustBeEnabled">Vereiste functies zijn niet ingeschakeld. Al deze functies moeten zijn ingeschakeld: {0}</text>
+    <text name="AtLeastOneOfTheseFeaturesMustBeEnabled">Vereiste functies zijn niet ingeschakeld. Ten minste één van deze functies moet zijn ingeschakeld: {0}</text>
+    <text name="MainMenu">Hoofdmenu</text>
+  </texts>
+</localizationDictionary>


### PR DESCRIPTION
ASP.NET Zero comes with dutch translations.
When using the confirm message from the MessageService in ABP the buttons won't be translated cause the dutch translations are not implemented in the ABP module.

![image](https://user-images.githubusercontent.com/43230397/57615352-c7801d00-757b-11e9-80ef-b90cf5d8808f.png)

In this pull request I've added the duch translations to ABP.