### PR TITLE
Changes security stamp when password change via using ChangePasswordAsync function

### DIFF
--- a/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.Zero/Authorization/Users/AbpUserManager.cs
@@ -364,16 +364,7 @@ namespace Abp.Authorization.Users
                 }
             }
 
-            bool isUserCredentialsSameWithStored = await IsUserCredentialsSameWithStored(user);
-
-            var updateResult = await base.UpdateAsync(user);
-
-            if (!isUserCredentialsSameWithStored)//update security stamp too, if any credential is changed
-            {
-                await UpdateSecurityStampAsync(user.Id);
-            }
-
-            return updateResult;
+            return await base.UpdateAsync(user);
         }
 
         public override async Task<IdentityResult> DeleteAsync(TUser user)
@@ -748,23 +739,6 @@ namespace Abp.Authorization.Users
             }
 
             return AbpSession.MultiTenancySide;
-        }
-
-        /// <summary>
-        /// Check if stored users critic credentials are same with given.
-        /// </summary>
-        public virtual async Task<bool> IsUserCredentialsSameWithStored(TUser user)
-        {
-            var storedUser = await GetUserByIdAsync(user.Id);
-            if (
-                storedUser.UserName != user.UserName ||
-                storedUser.EmailAddress != user.EmailAddress ||
-                storedUser.Password != user.Password
-            )
-            {
-                return false;
-            }
-            return true;
         }
     }
 }

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
@@ -363,16 +363,7 @@ namespace Abp.Authorization.Users
                 }
             }
 
-            bool isUserCredentialsSameWithStored = await IsUserCredentialsSameWithStored(user);
-
-            var updateResult = await base.UpdateAsync(user);
-
-            if (!isUserCredentialsSameWithStored)//update security stamp too, if any credential is changed
-            {
-                await UpdateSecurityStampAsync(user);
-            }
-
-            return updateResult;
+            return await base.UpdateAsync(user);
         }
 
         public override async Task<IdentityResult> DeleteAsync(TUser user)
@@ -409,7 +400,7 @@ namespace Abp.Authorization.Users
 
             return IdentityResult.Success;
         }
-
+        
         public virtual async Task<IdentityResult> CheckDuplicateUsernameOrEmailAddressAsync(long? expectedUserId, string userName, string emailAddress)
         {
             var user = (await FindByNameAsync(userName));
@@ -761,21 +752,5 @@ namespace Abp.Authorization.Users
             await AbpUserStore.RemoveTokenValidityKeyAsync(user, tokenValidityKey, cancellationToken);
         }
 
-        /// <summary>
-        /// Check if stored users critic credentials are same with given.
-        /// </summary>
-        public virtual async Task<bool> IsUserCredentialsSameWithStored(TUser user)
-        {
-            var storedUser = await GetUserByIdAsync(user.Id);
-            if (
-                storedUser.UserName != user.UserName ||
-                storedUser.EmailAddress != user.EmailAddress ||
-                storedUser.Password != user.Password
-                )
-            {
-                return false;
-            }
-            return true;
-        }
     }
 }

--- a/test/Abp.Zero.SampleApp.Tests/Users/UserAppService_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Users/UserAppService_Tests.cs
@@ -76,57 +76,5 @@ namespace Abp.Zero.SampleApp.Tests.Users
             updatedUser.UserName.ShouldBe("manager");
             updatedUser.PasswordResetCode.ShouldBe(null);
         }
