### PR TITLE
fix async background job ioc registration

### DIFF
--- a/src/Abp/AbpKernelModule.cs
+++ b/src/Abp/AbpKernelModule.cs
@@ -69,6 +69,8 @@ namespace Abp
             IocManager.Register(typeof(IOnlineClientManager<>), typeof(OnlineClientManager<>), DependencyLifeStyle.Singleton);
             IocManager.Register(typeof(IOnlineClientStore<>), typeof(InMemoryOnlineClientStore<>), DependencyLifeStyle.Singleton);
 
+            IocManager.Register(typeof(EventTriggerAsyncBackgroundJob<>), DependencyLifeStyle.Transient);
+
             IocManager.RegisterAssemblyByConvention(typeof(AbpKernelModule).GetAssembly(),
                 new ConventionalRegistrationConfig
                 {


### PR DESCRIPTION
Generic interface should be registered explicitly.

https://github.com/aspnetboilerplate/aspnetboilerplate/blob/5a96c66d5ec7cbfdaebe16429832b7a457872c3a/src/Abp/Dependency/BasicConventionalRegistrar.cs#L14-L23

Regression from #4702 