### PR TITLE
Update ApplicationLanguage MaxNameLength to 128.

### DIFF
--- a/src/Abp.Zero.Common/Localization/ApplicationLanguage.cs
+++ b/src/Abp.Zero.Common/Localization/ApplicationLanguage.cs
@@ -16,7 +16,7 @@ namespace Abp.Localization
         /// <summary>
         /// The maximum name length.
         /// </summary>
-        public const int MaxNameLength = 10;
+        public const int MaxNameLength = 128;
 
         /// <summary>
         /// The maximum display name length.


### PR DESCRIPTION
>  Custom Culture Names  
 The preferred format of the `cultureName` parameter for a new, custom culture is "[`prefix`-]`language`[-`region`][-`suffix`[`…`]]", where the `language` component is required and the `prefix`, `region`, and `suffix` components are optional. The maximum length of each component is 8 characters and the maximum length of the entire `cultureName` parameter is 84 characters.  

https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureandregioninfobuilder.-ctor?redirectedfrom=MSDN&view=netframework-4.8#custom-culture-names