### PR TITLE
Resolve #4779 UserAccountSynchronizer handles events where tenants are deleted.

### DIFF
--- a/src/Abp.Zero.Common/Authorization/Users/UserAccountSynchronizer.cs
+++ b/src/Abp.Zero.Common/Authorization/Users/UserAccountSynchronizer.cs
@@ -1,8 +1,10 @@
+using System.Linq;
 using Abp.Dependency;
 using Abp.Domain.Repositories;
 using Abp.Domain.Uow;
 using Abp.Events.Bus.Entities;
 using Abp.Events.Bus.Handlers;
+using Abp.MultiTenancy;
 
 namespace Abp.Authorization.Users
 {
@@ -13,6 +15,7 @@ namespace Abp.Authorization.Users
         IEventHandler<EntityCreatedEventData<AbpUserBase>>,
         IEventHandler<EntityDeletedEventData<AbpUserBase>>,
         IEventHandler<EntityUpdatedEventData<AbpUserBase>>,
+        IEventHandler<EntityDeletedEventData<AbpTenantBase>>,
         ITransientDependency
     {
         private readonly IRepository<UserAccount, long> _userAccountRepository;
@@ -37,13 +40,25 @@ namespace Abp.Authorization.Users
         {
             using (_unitOfWorkManager.Current.SetTenantId(null))
             {
-                _userAccountRepository.Insert(new UserAccount
+                var userAccount =
+                    _userAccountRepository.FirstOrDefault(
+                        ua => ua.TenantId == eventData.Entity.TenantId && ua.UserId == eventData.Entity.Id);
+                if (userAccount == null)
                 {
-                    TenantId = eventData.Entity.TenantId,
-                    UserName = eventData.Entity.UserName,
-                    UserId = eventData.Entity.Id,
-                    EmailAddress = eventData.Entity.EmailAddress
-                });
+                    _userAccountRepository.Insert(new UserAccount
+                    {
+                        TenantId = eventData.Entity.TenantId,
+                        UserName = eventData.Entity.UserName,
+                        UserId = eventData.Entity.Id,
+                        EmailAddress = eventData.Entity.EmailAddress
+                    });
+                }
+                else
+                {
+                    userAccount.UserName = eventData.Entity.UserName;
+                    userAccount.EmailAddress = eventData.Entity.EmailAddress;
+                    _userAccountRepository.Update(userAccount);
+                }
             }
         }
 
@@ -82,6 +97,19 @@ namespace Abp.Authorization.Users
                     userAccount.EmailAddress = eventData.Entity.EmailAddress;
                     _userAccountRepository.Update(userAccount);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Handles deletion event of tenant
+        /// </summary>
+        /// <param name="eventData"></param>
+        [UnitOfWork]
+        public virtual void HandleEvent(EntityDeletedEventData<AbpTenantBase> eventData)
+        {
+            using (_unitOfWorkManager.Current.SetTenantId(null))
+            {
+                _userAccountRepository.Delete(ua => ua.TenantId == eventData.Entity.Id);
             }
         }
     }

--- a/test/Abp.Zero.SampleApp.Tests/Users/UserAccountSynchronizer_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Users/UserAccountSynchronizer_Tests.cs
@@ -1,7 +1,11 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
+using Abp.Domain.Uow;
 using Abp.Timing;
+using Abp.Zero.SampleApp.MultiTenancy;
 using Abp.Zero.SampleApp.Users;
 using Abp.Zero.SampleApp.Users.Dto;
+using Microsoft.AspNet.Identity;
 using Shouldly;
 using Xunit;
 
@@ -10,10 +14,16 @@ namespace Abp.Zero.SampleApp.Tests.Users
     public class UserAccountSynchronizer_Tests : SampleAppTestBase
     {
         private readonly IUserAppService _userAppService;
+        private readonly TenantManager _tenantManager;
+        private readonly UserManager _userManager;
+        private readonly IUnitOfWorkManager _unitOfWorkManager;
 
         public UserAccountSynchronizer_Tests()
         {
             _userAppService = Resolve<IUserAppService>();
+            _tenantManager = Resolve<TenantManager>();
+            _userManager = Resolve<UserManager>();
+            _unitOfWorkManager = Resolve<IUnitOfWorkManager>();
         }
 
         [Fact]
@@ -78,6 +88,52 @@ namespace Abp.Zero.SampleApp.Tests.Users
                 context =>
                 {
                     var userAccount = context.UserAccounts.First(u => u.UserName == "yunus.emre");
+                    userAccount.IsDeleted.ShouldBe(true);
+                });
+        }
+
+        [Fact]
+        public async Task Should_Delete_UserAccount_When_Tenant_Deleted()
+        {
+            var tenant = new Tenant("test-tenant-name", "test-tenant-name");
+            await _tenantManager.CreateAsync(tenant);
+
+            var user = new User
+            {
+                TenantId = tenant.Id,
+                UserName = "TestTenantUser",
+                Name = "TestTenantUser",
+                Surname = "TestTenantUser",
+                EmailAddress = "TestTenantUser@abp.io",
+                IsEmailConfirmed = true,
+                Password = "AM4OLBpptxBYmM79lGOX9egzZk3vIQU3d/gFCJzaBjAPXzYIK3tQ2N7X4fcrHtElTw==" //123qwe
+            };
+
+            using (var uow = _unitOfWorkManager.Begin())
+            {
+                await _userManager.CreateAsync(user);
+                await _unitOfWorkManager.Current.SaveChangesAsync();
+                await uow.CompleteAsync();
+            }
+
+            UsingDbContext(
+                context =>
+                {
+                    var userAccount = context.UserAccounts.First(u => u.UserName == "TestTenantUser");
+                    userAccount.IsDeleted.ShouldBe(false);
+                });
+
+            using (var uow = _unitOfWorkManager.Begin())
+            {
+                await _tenantManager.DeleteAsync(tenant);
+                await _unitOfWorkManager.Current.SaveChangesAsync();
+                await uow.CompleteAsync();
+            }
+
+            UsingDbContext(
+                context =>
+                {
+                    var userAccount = context.UserAccounts.First(u => u.UserName == "TestTenantUser");
                     userAccount.IsDeleted.ShouldBe(true);
                 });
         }


### PR DESCRIPTION
User creation events should check for duplicates.