### PR TITLE
Ensure OrganizationUnitRole has ISoftDelete interface

### DIFF
--- a/src/Abp.Zero.Common/Organizations/OrganizationUnitRole.cs
+++ b/src/Abp.Zero.Common/Organizations/OrganizationUnitRole.cs
@@ -8,7 +8,7 @@ namespace Abp.Organizations
     /// Represents membership of a User to an OU.
     /// </summary>
     [Table("AbpOrganizationUnitRoles")]
-    public class OrganizationUnitRole : CreationAuditedEntity<long>, IMayHaveTenant
+    public class OrganizationUnitRole : CreationAuditedEntity<long>, IMayHaveTenant, ISoftDelete
     {
         /// <summary>
         /// TenantId of this entity.


### PR DESCRIPTION
Adding `ISoftDelete` interface to `OrganizationUnitRole` so that it can be correctly soft deleted.