### PR TITLE
OrganizationUnitRole change event handler is updated.

### DIFF
--- a/src/Abp.Zero.Common/Authorization/Roles/AbpRolePermissionCacheItemInvalidator.cs
+++ b/src/Abp.Zero.Common/Authorization/Roles/AbpRolePermissionCacheItemInvalidator.cs
@@ -1,4 +1,6 @@
+using Abp.Authorization.Users;
 using Abp.Dependency;
+using Abp.Domain.Repositories;
 using Abp.Events.Bus.Entities;
 using Abp.Events.Bus.Handlers;
 using Abp.Organizations;
@@ -13,10 +15,12 @@ namespace Abp.Authorization.Roles
         ITransientDependency
     {
         private readonly ICacheManager _cacheManager;
+        private readonly IRepository<UserOrganizationUnit, long> _userOrganizationUnitRepository;
 
-        public AbpRolePermissionCacheItemInvalidator(ICacheManager cacheManager)
+        public AbpRolePermissionCacheItemInvalidator(ICacheManager cacheManager, IRepository<UserOrganizationUnit, long> userOrganizationUnitRepository)
         {
             _cacheManager = cacheManager;
+            _userOrganizationUnitRepository = userOrganizationUnitRepository;
         }
 
         public void HandleEvent(EntityChangedEventData<RolePermissionSetting> eventData)
@@ -29,6 +33,16 @@ namespace Abp.Authorization.Roles
         {
             var cacheKey = eventData.Entity.RoleId + "@" + (eventData.Entity.TenantId ?? 0);
             _cacheManager.GetRolePermissionCache().Remove(cacheKey);
+
+            //get all users in organization unit
+            var users = _userOrganizationUnitRepository.GetAllList(x =>
+                x.OrganizationUnitId == eventData.Entity.OrganizationUnitId && x.TenantId == eventData.Entity.TenantId);
+            //delete all users permission cache
+            foreach (var userOrganizationUnit in users)
+            {
+                cacheKey = userOrganizationUnit.UserId + "@" + (eventData.Entity.TenantId ?? 0);
+                _cacheManager.GetUserPermissionCache().Remove(cacheKey);
+            }
         }
 
         public void HandleEvent(EntityDeletedEventData<AbpRoleBase> eventData)

--- a/src/Abp.Zero.Common/Authorization/Roles/AbpRolePermissionCacheItemInvalidator.cs
+++ b/src/Abp.Zero.Common/Authorization/Roles/AbpRolePermissionCacheItemInvalidator.cs
@@ -1,6 +1,4 @@
-using Abp.Authorization.Users;
 using Abp.Dependency;
-using Abp.Domain.Repositories;
 using Abp.Events.Bus.Entities;
 using Abp.Events.Bus.Handlers;
 using Abp.Organizations;
@@ -15,12 +13,10 @@ namespace Abp.Authorization.Roles
         ITransientDependency
     {
         private readonly ICacheManager _cacheManager;
-        private readonly IRepository<UserOrganizationUnit, long> _userOrganizationUnitRepository;
 
-        public AbpRolePermissionCacheItemInvalidator(ICacheManager cacheManager, IRepository<UserOrganizationUnit, long> userOrganizationUnitRepository)
+        public AbpRolePermissionCacheItemInvalidator(ICacheManager cacheManager)
         {
             _cacheManager = cacheManager;
-            _userOrganizationUnitRepository = userOrganizationUnitRepository;
         }
 
         public void HandleEvent(EntityChangedEventData<RolePermissionSetting> eventData)
@@ -33,16 +29,6 @@ namespace Abp.Authorization.Roles
         {
             var cacheKey = eventData.Entity.RoleId + "@" + (eventData.Entity.TenantId ?? 0);
             _cacheManager.GetRolePermissionCache().Remove(cacheKey);
-
-            //get all users in organization unit
-            var users = _userOrganizationUnitRepository.GetAllList(x =>
-                x.OrganizationUnitId == eventData.Entity.OrganizationUnitId && x.TenantId == eventData.Entity.TenantId);
-            //delete all users permission cache
-            foreach (var userOrganizationUnit in users)
-            {
-                cacheKey = userOrganizationUnit.UserId + "@" + (eventData.Entity.TenantId ?? 0);
-                _cacheManager.GetUserPermissionCache().Remove(cacheKey);
-            }
         }
 
         public void HandleEvent(EntityDeletedEventData<AbpRoleBase> eventData)


### PR DESCRIPTION
The OrganizationUnitRole change event handler must also clear the user's permission cache. It causes a cache error.