### PR TITLE
Entity History EF6 PropertyChange saved with Null Values

### DIFF
--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -68,9 +68,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 entityChange.ChangeType.ShouldBe(EntityChangeType.Created);
                 entityChange.EntityId.ShouldBe(blog2Id.ToJsonString());
                 entityChange.EntityTypeFullName.ShouldBe(typeof(Blog).FullName);
-                entityChange.PropertyChanges.Count.ShouldBe(4);
-                // TODO: 3 should be the correct value, Blog.Category is null for both new/original values
-                // entityChange.PropertyChanges.Count.ShouldBe(3);
+                entityChange.PropertyChanges.Count.ShouldBe(3);
 
                 var propertyChange1 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Blog.Url));
                 propertyChange1.OriginalValue.ShouldBeNull();
@@ -121,9 +119,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 context.EntityChanges.Count(e => e.TenantId == 1).ShouldBe(1);
                 context.EntityChangeSets.Count(e => e.TenantId == 1).ShouldBe(1);
                 context.EntityChangeSets.Single().CreationTime.ShouldBeGreaterThan(justNow);
-                context.EntityPropertyChanges.Count(e => e.TenantId == 1).ShouldBe(4);
-                // TODO: 3 should be the correct value, Blog.Category is null for both new/original values
-                // context.EntityPropertyChanges.Count(e => e.TenantId == 1).ShouldBe(3);
+                context.EntityPropertyChanges.Count(e => e.TenantId == 1).ShouldBe(3);
             });
         }
 

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -34,6 +34,10 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             _postRepository = Resolve<IRepository<Post, Guid>>();
             _commentRepository = Resolve<IRepository<Comment>>();
 
+            var user = GetDefaultTenantAdmin();
+            AbpSession.TenantId = user.TenantId;
+            AbpSession.UserId = user.Id;
+
             Resolve<IEntityHistoryConfiguration>().IsEnabledForAnonymousUsers = true;
         }
 
@@ -104,9 +108,9 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
 
             UsingDbContext((context) =>
             {
-                context.EntityChanges.Count(e => e.TenantId == null).ShouldBe(0);
-                context.EntityChangeSets.Count(e => e.TenantId == null).ShouldBe(0);
-                context.EntityPropertyChanges.Count(e => e.TenantId == null).ShouldBe(0);
+                context.EntityChanges.Count(e => e.TenantId == 1).ShouldBe(0);
+                context.EntityChangeSets.Count(e => e.TenantId == 1).ShouldBe(0);
+                context.EntityPropertyChanges.Count(e => e.TenantId == 1).ShouldBe(0);
             });
 
             var justNow = Clock.Now;
@@ -114,10 +118,10 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
 
             UsingDbContext((context) =>
             {
-                context.EntityChanges.Count(e => e.TenantId == null).ShouldBe(1);
-                context.EntityChangeSets.Count(e => e.TenantId == null).ShouldBe(1);
+                context.EntityChanges.Count(e => e.TenantId == 1).ShouldBe(1);
+                context.EntityChangeSets.Count(e => e.TenantId == 1).ShouldBe(1);
                 context.EntityChangeSets.Single().CreationTime.ShouldBeGreaterThan(justNow);
-                context.EntityPropertyChanges.Count(e => e.TenantId == null).ShouldBe(4);
+                context.EntityPropertyChanges.Count(e => e.TenantId == 1).ShouldBe(4);
                 // TODO: 3 should be the correct value, Blog.Category is null for both new/original values
                 // context.EntityPropertyChanges.Count(e => e.TenantId == 1).ShouldBe(3);
             });

--- a/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
+++ b/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
@@ -20,10 +20,10 @@ namespace Abp.Zero.SampleApp.Tests.TestDatas
             _context.Blogs.AddRange(new Blog[] { blog1, blog2 });
             _context.SaveChanges();
 
-            var post1 = new Post { Blog = blog1, Title = "test-post-1-title", Body = "test-post-1-body" };
-            var post2 = new Post { Blog = blog1, Title = "test-post-2-title", Body = "test-post-2-body" };
-            var post3 = new Post { Blog = blog1, Title = "test-post-3-title", Body = "test-post-3-body-deleted", IsDeleted = true };
-            var post4 = new Post { Blog = blog1, Title = "test-post-4-title", Body = "test-post-4-body", TenantId = 42 };
+            var post1 = new Post { TenantId = 1, Blog = blog1, Title = "test-post-1-title", Body = "test-post-1-body" };
+            var post2 = new Post { TenantId = 1, Blog = blog1, Title = "test-post-2-title", Body = "test-post-2-body" };
+            var post3 = new Post { TenantId = 1, Blog = blog1, Title = "test-post-3-title", Body = "test-post-3-body-deleted", IsDeleted = true };
+            var post4 = new Post { TenantId = 42, Blog = blog1, Title = "test-post-4-title", Body = "test-post-4-body" };
 
             _context.Posts.AddRange(new Post[] { post1, post2, post3, post4});
 


### PR DESCRIPTION
fixes #4814 

- clean up empty `entityChange.PropertyChanges` by updating the `new/original` values of  primitive/complex properties
- remove `PropertyChange` when it is empty

~*Currently this PR includes changes from #4813*~