### PR TITLE
Generic CacheManagerBase

### DIFF
--- a/doc/WebSite/Caching.md
+++ b/doc/WebSite/Caching.md
@@ -103,8 +103,8 @@ while all other cache items will expire in 2 hours.
 
 Your configuration action is called once the cache is first created (on
 first request). Configuration is not restricted to
-DefaultSlidingExpireTime only, since the cache object is an ICache, you can
-use it's properties and methods to freely configure and initialize it.
+DefaultSlidingExpireTime only, since the cache object is an **ICacheOptions**, you can
+use it's properties to freely configure and initialize it.
 
 ### Entity Caching
 

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheManager.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheManager.cs
@@ -6,7 +6,7 @@ namespace Abp.Runtime.Caching.Redis
     /// <summary>
     /// Used to create <see cref="AbpRedisCache"/> instances.
     /// </summary>
-    public class AbpRedisCacheManager : CacheManagerBase
+    public class AbpRedisCacheManager : CacheManagerBase<ICache>, ICacheManager
     {
         private readonly IIocManager _iocManager;
 

--- a/src/Abp/Runtime/Caching/CacheManagerBase.cs
+++ b/src/Abp/Runtime/Caching/CacheManagerBase.cs
@@ -10,12 +10,13 @@ namespace Abp.Runtime.Caching
     /// <summary>
     /// Base class for cache managers.
     /// </summary>
-    public abstract class CacheManagerBase : ICacheManager, ISingletonDependency
+    public abstract class CacheManagerBase<TCache> : ICacheManager<TCache>, ISingletonDependency
+        where TCache : class, ICacheOptions
     {
 
         protected readonly ICachingConfiguration Configuration;
 
-        protected readonly ConcurrentDictionary<string, ICache> Caches;
+        protected readonly ConcurrentDictionary<string, TCache> Caches;
 
         /// <summary>
         /// Constructor.
@@ -24,15 +25,15 @@ namespace Abp.Runtime.Caching
         protected CacheManagerBase(ICachingConfiguration configuration)
         {
             Configuration = configuration;
-            Caches = new ConcurrentDictionary<string, ICache>();
+            Caches = new ConcurrentDictionary<string, TCache>();
         }
 
-        public IReadOnlyList<ICache> GetAllCaches()
+        public IReadOnlyList<TCache> GetAllCaches()
         {
             return Caches.Values.ToImmutableList();
         }
 
-        public virtual ICache GetCache(string name)
+        public virtual TCache GetCache(string name)
         {
             Check.NotNull(name, nameof(name));
 
@@ -62,6 +63,6 @@ namespace Abp.Runtime.Caching
         /// </summary>
         /// <param name="name">Name of the cache</param>
         /// <returns>Cache object</returns>
-        protected abstract ICache CreateCacheImplementation(string name);
+        protected abstract TCache CreateCacheImplementation(string name);
     }
 }

--- a/src/Abp/Runtime/Caching/CacheManagerBase.cs
+++ b/src/Abp/Runtime/Caching/CacheManagerBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -7,6 +8,14 @@ using Abp.Runtime.Caching.Configuration;
 
 namespace Abp.Runtime.Caching
 {
+    [Obsolete("Use CacheManagerBase<TCache> instead.")]
+    public abstract class CacheManagerBase : CacheManagerBase<ICache>, ICacheManager
+    {
+        public CacheManagerBase(ICachingConfiguration configuration) : base(configuration)
+        {
+        }
+    }
+
     /// <summary>
     /// Base class for cache managers.
     /// </summary>

--- a/src/Abp/Runtime/Caching/Configuration/CacheConfigurator.cs
+++ b/src/Abp/Runtime/Caching/Configuration/CacheConfigurator.cs
@@ -6,14 +6,14 @@ namespace Abp.Runtime.Caching.Configuration
     {
         public string CacheName { get; private set; }
 
-        public Action<ICache> InitAction { get; private set; }
+        public Action<ICacheOptions> InitAction { get; private set; }
 
-        public CacheConfigurator(Action<ICache> initAction)
+        public CacheConfigurator(Action<ICacheOptions> initAction)
         {
             InitAction = initAction;
         }
 
-        public CacheConfigurator(string cacheName, Action<ICache> initAction)
+        public CacheConfigurator(string cacheName, Action<ICacheOptions> initAction)
         {
             CacheName = cacheName;
             InitAction = initAction;

--- a/src/Abp/Runtime/Caching/Configuration/CachingConfiguration.cs
+++ b/src/Abp/Runtime/Caching/Configuration/CachingConfiguration.cs
@@ -22,12 +22,12 @@ namespace Abp.Runtime.Caching.Configuration
             _configurators = new List<ICacheConfigurator>();
         }
 
-        public void ConfigureAll(Action<ICache> initAction)
+        public void ConfigureAll(Action<ICacheOptions> initAction)
         {
             _configurators.Add(new CacheConfigurator(initAction));
         }
 
-        public void Configure(string cacheName, Action<ICache> initAction)
+        public void Configure(string cacheName, Action<ICacheOptions> initAction)
         {
             _configurators.Add(new CacheConfigurator(cacheName, initAction));
         }

--- a/src/Abp/Runtime/Caching/Configuration/ICacheConfigurator.cs
+++ b/src/Abp/Runtime/Caching/Configuration/ICacheConfigurator.cs
@@ -16,6 +16,6 @@ namespace Abp.Runtime.Caching.Configuration
         /// <summary>
         /// Configuration action. Called just after the cache is created.
         /// </summary>
-        Action<ICache> InitAction { get; }
+        Action<ICacheOptions> InitAction { get; }
     }
 }

--- a/src/Abp/Runtime/Caching/Configuration/ICachingConfiguration.cs
+++ b/src/Abp/Runtime/Caching/Configuration/ICachingConfiguration.cs
@@ -26,7 +26,7 @@ namespace Abp.Runtime.Caching.Configuration
         /// An action to configure caches
         /// This action is called for each cache just after created.
         /// </param>
-        void ConfigureAll(Action<ICache> initAction);
+        void ConfigureAll(Action<ICacheOptions> initAction);
 
         /// <summary>
         /// Used to configure a specific cache. 
@@ -36,6 +36,6 @@ namespace Abp.Runtime.Caching.Configuration
         /// An action to configure the cache.
         /// This action is called just after the cache is created.
         /// </param>
-        void Configure(string cacheName, Action<ICache> initAction);
+        void Configure(string cacheName, Action<ICacheOptions> initAction);
     }
 }

