### PR TITLE
Fix #4729 Filter ApplicationText entities in memory

### DIFF
--- a/src/Abp.Zero.Common/Localization/ApplicationLanguageTextManager.cs
+++ b/src/Abp.Zero.Common/Localization/ApplicationLanguageTextManager.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Abp.Dependency;
 using Abp.Domain.Repositories;
@@ -64,11 +65,11 @@ namespace Abp.Localization
         {
             using (_unitOfWorkManager.Current.SetTenantId(tenantId))
             {
-                var existingEntity = await _applicationTextRepository.FirstOrDefaultAsync(t =>
+                var existingEntity = (await _applicationTextRepository.GetAllListAsync(t =>
                     t.Source == sourceName &&
                     t.LanguageName == culture.Name &&
-                    t.Key == key
-                    );
+                    t.Key == key))
+                    .FirstOrDefault(t => t.Key == key);
 
                 if (existingEntity != null)
                 {


### PR DESCRIPTION
Simple fix for #4729 
Retrieves all `ApplicationText` entities with given source, culture and key, then filters in memory to get the actual entity with matching text case.