### PR TITLE
Entity History EF6 Complex Type property null value

### DIFF
--- a/src/Abp.Zero.EntityFramework/EntityHistory/Extensions/DbComplexPropertyEntryExtensions.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/Extensions/DbComplexPropertyEntryExtensions.cs
@@ -29,7 +29,7 @@ namespace Abp.EntityHistory.Extensions
                 var propertyOldValue = originalValue?.GetType()?.GetProperty(property.Name)?.GetValue(originalValue);
                 if (property.IsPrimitiveType)
                 {
-                    isModified = !(propertyNewValue?.Equals(propertyOldValue)) ?? false;
+                    isModified = !(propertyOldValue?.Equals(propertyNewValue) ?? propertyNewValue == null);
                 }
                 else if (property.IsComplexType)
                 {

--- a/src/Abp.Zero.EntityFramework/EntityHistory/Extensions/DbPropertyEntryExtensions.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/Extensions/DbPropertyEntryExtensions.cs
@@ -9,7 +9,7 @@ namespace Abp.EntityHistory.Extensions
         {
             if (propertyEntry.EntityEntry.State == EntityState.Deleted)
             {
-                return propertyEntry.OriginalValue;
+                return null;
             }
 
             return propertyEntry.CurrentValue;
@@ -19,7 +19,7 @@ namespace Abp.EntityHistory.Extensions
         {
             if (propertyEntry.EntityEntry.State == EntityState.Added)
             {
-                return propertyEntry.CurrentValue;
+                return null;
             }
 
             return propertyEntry.OriginalValue;

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -64,7 +64,19 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 entityChange.ChangeType.ShouldBe(EntityChangeType.Created);
                 entityChange.EntityId.ShouldBe(blog2Id.ToJsonString());
                 entityChange.EntityTypeFullName.ShouldBe(typeof(Blog).FullName);
-                entityChange.PropertyChanges.Count.ShouldBe(4);  // Blog.Name, Blog.Url, Blog.Category Blog.More
+                entityChange.PropertyChanges.Count.ShouldBe(4);
+
+                var propertyChange1 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Blog.Url));
+                propertyChange1.OriginalValue.ShouldBeNull();
+                propertyChange1.NewValue.ShouldNotBeNull();
+
+                var propertyChange2 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Blog.More));
+                propertyChange2.OriginalValue.ShouldBeNull();
+                propertyChange2.NewValue.ShouldNotBeNull();
+
+                var propertyChange3 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Blog.CreationTime));
+                propertyChange3.OriginalValue.ShouldBeNull();
+                propertyChange3.NewValue.ShouldNotBeNull();
 
                 // Check "who did this change"
                 s.ImpersonatorTenantId.ShouldBe(AbpSession.ImpersonatorTenantId);

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -65,6 +65,8 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 entityChange.EntityId.ShouldBe(blog2Id.ToJsonString());
                 entityChange.EntityTypeFullName.ShouldBe(typeof(Blog).FullName);
                 entityChange.PropertyChanges.Count.ShouldBe(4);
+                // TODO: 3 should be the correct value, Blog.Category is null for both new/original values
+                // entityChange.PropertyChanges.Count.ShouldBe(3);
 
                 var propertyChange1 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Blog.Url));
                 propertyChange1.OriginalValue.ShouldBeNull();
@@ -116,6 +118,8 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 context.EntityChangeSets.Count(e => e.TenantId == null).ShouldBe(1);
                 context.EntityChangeSets.Single().CreationTime.ShouldBeGreaterThan(justNow);
                 context.EntityPropertyChanges.Count(e => e.TenantId == null).ShouldBe(4);
+                // TODO: 3 should be the correct value, Blog.Category is null for both new/original values
+                // context.EntityPropertyChanges.Count(e => e.TenantId == 1).ShouldBe(3);
             });
         }
 

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -159,16 +159,14 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             var originalValue = "http://testblog2.myblogs.com";
             var newValue = "http://testblog2-changed.myblogs.com";
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var blog2 = _blogRepository.Single(b => b.Url == originalValue && b.Category == null);
 
                 // Update only the Url of the Blog
                 blog2.ChangeUrl(newValue);
                 _blogRepository.Update(blog2);