-
-        [Fact]
-        public async Task Should_Change_Security_Stamp()
-        {
-            _userAppService.CreateUser(
-                new CreateUserInput
-                {
-                    EmailAddress = "security@stamp.com",
-                    Name = "Security",
-                    Surname = "Stamp",
-                    UserName = "SecurityStamp"
-                });
-
-            var firstUser = await _userManager.FindByNameAsync("SecurityStamp");
-            var firstSecurityStamp = firstUser.SecurityStamp;
-
-            //change password
-            await _userManager.ChangePasswordAsync(firstUser, "asd123");
-
-            User passwordChangedUser = await _userManager.FindByIdAsync(firstUser.Id);
-            var passwordChangedUserSecurityStamp = passwordChangedUser.SecurityStamp;
-            passwordChangedUserSecurityStamp.ShouldNotBe(firstSecurityStamp);
-
-            //change password2
-            var passwordHash = new PasswordHasher().HashPassword("asd123456");
-            passwordChangedUser.Password = passwordHash;
-            await _userManager.UpdateAsync(passwordChangedUser);
-
-            User passwordChangedUser2 = await _userManager.FindByIdAsync(firstUser.Id);
-            var passwordChangedUserSecurityStamp2 = passwordChangedUser2.SecurityStamp;
-            passwordChangedUserSecurityStamp2.ShouldNotBe(passwordChangedUserSecurityStamp);
-
-            //update username
-            passwordChangedUser.UserName = "SecurityStamp2";
-            await _userManager.UpdateAsync(passwordChangedUser);
-
-            User userNameUpdatedUser = await _userManager.FindByIdAsync(firstUser.Id);
-            userNameUpdatedUser.ShouldNotBeNull();
-            userNameUpdatedUser.UserName.ShouldBe("SecurityStamp2");
-            var userNameUpdateUserSecurityStamp = userNameUpdatedUser.SecurityStamp;
-            userNameUpdateUserSecurityStamp.ShouldNotBe(passwordChangedUserSecurityStamp2);
-
-            //update email
-            userNameUpdatedUser.EmailAddress = "test@hotmail.com";
-            await _userManager.UpdateAsync(userNameUpdatedUser);
-
-            User emailUpdatedUser = await _userManager.FindByIdAsync(firstUser.Id);
-            emailUpdatedUser.ShouldNotBeNull();
-            emailUpdatedUser.EmailAddress.ShouldBe("test@hotmail.com");
-            var emailUpdatedUserSecurityStamp = emailUpdatedUser.SecurityStamp;
-            emailUpdatedUserSecurityStamp.ShouldNotBe(userNameUpdateUserSecurityStamp);
-        }
     }
 }

--- a/test/Abp.Zero.SampleApp.Tests/Users/UserAppService_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Users/UserAppService_Tests.cs
@@ -1,6 +1,4 @@
-﻿using System.Data.Entity;
-using System.Linq;
-using System.Runtime.InteropServices;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Abp.Auditing;
 using Abp.Zero.SampleApp.Users;

--- a/test/Abp.Zero.SampleApp.Tests/Users/UserAppService_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Users/UserAppService_Tests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Data.Entity;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Abp.Auditing;
 using Abp.Zero.SampleApp.Users;
