### PR TITLE
Generic ICache, CacheBase

### DIFF
--- a/src/Abp/Runtime/Caching/ICache.cs
+++ b/src/Abp/Runtime/Caching/ICache.cs
@@ -7,22 +7,12 @@ namespace Abp.Runtime.Caching
     /// <summary>
     /// Defines a cache that can be store and get items by keys.
     /// </summary>
-    public interface ICache : IDisposable, ICacheOptions, ICacheOperations
+    public interface ICache : IDisposable, ICacheOptions, ICacheOperations, ICacheSingleKeyOperations<string, object>
     {
         /// <summary>
         /// Unique name of the cache.
         /// </summary>
         string Name { get; }
-
-        /// <summary>
-        /// Gets an item from the cache.
-        /// This method hides cache provider failures (and logs them),
-        /// uses the factory method to get the object if cache provider fails.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="factory">Factory method to create cache item if not exists</param>
-        /// <returns>Cached item</returns>
-        object Get(string key, Func<string, object> factory);
 
         /// <summary>
         /// Gets items from the cache.
@@ -35,16 +25,6 @@ namespace Abp.Runtime.Caching
         object[] Get(string[] keys, Func<string, object> factory);
 
         /// <summary>
-        /// Gets an item from the cache.
-        /// This method hides cache provider failures (and logs them),
-        /// uses the factory method to get the object if cache provider fails.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="factory">Factory method to create cache item if not exists</param>
-        /// <returns>Cached item</returns>
-        Task<object> GetAsync(string key, Func<string, Task<object>> factory);
-
-        /// <summary>
         /// Gets items from the cache.
         /// This method hides cache provider failures (and logs them),
         /// uses the factory method to get the object if cache provider fails.
@@ -55,13 +35,6 @@ namespace Abp.Runtime.Caching
         Task<object[]> GetAsync(string[] keys, Func<string, Task<object>> factory);
 
         /// <summary>
-        /// Gets an item from the cache or null if not found.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Cached item or null if not found</returns>
-        object GetOrDefault(string key);
-
-        /// <summary>
         /// Gets items from the cache. For every key that is not found, a null value is returned.
         /// </summary>
         /// <param name="keys">Keys</param>
@@ -69,31 +42,11 @@ namespace Abp.Runtime.Caching
         object[] GetOrDefault(string[] keys);
 
         /// <summary>
-        /// Gets an item from the cache or null if not found.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Cached item or null if not found</returns>
-        Task<object> GetOrDefaultAsync(string key);
-
-        /// <summary>
         /// Gets items from the cache. For every key that is not found, a null value is returned.
         /// </summary>
         /// <param name="keys">Keys</param>
         /// <returns>Cached items</returns>
         Task<object[]> GetOrDefaultAsync(string[] keys);
-
-        /// <summary>
-        /// Saves/Overrides an item in the cache by a key.
-        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
-        /// If none of them is specified, then
-        /// <see cref="ICacheOptions.DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="ICacheOptions.DefaultSlidingExpireTime"/>
-        /// will be used.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="value">Value</param>
-        /// <param name="slidingExpireTime">Sliding expire time</param>
-        /// <param name="absoluteExpireTime">Absolute expire time</param>
-        void Set(string key, object value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
         /// Saves/Overrides items in the cache by the pairs.
@@ -108,19 +61,6 @@ namespace Abp.Runtime.Caching
         void Set(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
-        /// Saves/Overrides an item in the cache by a key.
-        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
-        /// If none of them is specified, then
-        /// <see cref="ICacheOptions.DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="ICacheOptions.DefaultSlidingExpireTime"/>
-        /// will be used.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="value">Value</param>
-        /// <param name="slidingExpireTime">Sliding expire time</param>
-        /// <param name="absoluteExpireTime">Absolute expire time</param>
-        Task SetAsync(string key, object value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
-
-        /// <summary>
         /// Saves/Overrides items in the cache by the pairs.
         /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
         /// If none of them is specified, then
@@ -133,22 +73,10 @@ namespace Abp.Runtime.Caching
         Task SetAsync(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
-        /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
-        /// </summary>
-        /// <param name="key">Key</param>
-        void Remove(string key);
-
-        /// <summary>
         /// Removes cache items by their keys.
         /// </summary>
         /// <param name="keys">Keys</param>
         void Remove(string[] keys);
-
-        /// <summary>
-        /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
-        /// </summary>
-        /// <param name="key">Key</param>
-        Task RemoveAsync(string key);
 
         /// <summary>
         /// Removes cache items by their keys.

--- a/src/Abp/Runtime/Caching/ICache.cs
+++ b/src/Abp/Runtime/Caching/ICache.cs
@@ -7,81 +7,11 @@ namespace Abp.Runtime.Caching
     /// <summary>
     /// Defines a cache that can be store and get items by keys.
     /// </summary>
-    public interface ICache : IDisposable, ICacheOptions, ICacheOperations, ICacheSingleKeyOperations<string, object>
+    public interface ICache : IDisposable, ICacheOptions, ICacheOperations, ICacheSingleKeyOperations<string, object>, ICacheMultipleKeysOperations<string, object>
     {
         /// <summary>
         /// Unique name of the cache.
         /// </summary>
         string Name { get; }
-
-        /// <summary>
-        /// Gets items from the cache.
-        /// This method hides cache provider failures (and logs them),
-        /// uses the factory method to get the object if cache provider fails.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        /// <param name="factory">Factory method to create cache item if not exists</param>
-        /// <returns>Cached item</returns>
-        object[] Get(string[] keys, Func<string, object> factory);
-
-        /// <summary>
-        /// Gets items from the cache.
-        /// This method hides cache provider failures (and logs them),
-        /// uses the factory method to get the object if cache provider fails.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        /// <param name="factory">Factory method to create cache item if not exists</param>
-        /// <returns>Cached items</returns>
-        Task<object[]> GetAsync(string[] keys, Func<string, Task<object>> factory);
-
-        /// <summary>
-        /// Gets items from the cache. For every key that is not found, a null value is returned.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        /// <returns>Cached items</returns>
-        object[] GetOrDefault(string[] keys);
-
-        /// <summary>
-        /// Gets items from the cache. For every key that is not found, a null value is returned.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        /// <returns>Cached items</returns>
-        Task<object[]> GetOrDefaultAsync(string[] keys);
-
-        /// <summary>
-        /// Saves/Overrides items in the cache by the pairs.
-        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
-        /// If none of them is specified, then
-        /// <see cref="DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="DefaultSlidingExpireTime"/>
-        /// will be used.
-        /// </summary>
-        /// <param name="pairs">Pairs</param>
-        /// <param name="slidingExpireTime">Sliding expire time</param>
-        /// <param name="absoluteExpireTime">Absolute expire time</param>
-        void Set(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
-
-        /// <summary>
-        /// Saves/Overrides items in the cache by the pairs.
-        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
-        /// If none of them is specified, then
-        /// <see cref="DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="DefaultSlidingExpireTime"/>
-        /// will be used.
-        /// </summary>
-        /// <param name="pairs">Pairs</param>
-        /// <param name="slidingExpireTime">Sliding expire time</param>
-        /// <param name="absoluteExpireTime">Absolute expire time</param>
-        Task SetAsync(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
-
-        /// <summary>
-        /// Removes cache items by their keys.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        void Remove(string[] keys);
-
-        /// <summary>
-        /// Removes cache items by their keys.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        Task RemoveAsync(string[] keys);
     }
 }

--- a/src/Abp/Runtime/Caching/ICache.cs
+++ b/src/Abp/Runtime/Caching/ICache.cs
@@ -7,7 +7,7 @@ namespace Abp.Runtime.Caching
     /// <summary>
     /// Defines a cache that can be store and get items by keys.
     /// </summary>
-    public interface ICache : IDisposable, ICacheOptions
+    public interface ICache : IDisposable, ICacheOptions, ICacheOperations
     {
         /// <summary>
         /// Unique name of the cache.
@@ -155,15 +155,5 @@ namespace Abp.Runtime.Caching
         /// </summary>
         /// <param name="keys">Keys</param>
         Task RemoveAsync(string[] keys);
-
-        /// <summary>
-        /// Clears all items in this cache.
-        /// </summary>
-        void Clear();
-
-        /// <summary>
-        /// Clears all items in this cache.
-        /// </summary>
-        Task ClearAsync();
     }
 }

--- a/src/Abp/Runtime/Caching/ICacheMultipleKeysOperations.cs
+++ b/src/Abp/Runtime/Caching/ICacheMultipleKeysOperations.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Abp.Runtime.Caching
+{
+    public interface ICacheMultipleKeysOperations<TKey, TSingleValue> : ICacheMultipleKeysOperations<TKey, TSingleValue, TSingleValue[]>
+    {
+    }
+
+    public interface ICacheMultipleKeysOperations<TKey, TSingleValue, TMultipleValues>
+    {
+        /// <summary>
+        /// Gets items from the cache.
+        /// This method hides cache provider failures (and logs them),
+        /// uses the factory method to get the object if cache provider fails.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <param name="factory">Factory method to create cache item if not exists</param>
+        /// <returns>Cached item</returns>
+        TMultipleValues Get(TKey[] keys, Func<TKey, TSingleValue> factory);
+
+        /// <summary>
+        /// Gets items from the cache.
+        /// This method hides cache provider failures (and logs them),
+        /// uses the factory method to get the object if cache provider fails.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <param name="factory">Factory method to create cache item if not exists</param>
+        /// <returns>Cached items</returns>
+        Task<TMultipleValues> GetAsync(TKey[] keys, Func<TKey, Task<TSingleValue>> factory);
+
+        /// <summary>
+        /// Gets items from the cache. For every key that is not found, a null value is returned.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <returns>Cached items</returns>
+        TMultipleValues GetOrDefault(TKey[] keys);
+
+        /// <summary>
+        /// Gets items from the cache. For every key that is not found, a null value is returned.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        /// <returns>Cached items</returns>
+        Task<TMultipleValues> GetOrDefaultAsync(TKey[] keys);
+
+        /// <summary>
+        /// Saves/Overrides items in the cache by the pairs.
+        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
+        /// If none of them is specified, then
+        /// <see cref="ICache.DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="DefaultSlidingExpireTime"/>
+        /// will be used.
+        /// </summary>
+        /// <param name="pairs">Pairs</param>
+        /// <param name="slidingExpireTime">Sliding expire time</param>
+        /// <param name="absoluteExpireTime">Absolute expire time</param>
+        void Set(KeyValuePair<TKey, TSingleValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        /// <summary>
+        /// Saves/Overrides items in the cache by the pairs.
+        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
+        /// If none of them is specified, then
+        /// <see cref="ICache.DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="DefaultSlidingExpireTime"/>
+        /// will be used.
+        /// </summary>
+        /// <param name="pairs">Pairs</param>
+        /// <param name="slidingExpireTime">Sliding expire time</param>
+        /// <param name="absoluteExpireTime">Absolute expire time</param>
+        Task SetAsync(KeyValuePair<TKey, TSingleValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        /// <summary>
+        /// Removes cache items by their keys.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        void Remove(TKey[] keys);
+
+        /// <summary>
+        /// Removes cache items by their keys.
+        /// </summary>
+        /// <param name="keys">Keys</param>
+        Task RemoveAsync(TKey[] keys);
+    }
+}

--- a/src/Abp/Runtime/Caching/ICacheOperations.cs
+++ b/src/Abp/Runtime/Caching/ICacheOperations.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Abp.Runtime.Caching
+{
+    public interface ICacheOperations
+    {
+        /// <summary>
+        /// Clears all items in this cache.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
+        /// Clears all items in this cache.
+        /// </summary>
+        Task ClearAsync();
+    }
+}

--- a/src/Abp/Runtime/Caching/ICacheSingleKeyOperations.cs
+++ b/src/Abp/Runtime/Caching/ICacheSingleKeyOperations.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Abp.Runtime.Caching
+{
+    public interface ICacheSingleKeyOperations<TKey, TValue>
+    {
+        /// <summary>
+        /// Gets an item from the cache.
+        /// This method hides cache provider failures (and logs them),
+        /// uses the factory method to get the object if cache provider fails.
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="factory">Factory method to create cache item if not exists</param>
+        /// <returns>Cached item</returns>
+        TValue Get(TKey key, Func<TKey, TValue> factory);
+
+        /// <summary>
+        /// Gets an item from the cache.
+        /// This method hides cache provider failures (and logs them),
+        /// uses the factory method to get the object if cache provider fails.
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="factory">Factory method to create cache item if not exists</param>
+        /// <returns>Cached item</returns>
+        Task<TValue> GetAsync(TKey key, Func<TKey, Task<TValue>> factory);
+
+        /// <summary>
+        /// Gets an item from the cache or null if not found.
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <returns>Cached item or null if not found</returns>
+        TValue GetOrDefault(TKey key);
+
+        /// <summary>
+        /// Gets an item from the cache or null if not found.
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <returns>Cached item or null if not found</returns>
+        Task<TValue> GetOrDefaultAsync(TKey key);
+
+        /// <summary>
+        /// Saves/Overrides an item in the cache by a key.
+        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
+        /// If none of them is specified, then
+        /// <see cref="ICacheOptions.DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="ICacheOptions.DefaultSlidingExpireTime"/>
+        /// will be used.
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        /// <param name="slidingExpireTime">Sliding expire time</param>
+        /// <param name="absoluteExpireTime">Absolute expire time</param>
+        void Set(TKey key, TValue value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        /// <summary>
+        /// Saves/Overrides an item in the cache by a key.
+        /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
+        /// If none of them is specified, then
+        /// <see cref="ICacheOptions.DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="ICacheOptions.DefaultSlidingExpireTime"/>
+        /// will be used.
+        /// </summary>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        /// <param name="slidingExpireTime">Sliding expire time</param>
+        /// <param name="absoluteExpireTime">Absolute expire time</param>
+        Task SetAsync(TKey key, TValue value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
+
+        /// <summary>
+        /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
+        /// </summary>
+        /// <param name="key">Key</param>
+        void Remove(TKey key);
+
+        /// <summary>
+        /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
+        /// </summary>
+        /// <param name="key">Key</param>
+        Task RemoveAsync(TKey key);
+    }
+}

--- a/src/Abp/Runtime/Caching/ITypedCache.cs
+++ b/src/Abp/Runtime/Caching/ITypedCache.cs
@@ -11,7 +11,7 @@ namespace Abp.Runtime.Caching
     /// </summary>
     /// <typeparam name="TKey">Key type for cache items</typeparam>
     /// <typeparam name="TValue">Value type for cache items</typeparam>
-    public interface ITypedCache<TKey, TValue> : IDisposable, ICacheOptions, ICacheOperations, ICacheSingleKeyOperations<TKey, TValue>
+    public interface ITypedCache<TKey, TValue> : IDisposable, ICacheOptions, ICacheOperations, ICacheSingleKeyOperations<TKey, TValue>, ICacheMultipleKeysOperations<TKey, TValue>
     {
         /// <summary>
         /// Unique name of the cache.
@@ -22,63 +22,5 @@ namespace Abp.Runtime.Caching
         /// Gets the internal cache.
         /// </summary>
         ICache InternalCache { get; }
-
-        /// <summary>
-        /// Gets items from the cache.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        /// <param name="factory">Factory method to create cache item if not exists</param>
-        /// <returns>Cached items</returns>
-        TValue[] Get(TKey[] keys, Func<TKey, TValue> factory);
-
-        /// <summary>
-        /// Gets items from the cache.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        /// <param name="factory">Factory method to create cache item if not exists</param>
-        /// <returns>Cached item</returns>
-        Task<TValue[]> GetAsync(TKey[] keys, Func<TKey, Task<TValue>> factory);
-
-        /// <summary>
-        /// Gets items from the cache. For every key that is not found, a null value is returned.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        /// <returns>Cached items</returns>
-        TValue[] GetOrDefault(TKey[] keys);
-
-        /// <summary>
-        /// Gets items from the cache. For every key that is not found, a null value is returned.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        /// <returns>Cached items</returns>
-        Task<TValue[]> GetOrDefaultAsync(TKey[] keys);
-
-        /// <summary>
-        /// Saves/Overrides items in the cache by the pairs.
-        /// </summary>
-        /// <param name="pairs">Pairs</param>
-        /// <param name="slidingExpireTime">Sliding expire time</param>
-        /// <param name="absoluteExpireTime">Absolute expire time</param>
-        void Set(KeyValuePair<TKey, TValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
-
-        /// <summary>
-        /// Saves/Overrides items in the cache by the pairs.
-        /// </summary>
-        /// <param name="pairs">Pairs</param>
-        /// <param name="slidingExpireTime">Sliding expire time</param>
-        /// <param name="absoluteExpireTime">Absolute expire time</param>
-        Task SetAsync(KeyValuePair<TKey, TValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
-
-        /// <summary>
-        /// Removes cache items by their keys.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        void Remove(TKey[] keys);
-
-        /// <summary>
-        /// Removes cache items by their keys.
-        /// </summary>
-        /// <param name="keys">Keys</param>
-        Task RemoveAsync(TKey[] keys);
     }
 }

--- a/src/Abp/Runtime/Caching/ITypedCache.cs
+++ b/src/Abp/Runtime/Caching/ITypedCache.cs
@@ -11,7 +11,7 @@ namespace Abp.Runtime.Caching
     /// </summary>
     /// <typeparam name="TKey">Key type for cache items</typeparam>
     /// <typeparam name="TValue">Value type for cache items</typeparam>
-    public interface ITypedCache<TKey, TValue> : IDisposable, ICacheOptions
+    public interface ITypedCache<TKey, TValue> : IDisposable, ICacheOptions, ICacheOperations
     {
         /// <summary>
         /// Unique name of the cache.
@@ -140,15 +140,5 @@ namespace Abp.Runtime.Caching
         /// </summary>
         /// <param name="keys">Keys</param>
         Task RemoveAsync(TKey[] keys);
-
-        /// <summary>
-        /// Clears all items in this cache.
-        /// </summary>
-        void Clear();
-
-        /// <summary>
-        /// Clears all items in this cache.
-        /// </summary>
-        Task ClearAsync();
     }
 }

--- a/src/Abp/Runtime/Caching/ITypedCache.cs
+++ b/src/Abp/Runtime/Caching/ITypedCache.cs
@@ -11,7 +11,7 @@ namespace Abp.Runtime.Caching
     /// </summary>
     /// <typeparam name="TKey">Key type for cache items</typeparam>
     /// <typeparam name="TValue">Value type for cache items</typeparam>
-    public interface ITypedCache<TKey, TValue> : IDisposable, ICacheOptions, ICacheOperations
+    public interface ITypedCache<TKey, TValue> : IDisposable, ICacheOptions, ICacheOperations, ICacheSingleKeyOperations<TKey, TValue>
     {
         /// <summary>
         /// Unique name of the cache.
@@ -24,28 +24,12 @@ namespace Abp.Runtime.Caching
         ICache InternalCache { get; }
 
         /// <summary>
-        /// Gets an item from the cache.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="factory">Factory method to create cache item if not exists</param>
-        /// <returns>Cached item</returns>
-        TValue Get(TKey key, Func<TKey, TValue> factory);
-
-        /// <summary>
         /// Gets items from the cache.
         /// </summary>
         /// <param name="keys">Keys</param>
         /// <param name="factory">Factory method to create cache item if not exists</param>
         /// <returns>Cached items</returns>
         TValue[] Get(TKey[] keys, Func<TKey, TValue> factory);
-
-        /// <summary>
-        /// Gets an item from the cache.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="factory">Factory method to create cache item if not exists</param>
-        /// <returns>Cached item</returns>
-        Task<TValue> GetAsync(TKey key, Func<TKey, Task<TValue>> factory);
 
         /// <summary>
         /// Gets items from the cache.
@@ -56,13 +40,6 @@ namespace Abp.Runtime.Caching
         Task<TValue[]> GetAsync(TKey[] keys, Func<TKey, Task<TValue>> factory);
 
         /// <summary>
-        /// Gets an item from the cache or null if not found.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Cached item or null if not found</returns>
-        TValue GetOrDefault(TKey key);
-
-        /// <summary>
         /// Gets items from the cache. For every key that is not found, a null value is returned.
         /// </summary>
         /// <param name="keys">Keys</param>
@@ -70,27 +47,11 @@ namespace Abp.Runtime.Caching
         TValue[] GetOrDefault(TKey[] keys);
 
         /// <summary>
-        /// Gets an item from the cache or null if not found.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Cached item or null if not found</returns>
-        Task<TValue> GetOrDefaultAsync(TKey key);
-
-        /// <summary>
         /// Gets items from the cache. For every key that is not found, a null value is returned.
         /// </summary>
         /// <param name="keys">Keys</param>
         /// <returns>Cached items</returns>
         Task<TValue[]> GetOrDefaultAsync(TKey[] keys);
-
-        /// <summary>
-        /// Saves/Overrides an item in the cache by a key.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="value">Value</param>
-        /// <param name="slidingExpireTime">Sliding expire time</param>
-        /// <param name="absoluteExpireTime">Absolute expire time</param>
-        void Set(TKey key, TValue value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
         /// Saves/Overrides items in the cache by the pairs.
@@ -101,15 +62,6 @@ namespace Abp.Runtime.Caching
         void Set(KeyValuePair<TKey, TValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
-        /// Saves/Overrides an item in the cache by a key.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="value">Value</param>
-        /// <param name="slidingExpireTime">Sliding expire time</param>
-        /// <param name="absoluteExpireTime">Absolute expire time</param>
-        Task SetAsync(TKey key, TValue value, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
-
-        /// <summary>
         /// Saves/Overrides items in the cache by the pairs.
         /// </summary>
         /// <param name="pairs">Pairs</param>
@@ -118,22 +70,10 @@ namespace Abp.Runtime.Caching
         Task SetAsync(KeyValuePair<TKey, TValue>[] pairs, TimeSpan? slidingExpireTime = null, TimeSpan? absoluteExpireTime = null);
 
         /// <summary>
-        /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
-        /// </summary>
-        /// <param name="key">Key</param>
-        void Remove(TKey key);
-
-        /// <summary>
         /// Removes cache items by their keys.
         /// </summary>
         /// <param name="keys">Keys</param>
         void Remove(TKey[] keys);
-
-        /// <summary>
-        /// Removes a cache item by it's key (does nothing if given key does not exists in the cache).
-        /// </summary>
-        /// <param name="key">Key</param>
-        Task RemoveAsync(TKey key);
 
         /// <summary>
         /// Removes cache items by their keys.


### PR DESCRIPTION
Allow CacheBase to be used for different types of `key`.
Also, to allow customisation on the return types for CacheBase APIs

For example,
[StackExchange.Redis#RedisKey supports string and btye](https://stackexchange.github.io/StackExchange.Redis/KeysValues.html)

- Keep non generic `ICache`
- Deprecate non generic `CacheBase`
   - `CacheBase<TKey, TValue>` for single key operations
   - `CacheBase<TKey, TSingleValue, TMultipleValues>` for multiple keys operations

#### Review
~This PR is base off #4722, so there will be additional commits/changes from other PR~