### PR TITLE
Entity History handle invalid entity with audited property

### DIFF
--- a/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
+++ b/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
@@ -14,16 +14,18 @@ namespace Abp.Zero.SampleApp.EntityFramework
     {
         public DbSet<Book> Books { get; set; }
 
-        public DbSet<Comment> Comments { get; set; }
-
         public DbSet<Blog> Blogs { get; set; }
 
         public DbSet<Post> Posts { get; set; }
 
+        public DbSet<Category> Categories { get; set; }
+
+        public DbSet<Comment> Comments { get; set; }
+
         public DbSet<Author> Authors { get; set; }
 
         public DbSet<Store> Stores { get; set; }
-        
+
         public DbSet<UserTestEntity> UserTestEntities { get; set; }
 
         public AppDbContext(DbConnection existingConnection)

--- a/test/Abp.Zero.SampleApp/EntityHistory/Category.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Category.cs
@@ -1,0 +1,15 @@
+﻿using Abp.Auditing;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Abp.Zero.SampleApp.EntityHistory
+{
+    public class Category
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Audited]
+        public string DisplayName { get; set; }
+    }
+}

--- a/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
@@ -25,6 +25,10 @@ namespace Abp.Zero.SampleApp.EntityHistory
 
         public int? TenantId { get; set; }
 
+        public int? CategoryId { get; set; }
+
+        public Category Category { get; set; }
+
         public Post()
         {
             Id = Guid.NewGuid();

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Category.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Category.cs
@@ -1,0 +1,15 @@
+﻿using Abp.Auditing;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
+{
+    public class Category
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Audited]
+        public string DisplayName { get; set; }
+    }
+}

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Post.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Post.cs
@@ -22,6 +22,10 @@ namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
 
         public int? TenantId { get; set; }
 
+        public int? CategoryId { get; set; }
+
+        public Category Category { get; set; }
+
         public Post()
         {
             Id = Guid.NewGuid();

--- a/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
+++ b/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
@@ -19,11 +19,13 @@ namespace Abp.ZeroCore.SampleApp.EntityFramework
 
         public DbSet<Post> Posts { get; set; }
 
+        public DbSet<Category> Categories { get; set; }
+
+        public DbSet<Comment> Comments { get; set; }
+
         public DbSet<Product> Products { get; set; }
 
         public DbSet<ProductTranslation> ProductTranslations { get; set; }
-
-        public DbSet<Comment> Comments { get; set; }
 
         public DbSet<Author> Authors { get; set; }
 

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -304,6 +304,53 @@ namespace Abp.Zero.EntityHistory
             _entityHistoryStore.DidNotReceive().SaveAsync(Arg.Any<EntityChangeSet>());
         }
 
+        [Fact]
+        public void Should_Not_Write_History_If_Invalid_Entity_Has_Property_With_Audited_Attribute_Created()
+        {
+            //Arrange
+            Post post1 = null;
+
+            //Act
+            WithUnitOfWork(() =>
+            {
+                post1 = _postRepository.Single(b => b.Body == "test-post-1-body");
+                /* Category does not inherit from Entity<> and is not an owned entity*/
+                post1.Category = new Category { DisplayName = "My Category" };
+                _postRepository.Update(post1);
+
+            });
+
+            //Assert
+            _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
+        }
+
+        [Fact]
+        public void Should_Not_Write_History_If_Invalid_Entity_Has_Property_With_Audited_Attribute_Updated()
+        {
+            //Arrange
+            Post post1 = null;
+            WithUnitOfWork(() =>
+            {
+                post1 = _postRepository.Single(b => b.Body == "test-post-1-body");
+                /* Category does not inherit from Entity<> and is not an owned entity*/
+                post1.Category = new Category { DisplayName = "My Category" };
+                _postRepository.Update(post1);
+
+            });
+            _entityHistoryStore.ClearReceivedCalls();
+
+            //Act
+            WithUnitOfWork(() =>
+            {
+                post1 = _postRepository.GetAllIncluding(e => e.Category).Single(b => b.Body == "test-post-1-body");
+                post1.Category.DisplayName = "Invalid Category";
+                _postRepository.Update(post1);
+            });
+
+            //Assert
+            _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
+        }
+
         #endregion
 
         private int CreateBlogAndGetId()


### PR DESCRIPTION
Entity History should not be capturing entity changes that does not comply with the conditions stated in https://github.com/aspnetboilerplate/aspnetboilerplate/blob/213f6f2b0e99087c6874bd52afe808b28fe36afe/doc/WebSite/Entity-History.md#entity-changes
> ### Entity Changes
> 
> -   An entity must not be one of the **IgnoredTypes**.
> -   An entity must be **public** in order to be saved in the change logs.
>     **private**, **protected**, **internal** entities are ignored.
> -   **DisableAuditing** takes priority over the **Audited** attribute when saving entity changes.
> -   An entity must satisfy one of the predicates from **Selectors**.

At the moment, when an entity fails at the validation for entity history, `HasAuditProperties` will invalidate the failed validation and proceed with `EntityChange` creation.

i.e. Entity A that does not inherit from `Entity<>` contains `Audited` property B. When property B has dirty data, `EntityChange` will be created for Entity A even thought Entity A is not a valid entity in Entity History System

#### EFCore
https://github.com/aspnetboilerplate/aspnetboilerplate/blob/65eed3b500f981b38c9a96f1398055811db2d721/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs#L90-L94

#### EF6
https://github.com/aspnetboilerplate/aspnetboilerplate/blob/65eed3b500f981b38c9a96f1398055811db2d721/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs#L100-L104

- [x] Add failing test for EF Core
- [x] Add failing test for EF6
- [x] Fix Entity History for EF Core (see #4870)
- [x] Fix Entity History for EF6 (see #4843)