### PR TITLE
Improve performance of Skip() and Take() by converting to Lambda

### DIFF
--- a/src/Abp/Linq/Extensions/QueryableExtensions.cs
+++ b/src/Abp/Linq/Extensions/QueryableExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using Abp.Application.Services.Dto;
+using System.Data.Entity;
 
 namespace Abp.Linq.Extensions
 {
@@ -20,7 +21,7 @@ namespace Abp.Linq.Extensions
                 throw new ArgumentNullException("query");
             }
 
-            return query.Skip(skipCount).Take(maxResultCount);
+            return query.Skip(() => skipCount).Take(() => maxResultCount);
         }
 
         /// <summary>


### PR DESCRIPTION
I have done no testing of this code but it might be worth looking at if it improves repeated query speed?
I saw the suggestion here: https://visualstudiomagazine.com/articles/2016/12/06/skip-take-entity-framework-lambda.aspx
So it might not apply to .NETCore?