-
-                uow.Complete();
-            }
+            });
 
             Predicate<EntityChangeSet> predicate = s =>
             {
@@ -197,11 +195,11 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         {
             /* Blog has Audited attribute. */
 
-            int blog1Id;
+            int blog1Id = 0;
             var newValue = new BlogEx { BloggerName = "blogger-2" };
-            BlogEx originalValue;
+            BlogEx originalValue = null;
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var blog1 = _blogRepository.Single(b => b.More.BloggerName == "blogger-1");
                 blog1Id = blog1.Id;
@@ -209,9 +207,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 originalValue = new BlogEx { BloggerName = blog1.More.BloggerName };
                 blog1.More.BloggerName = newValue.BloggerName;
                 _blogRepository.Update(blog1);
-
-                uow.Complete();
-            }
+            });
 
             Predicate<EntityChangeSet> predicate = s =>
             {
@@ -241,9 +237,9 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             /* Post.BlogId has Audited attribute. */
 
             var blogId = CreateBlogAndGetId();
-            Guid post1Id;
+            Guid post1Id = Guid.Empty;
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var blog2 = _blogRepository.Single(b => b.Id == 2);
                 var post1 = _postRepository.Single(p => p.Body == "test-post-1-body");
@@ -252,9 +248,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 // Change foreign key by assigning navigation property
                 post1.Blog = blog2;
                 _postRepository.Update(post1);
-
-                uow.Complete();
-            }
+            });
 
             Predicate<EntityChangeSet> predicate = s =>
             {
@@ -281,7 +275,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         [Fact]
         public void Should_Write_History_For_Tracked_Property_Foreign_Key_Collection()
         {
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
                 var post10 = new Post { Blog = blog1, Title = "test-post-10-title", Body = "test-post-10-body" };
@@ -289,9 +283,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 // Change navigation property by adding into collection
                 blog1.Posts.Add(post10);
                 _blogRepository.Update(blog1);
-
-                uow.Complete();
-            }
+            });
 
             Predicate<EntityChangeSet> predicate = s =>
             {
@@ -323,7 +315,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             var post1KeyValue = new Dictionary<string, object>();
             var post2KeyValue = new Dictionary<string, object>();
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var post2 = _postRepository.Single(p => p.Body == "test-post-2-body");
                 post2KeyValue.Add("Id", post2.Id);
@@ -334,9 +326,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 // Change foreign key by assigning navigation property
                 comment1.Post = post2;
                 _commentRepository.Update(comment1);
-
-                uow.Complete();
-            }
+            });
 
             Predicate<EntityChangeSet> predicate = s =>
             {
@@ -362,15 +352,12 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         {
             /* Blog.Name has DisableAuditing attribute. */
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
-
                 blog1.Name = null;
                 _blogRepository.Update(blog1);
-
-                uow.Complete();
-            }
+            });
 
             Predicate<EntityChangeSet> predicate = s =>
             {
@@ -410,15 +397,12 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         {
             /* Post.Body does not have Audited attribute. */
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var post1 = _postRepository.Single(p => p.Body == "test-post-1-body");
-
                 post1.Body = null;
                 _postRepository.Update(post1);
-
-                uow.Complete();
-            }
+            });
 
             _entityHistoryStore.DidNotReceive().SaveAsync(Arg.Any<EntityChangeSet>());
         }
@@ -427,34 +411,29 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
 
         private int CreateBlogAndGetId()
         {
-            int blog2Id;
+            int blog2Id = 0;
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var blog2 = new Blog("test-blog-2", "http://testblog2.myblogs.com", "blogger-2");
-
                 blog2Id = _blogRepository.InsertAndGetId(blog2);
-
-                uow.Complete();
-            }
+            });
 
             return blog2Id;
         }
 
         private string UpdateBlogUrlAndGetOriginalValue(string newValue)
         {
-            string originalValue;
+            string originalValue = null;
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
                 originalValue = blog1.Url;
 
                 blog1.ChangeUrl(newValue);
                 _blogRepository.Update(blog1);
-
-                uow.Complete();
-            }
+            });
 
             return originalValue;
         }


### PR DESCRIPTION
fixes #4812 

- fix incorrect `isModified` check
- fix `ComplexProperty.HasChanged()` by changing
  - `DbProperty.GetNewValue()` return `null` if `State.Deleted`
  - `DbProperty.GetOriginalValue()` return `null` if `State.Added`