@@ -13,7 +15,6 @@ namespace Abp.Zero.SampleApp.Tests.Users
     {
         private readonly IUserAppService _userAppService;
         private readonly UserManager _userManager;
-
         public UserAppService_Tests()
         {
             _userAppService = Resolve<IUserAppService>();
@@ -49,7 +50,7 @@ namespace Abp.Zero.SampleApp.Tests.Users
         }
 
         [Fact]
-        public async Task Shoudl_Reset_Password()
+        public async Task Should_Reset_Password()
         {
             AbpSession.TenantId = 1; //Default tenant   
             var managerUser = await _userManager.FindByNameAsync("manager");
@@ -74,6 +75,58 @@ namespace Abp.Zero.SampleApp.Tests.Users
 
             updatedUser.UserName.ShouldBe("manager");
             updatedUser.PasswordResetCode.ShouldBe(null);
+        }
+
+        [Fact]
+        public async Task Should_Change_Security_Stamp()
+        {
+            _userAppService.CreateUser(
+                new CreateUserInput
+                {
+                    EmailAddress = "security@stamp.com",
+                    Name = "Security",
+                    Surname = "Stamp",
+                    UserName = "SecurityStamp"
+                });
+
+            var firstUser = await _userManager.FindByNameAsync("SecurityStamp");
+            var firstSecurityStamp = firstUser.SecurityStamp;
+
+            //change password
+            await _userManager.ChangePasswordAsync(firstUser, "asd123");
+
+            User passwordChangedUser = await _userManager.FindByIdAsync(firstUser.Id);
+            var passwordChangedUserSecurityStamp = passwordChangedUser.SecurityStamp;
+            passwordChangedUserSecurityStamp.ShouldNotBe(firstSecurityStamp);
+
+            //change password2
+            var passwordHash = new PasswordHasher().HashPassword("asd123456");
+            passwordChangedUser.Password = passwordHash;
+            await _userManager.UpdateAsync(passwordChangedUser);
+
+            User passwordChangedUser2 = await _userManager.FindByIdAsync(firstUser.Id);
+            var passwordChangedUserSecurityStamp2 = passwordChangedUser2.SecurityStamp;
+            passwordChangedUserSecurityStamp2.ShouldNotBe(passwordChangedUserSecurityStamp);
+
+            //update username
+            passwordChangedUser.UserName = "SecurityStamp2";
+            await _userManager.UpdateAsync(passwordChangedUser);
+
+            User userNameUpdatedUser = await _userManager.FindByIdAsync(firstUser.Id);
+            userNameUpdatedUser.ShouldNotBeNull();
+            userNameUpdatedUser.UserName.ShouldBe("SecurityStamp2");
+            var userNameUpdateUserSecurityStamp = userNameUpdatedUser.SecurityStamp;
+            userNameUpdateUserSecurityStamp.ShouldNotBe(passwordChangedUserSecurityStamp2);
+
+            //update email
+            userNameUpdatedUser.EmailAddress = "test@hotmail.com";
+            await _userManager.UpdateAsync(userNameUpdatedUser);
+
+            User emailUpdatedUser = await _userManager.FindByIdAsync(firstUser.Id);
+            emailUpdatedUser.ShouldNotBeNull();
+            emailUpdatedUser.EmailAddress.ShouldBe("test@hotmail.com");
+            var emailUpdatedUserSecurityStamp = emailUpdatedUser.SecurityStamp;
+            emailUpdatedUserSecurityStamp.ShouldNotBe(userNameUpdateUserSecurityStamp);
         }
     }
 }

--- a/test/Abp.Zero.SampleApp.Tests/Users/UserManager_SecurityStamp_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Users/UserManager_SecurityStamp_Tests.cs
@@ -61,35 +61,6 @@ namespace Abp.Zero.SampleApp.Tests.Users
             User passwordChangedUser = await _userManager.FindByIdAsync(firstUser.Id);
             var passwordChangedUserSecurityStamp = passwordChangedUser.SecurityStamp;
             passwordChangedUserSecurityStamp.ShouldNotBe(firstSecurityStamp);
-
-            //change password2
-            var passwordHash = new PasswordHasher().HashPassword("asd123456");
-            passwordChangedUser.Password = passwordHash;
-            await _userManager.UpdateAsync(passwordChangedUser);
-
-            User passwordChangedUser2 = await _userManager.FindByIdAsync(firstUser.Id);
-            var passwordChangedUserSecurityStamp2 = passwordChangedUser2.SecurityStamp;
-            passwordChangedUserSecurityStamp2.ShouldNotBe(passwordChangedUserSecurityStamp);
-
-            //update username
-            passwordChangedUser.UserName = "SecurityStamp2";
-            await _userManager.UpdateAsync(passwordChangedUser);
-
-            User userNameUpdatedUser = await _userManager.FindByIdAsync(firstUser.Id);
-            userNameUpdatedUser.ShouldNotBeNull();
-            userNameUpdatedUser.UserName.ShouldBe("SecurityStamp2");
-            var userNameUpdateUserSecurityStamp = userNameUpdatedUser.SecurityStamp;
-            userNameUpdateUserSecurityStamp.ShouldNotBe(passwordChangedUserSecurityStamp2);
-
-            //update email
-            userNameUpdatedUser.EmailAddress = "test@hotmail.com";
-            await _userManager.UpdateAsync(userNameUpdatedUser);
-
-            User emailUpdatedUser = await _userManager.FindByIdAsync(firstUser.Id);
-            emailUpdatedUser.ShouldNotBeNull();
-            emailUpdatedUser.EmailAddress.ShouldBe("test@hotmail.com");
-            var emailUpdatedUserSecurityStamp = emailUpdatedUser.SecurityStamp;
-            emailUpdatedUserSecurityStamp.ShouldNotBe(userNameUpdateUserSecurityStamp);
         }
     }
 }