--- a/src/Abp/Runtime/Caching/ICache.cs
+++ b/src/Abp/Runtime/Caching/ICache.cs
@@ -7,25 +7,12 @@ namespace Abp.Runtime.Caching
     /// <summary>
     /// Defines a cache that can be store and get items by keys.
     /// </summary>
-    public interface ICache : IDisposable
+    public interface ICache : IDisposable, ICacheOptions
     {
         /// <summary>
         /// Unique name of the cache.
         /// </summary>
         string Name { get; }
-
-        /// <summary>
-        /// Default sliding expire time of cache items.
-        /// Default value: 60 minutes (1 hour).
-        /// Can be changed by configuration.
-        /// </summary>
-        TimeSpan DefaultSlidingExpireTime { get; set; }
-
-        /// <summary>
-        /// Default absolute expire time of cache items.
-        /// Default value: null (not used).
-        /// </summary>
-        TimeSpan? DefaultAbsoluteExpireTime { get; set; }
 
         /// <summary>
         /// Gets an item from the cache.
@@ -99,7 +86,7 @@ namespace Abp.Runtime.Caching
         /// Saves/Overrides an item in the cache by a key.
         /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
         /// If none of them is specified, then
-        /// <see cref="DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="DefaultSlidingExpireTime"/>
+        /// <see cref="ICacheOptions.DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="ICacheOptions.DefaultSlidingExpireTime"/>
         /// will be used.
         /// </summary>
         /// <param name="key">Key</param>
@@ -124,7 +111,7 @@ namespace Abp.Runtime.Caching
         /// Saves/Overrides an item in the cache by a key.
         /// Use one of the expire times at most (<paramref name="slidingExpireTime"/> or <paramref name="absoluteExpireTime"/>).
         /// If none of them is specified, then
-        /// <see cref="DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="DefaultSlidingExpireTime"/>
+        /// <see cref="ICacheOptions.DefaultAbsoluteExpireTime"/> will be used if it's not null. Othewise, <see cref="ICacheOptions.DefaultSlidingExpireTime"/>
         /// will be used.
         /// </summary>
         /// <param name="key">Key</param>

--- a/src/Abp/Runtime/Caching/ICacheManager.cs
+++ b/src/Abp/Runtime/Caching/ICacheManager.cs
@@ -8,13 +8,18 @@ namespace Abp.Runtime.Caching
     /// An upper level container for <see cref="ICache"/> objects. 
     /// A cache manager should work as Singleton and track and manage <see cref="ICache"/> objects.
     /// </summary>
-    public interface ICacheManager : IDisposable
+    public interface ICacheManager : ICacheManager<ICache>
+    {
+    }
+
+    public interface ICacheManager<TCache> : IDisposable
+        where TCache : class
     {
         /// <summary>
         /// Gets all caches.
         /// </summary>
         /// <returns>List of caches</returns>
-        IReadOnlyList<ICache> GetAllCaches();
+        IReadOnlyList<TCache> GetAllCaches();
 
         /// <summary>
         /// Gets a <see cref="ICache"/> instance.
@@ -24,6 +29,6 @@ namespace Abp.Runtime.Caching
         /// Unique and case sensitive name of the cache.
         /// </param>
         /// <returns>The cache reference</returns>
-        [NotNull] ICache GetCache([NotNull] string name);
+        [NotNull] TCache GetCache([NotNull] string name);
     }
 }

