### PR TITLE
fixed entity history property change null value check bug

### DIFF
--- a/src/Abp.Zero.EntityFramework/EntityHistory/Extensions/DbPropertyEntryExtensions.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/Extensions/DbPropertyEntryExtensions.cs
@@ -37,6 +37,11 @@ namespace Abp.EntityHistory.Extensions
                 return propertyEntry.OriginalValue != null;
             }
 
+            if (propertyEntry.OriginalValue == null && propertyEntry.CurrentValue == null)
+            {
+                return false;
+            }
+
             return !(propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue) ?? propertyEntry.CurrentValue == null);
         }
     }

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -330,6 +330,11 @@ namespace Abp.EntityHistory
                 return false;
             }
 
+            if (propertyEntry.OriginalValue == null && propertyEntry.CurrentValue == null)
+            {
+                return false;
+            }
+
             var propertyInfo = propertyEntry.Metadata.PropertyInfo;
 
             var shouldSavePropertyHistoryForInfo = ShouldSavePropertyHistoryForInfo(propertyInfo, shouldSaveEntityHistory);


### PR DESCRIPTION
When the CurrentValue and OriginalValue of a property are both Null, a data will still be recorded in the EntityPropertyChange.
The code for the EfCore version is as follows:
https://github.com/aspnetboilerplate/aspnetboilerplate/blob/c33224544a18b00512162a489bc55c3ca194431f/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs#L341

When CurrentValue And NewValue both null，`propertyEntry.OriginalValue?.Equals(propertyEntry.CurrentValue`  return `null`.

And the result of `propertyEntry.CurrentValue == null` will be used to decide whether to save the data.