### PR TITLE
Entity history audit properties

### DIFF
--- a/src/Abp/Domain/Entities/Auditing/AuditedAggregateRoot.cs
+++ b/src/Abp/Domain/Entities/Auditing/AuditedAggregateRoot.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Abp.Auditing;
 
 namespace Abp.Domain.Entities.Auditing
 {
@@ -22,11 +23,13 @@ namespace Abp.Domain.Entities.Auditing
         /// <summary>
         /// Last modification date of this entity.
         /// </summary>
+        [Audited]
         public virtual DateTime? LastModificationTime { get; set; }
 
         /// <summary>
         /// Last modifier user of this entity.
         /// </summary>
+        [Audited]
         public virtual long? LastModifierUserId { get; set; }
     }
 

--- a/src/Abp/Domain/Entities/Auditing/AuditedEntity.cs
+++ b/src/Abp/Domain/Entities/Auditing/AuditedEntity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Abp.Auditing;
 
 namespace Abp.Domain.Entities.Auditing
 {
@@ -22,11 +23,13 @@ namespace Abp.Domain.Entities.Auditing
         /// <summary>
         /// Last modification date of this entity.
         /// </summary>
+        [Audited]
         public virtual DateTime? LastModificationTime { get; set; }
 
         /// <summary>
         /// Last modifier user of this entity.
         /// </summary>
+        [Audited]
         public virtual long? LastModifierUserId { get; set; }
     }
 

--- a/src/Abp/Domain/Entities/Auditing/CreationAuditedAggregateRoot.cs
+++ b/src/Abp/Domain/Entities/Auditing/CreationAuditedAggregateRoot.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Abp.Auditing;
 using Abp.Timing;
 
 namespace Abp.Domain.Entities.Auditing
@@ -10,7 +11,7 @@ namespace Abp.Domain.Entities.Auditing
     [Serializable]
     public abstract class CreationAuditedAggregateRoot : CreationAuditedAggregateRoot<int>
     {
-        
+
     }
 
     /// <summary>
@@ -23,11 +24,13 @@ namespace Abp.Domain.Entities.Auditing
         /// <summary>
         /// Creation time of this entity.
         /// </summary>
+        [Audited]
         public virtual DateTime CreationTime { get; set; }
 
         /// <summary>
         /// Creator of this entity.
         /// </summary>
+        [Audited]
         public virtual long? CreatorUserId { get; set; }
 
         /// <summary>

--- a/src/Abp/Domain/Entities/Auditing/CreationAuditedEntity.cs
+++ b/src/Abp/Domain/Entities/Auditing/CreationAuditedEntity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Abp.Auditing;
 using Abp.Timing;
 
 namespace Abp.Domain.Entities.Auditing
@@ -23,11 +24,13 @@ namespace Abp.Domain.Entities.Auditing
         /// <summary>
         /// Creation time of this entity.
         /// </summary>
+        [Audited]
         public virtual DateTime CreationTime { get; set; }
 
         /// <summary>
         /// Creator of this entity.
         /// </summary>
+        [Audited]
         public virtual long? CreatorUserId { get; set; }
 
         /// <summary>

--- a/src/Abp/Domain/Entities/Auditing/FullAuditedAggregateRoot.cs
+++ b/src/Abp/Domain/Entities/Auditing/FullAuditedAggregateRoot.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Abp.Auditing;
 
 namespace Abp.Domain.Entities.Auditing
 {
@@ -22,16 +23,19 @@ namespace Abp.Domain.Entities.Auditing
         /// <summary>
         /// Is this entity Deleted?
         /// </summary>
+        [Audited]
         public virtual bool IsDeleted { get; set; }
 
         /// <summary>
         /// Which user deleted this entity?
         /// </summary>
+        [Audited]
         public virtual long? DeleterUserId { get; set; }
 
         /// <summary>
         /// Deletion time of this entity.
         /// </summary>
+        [Audited]
         public virtual DateTime? DeletionTime { get; set; }
     }
 