--- a/test/Abp.Zero.SampleApp.Tests/Users/UserManager_SecurityStamp_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Users/UserManager_SecurityStamp_Tests.cs
@@ -2,6 +2,8 @@
 using System.Threading.Tasks;
 using Abp.Threading;
 using Abp.Zero.SampleApp.Users;
+using Abp.Zero.SampleApp.Users.Dto;
+using Microsoft.AspNet.Identity;
 using Shouldly;
 using Xunit;
 
@@ -11,9 +13,11 @@ namespace Abp.Zero.SampleApp.Tests.Users
     {
         private readonly UserManager _userManager;
         private readonly User _testUser;
+        private readonly IUserAppService _userAppService;
 
         public UserManager_SecurityStamp_Tests()
         {
+            _userAppService = Resolve<IUserAppService>();
             _userManager = Resolve<UserManager>();
 
             _userManager.DefaultAccountLockoutTimeSpan = TimeSpan.FromSeconds(0.5);
@@ -35,6 +39,57 @@ namespace Abp.Zero.SampleApp.Tests.Users
             await _userManager.UpdateSecurityStampAsync(_testUser.Id);
 
             (await _userManager.GetSecurityStampAsync(_testUser.Id)).ShouldNotBe(oldStamp);
+        }
+         [Fact]
+        public async Task Should_Change_Security_Stamp()
+        {
+            _userAppService.CreateUser(
+                new CreateUserInput
+                {
+                    EmailAddress = "security@stamp.com",
+                    Name = "Security",
+                    Surname = "Stamp",
+                    UserName = "SecurityStamp"
+                });
+
+            var firstUser = await _userManager.FindByNameAsync("SecurityStamp");
+            var firstSecurityStamp = firstUser.SecurityStamp;
+
+            //change password
+            await _userManager.ChangePasswordAsync(firstUser, "asd123");
+
+            User passwordChangedUser = await _userManager.FindByIdAsync(firstUser.Id);
+            var passwordChangedUserSecurityStamp = passwordChangedUser.SecurityStamp;
+            passwordChangedUserSecurityStamp.ShouldNotBe(firstSecurityStamp);
+
+            //change password2
+            var passwordHash = new PasswordHasher().HashPassword("asd123456");
+            passwordChangedUser.Password = passwordHash;
+            await _userManager.UpdateAsync(passwordChangedUser);
+
+            User passwordChangedUser2 = await _userManager.FindByIdAsync(firstUser.Id);
+            var passwordChangedUserSecurityStamp2 = passwordChangedUser2.SecurityStamp;
+            passwordChangedUserSecurityStamp2.ShouldNotBe(passwordChangedUserSecurityStamp);
+
+            //update username
+            passwordChangedUser.UserName = "SecurityStamp2";
+            await _userManager.UpdateAsync(passwordChangedUser);
+
+            User userNameUpdatedUser = await _userManager.FindByIdAsync(firstUser.Id);
+            userNameUpdatedUser.ShouldNotBeNull();
+            userNameUpdatedUser.UserName.ShouldBe("SecurityStamp2");
+            var userNameUpdateUserSecurityStamp = userNameUpdatedUser.SecurityStamp;
+            userNameUpdateUserSecurityStamp.ShouldNotBe(passwordChangedUserSecurityStamp2);
+
+            //update email
+            userNameUpdatedUser.EmailAddress = "test@hotmail.com";
+            await _userManager.UpdateAsync(userNameUpdatedUser);
+
+            User emailUpdatedUser = await _userManager.FindByIdAsync(firstUser.Id);
+            emailUpdatedUser.ShouldNotBeNull();
+            emailUpdatedUser.EmailAddress.ShouldBe("test@hotmail.com");
+            var emailUpdatedUserSecurityStamp = emailUpdatedUser.SecurityStamp;
+            emailUpdatedUserSecurityStamp.ShouldNotBe(userNameUpdateUserSecurityStamp);
         }
     }
 }


### PR DESCRIPTION
User.SecurityStamp will be changed when:

- `(AbpUserManager).ChangePasswordAsync` called
- ~~`(AbpUserManager).UpdateAsync` called and if IsUserCredentialsSameWithStored returns false
(It controls If UserName , Email and Password are changed)~~ removed

resolves #4775