### PR TITLE
 fix #4446 Improve the function of SettingManager.

### DIFF
--- a/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Lockout_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Lockout_Tests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using Abp.Configuration;
+using Abp.Configuration.Startup;
 using Abp.Dependency;
+using Abp.Extensions;
 using Abp.Zero.Configuration;
 using Abp.ZeroCore.SampleApp.Core;
 using Shouldly;
@@ -11,10 +13,12 @@ namespace Abp.Zero.Users
     public class UserManager_Lockout_Tests : AbpZeroTestBase
     {
         private readonly UserManager _userManager;
+        private readonly IMultiTenancyConfig _multiTenancyConfig;
 
         public UserManager_Lockout_Tests()
         {
             _userManager = Resolve<UserManager>();
+            _multiTenancyConfig = Resolve<IMultiTenancyConfig>();
         }
 
         [Theory]
@@ -86,7 +90,7 @@ namespace Abp.Zero.Users
 
             LocalIocManager.Using<ISettingManager>(settingManager =>
             {
-                if (AbpSession.TenantId is int tenantId)
+                if (_multiTenancyConfig.IsEnabled && AbpSession.TenantId is int tenantId)
                 {
                     settingManager.ChangeSettingForTenant(tenantId, AbpZeroSettingNames.UserManagement.UserLockOut.IsEnabled, isLockoutEnabledByDefault.ToString());
                 }


### PR DESCRIPTION
It is not necessary to judge whether multi-tenancy is enabled in multiple places.
If you disable multi-tenancy, you should not use the related tenant method of SettingManager.

Currently all the tests of the SettingManager are passed.