--- a/src/Abp/Runtime/Caching/ICacheOptions.cs
+++ b/src/Abp/Runtime/Caching/ICacheOptions.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Abp.Runtime.Caching
+{
+    public interface ICacheOptions
+    {
+        /// <summary>
+        /// Default sliding expire time of cache items.
+        /// Default value: 60 minutes (1 hour).
+        /// Can be changed by configuration.
+        /// </summary>
+        TimeSpan DefaultSlidingExpireTime { get; set; }
+
+        /// <summary>
+        /// Default absolute expire time of cache items.
+        /// Default value: null (not used).
+        /// </summary>
+        TimeSpan? DefaultAbsoluteExpireTime { get; set; }
+    }
+}

--- a/src/Abp/Runtime/Caching/ITypedCache.cs
+++ b/src/Abp/Runtime/Caching/ITypedCache.cs
@@ -11,17 +11,12 @@ namespace Abp.Runtime.Caching
     /// </summary>
     /// <typeparam name="TKey">Key type for cache items</typeparam>
     /// <typeparam name="TValue">Value type for cache items</typeparam>
-    public interface ITypedCache<TKey, TValue> : IDisposable
+    public interface ITypedCache<TKey, TValue> : IDisposable, ICacheOptions
     {
         /// <summary>
         /// Unique name of the cache.
         /// </summary>
         string Name { get; }
-
-        /// <summary>
-        /// Default sliding expire time of cache items.
-        /// </summary>
-        TimeSpan DefaultSlidingExpireTime { get; set; }
 
         /// <summary>
         /// Gets the internal cache.

--- a/src/Abp/Runtime/Caching/Memory/AbpMemoryCacheManager.cs
+++ b/src/Abp/Runtime/Caching/Memory/AbpMemoryCacheManager.cs
@@ -1,5 +1,4 @@
-﻿using Abp.Dependency;
-using Abp.Runtime.Caching.Configuration;
+﻿using Abp.Runtime.Caching.Configuration;
 using Castle.Core.Logging;
 
 namespace Abp.Runtime.Caching.Memory
@@ -7,7 +6,7 @@ namespace Abp.Runtime.Caching.Memory
     /// <summary>
     /// Implements <see cref="ICacheManager"/> to work with MemoryCache.
     /// </summary>
-    public class AbpMemoryCacheManager : CacheManagerBase
+    public class AbpMemoryCacheManager : CacheManagerBase<ICache>, ICacheManager
     {
         public ILogger Logger { get; set; }
 


### PR DESCRIPTION
#### Breaking Change
- caching configuration action will be passing `ICacheOptions` instead `ICache`.
   *This is allow different caching implementations to be configured without implementing `ICache`*

```csharp
Configuration.Caching.ConfigureAll(cache =>
{
    cache.DefaultSlidingExpireTime = TimeSpan.FromHours(2);
    
    // The followings will NO LONGER BE SUPPORTED within configure action
    var name = cache.Name;
    cache.Clear();
    cache.Remove("My Key");
});

Configuration.Caching.Configure("MyCache", cache =>
{
    cache.DefaultSlidingExpireTime = TimeSpan.FromHours(8);

    // The followings will NO LONGER BE SUPPORTED within configure action
    var name = cache.Name;
    cache.Clear();
    cache.Remove("My Key");
});
```

#### Enhancement
- Add `ICacheOptions` which extracts configurable fields from `ICache`
   (previously, `ITypeCache` implementation supports `DefaultAbsoluteExpireTime` but it was missed out in the interface)
- Create generic `CacheManagerBase<TCache>` to allow custom implementation of cache manager
- Deprecate non-generic `CacheManagerBase` 