--- a/src/Abp/Domain/Entities/Auditing/FullAuditedEntity.cs
+++ b/src/Abp/Domain/Entities/Auditing/FullAuditedEntity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Abp.Auditing;
 
 namespace Abp.Domain.Entities.Auditing
 {
@@ -22,16 +23,19 @@ namespace Abp.Domain.Entities.Auditing
         /// <summary>
         /// Is this entity Deleted?
         /// </summary>
+        [Audited]
         public virtual bool IsDeleted { get; set; }
 
         /// <summary>
         /// Which user deleted this entity?
         /// </summary>
+        [Audited]
         public virtual long? DeleterUserId { get; set; }
 
         /// <summary>
         /// Deletion time of this entity.
         /// </summary>
+        [Audited]
         public virtual DateTime? DeletionTime { get; set; }
     }
 
@@ -47,6 +51,7 @@ namespace Abp.Domain.Entities.Auditing
         /// <summary>
         /// Is this entity Deleted?
         /// </summary>
+        [Audited]
         public virtual bool IsDeleted { get; set; }
 
         /// <summary>
@@ -58,11 +63,13 @@ namespace Abp.Domain.Entities.Auditing
         /// <summary>
         /// Which user deleted this entity?
         /// </summary>
+        [Audited]
         public virtual long? DeleterUserId { get; set; }
 
         /// <summary>
         /// Deletion time of this entity.
         /// </summary>
+        [Audited]
         public virtual DateTime? DeletionTime { get; set; }
     }
 }

--- a/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
+++ b/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
@@ -14,15 +14,17 @@ namespace Abp.Zero.SampleApp.EntityFramework
     {
         public DbSet<Book> Books { get; set; }
 
-        public DbSet<Comment> Comments { get; set; }
-
-        public DbSet<Blog> Blogs { get; set; }
-
-        public DbSet<Post> Posts { get; set; }
-
         public DbSet<Author> Authors { get; set; }
 
         public DbSet<Store> Stores { get; set; }
+
+        public DbSet<Blog> Blogs { get; set; }
+
+        public DbSet<Advertisement> Advertisements { get; set; }
+
+        public DbSet<Comment> Comments { get; set; }
+
+        public DbSet<Post> Posts { get; set; }
         
         public DbSet<UserTestEntity> UserTestEntities { get; set; }
 

--- a/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
+++ b/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
@@ -31,6 +31,9 @@ namespace Abp.Zero.SampleApp.Tests.TestDatas
             var comment2 = new Comment { Post = post2, Content = "test-comment-2-content" };
 
             _context.Comments.AddRange(new Comment[] { comment1, comment2 });
+
+            var advertisement1 = new Advertisement { Title = "test-advertisement-1" };
+            _context.Advertisements.Add(advertisement1);
         }
     }
 }

--- a/test/Abp.Zero.SampleApp/EntityHistory/Advertisement.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Advertisement.cs
@@ -1,0 +1,13 @@
+﻿using Abp.Domain.Entities.Auditing;
+
+namespace Abp.Zero.SampleApp.EntityHistory
+{
+    public class Advertisement : FullAuditedAggregateRoot
+    {
+        public string Title { get; set; }
+
+        public Advertisement()
+        {
+        }
+    }
+}

--- a/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
@@ -7,7 +7,7 @@ using Abp.Domain.Entities;
 
 namespace Abp.Zero.SampleApp.EntityHistory
 {
-    public class Post : AuditedEntity<Guid>, ISoftDelete, IMayHaveTenant
+    public class Post : FullAuditedEntity<Guid>, IMayHaveTenant
     {
         [Required]
         public virtual Blog Blog { get; set; }
@@ -20,8 +20,6 @@ namespace Abp.Zero.SampleApp.EntityHistory
         public string Title { get; set; }
 
         public string Body { get; set; }
-
-        public bool IsDeleted { get; set; }
 
         public int? TenantId { get; set; }
 


### PR DESCRIPTION
Resolve #4693

Follows up on https://github.com/aspnetboilerplate/aspnetboilerplate/pull/4694#discussion_r305653917

- Add `Audited` attribute to all Auditing Entity base class

The following will be done in #4815 
- ~Entity History post-saving (e.g after `SaveChanges()`) will~
  - ~Update Entity Id (existing)~
  - ~Update Foreign Keys (existing)~
  - ~Update Other tracked properties in `EntityChange.PropertyChanges` (new)~

Fix for
- [ ] EF6
- [ ] EF Core

Test for
- [x] EF6
- [ ] Ef Core