### PR TITLE
Prevent null being saved into user's DefaultLanguage

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Localization/AbpDefaultRequestCultureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Localization/AbpDefaultRequestCultureProvider.cs
@@ -1,15 +1,23 @@
 ﻿using System.Threading.Tasks;
-using Abp.Configuration;
-using Abp.Extensions;
-using Abp.Localization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
+using Abp.Configuration;
+using Abp.Extensions;
+using Abp.Localization;
+using Castle.Core.Logging;
 
 namespace Abp.AspNetCore.Localization
 {
     public class AbpDefaultRequestCultureProvider : RequestCultureProvider
     {
+        public ILogger Logger { get; set; }
+
+        public AbpDefaultRequestCultureProvider()
+        {
+            Logger = NullLogger.Instance;
+        }
+
         public override async Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
         {
             var settingManager = httpContext.RequestServices.GetRequiredService<ISettingManager>();
@@ -21,6 +29,7 @@ namespace Abp.AspNetCore.Localization
                 return null;
             }
 
+            Logger.DebugFormat("{0} - Using Culture:{1} , UICulture:{2}", nameof(AbpDefaultRequestCultureProvider), culture, culture);
             return new ProviderCultureResult(culture, culture);
         }
     }

--- a/src/Abp.AspNetCore/AspNetCore/Localization/AbpLocalizationHeaderRequestCultureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Localization/AbpLocalizationHeaderRequestCultureProvider.cs
@@ -1,16 +1,25 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
+using Castle.Core.Logging;
 
 namespace Abp.AspNetCore.Localization
 {
     public class AbpLocalizationHeaderRequestCultureProvider : RequestCultureProvider
     {
+        public ILogger Logger { get; set; }
+
         private static readonly char[] Separator = { '|' };
 
         private static readonly string _culturePrefix = "c=";
         private static readonly string _uiCulturePrefix = "uic=";
+
+        public AbpLocalizationHeaderRequestCultureProvider()
+        {
+            Logger = NullLogger.Instance;
+        }
 
         /// <inheritdoc />
         public override Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
@@ -27,7 +36,12 @@ namespace Abp.AspNetCore.Localization
                 return Task.FromResult((ProviderCultureResult) null);
             }
 
-            return Task.FromResult(ParseHeaderValue(localizationHeader));
+            var cultureResult = ParseHeaderValue(localizationHeader);
+            var culture = cultureResult.Cultures.First().Value;
+            var uiCulture = cultureResult.UICultures.First().Value;
+            Logger.DebugFormat("{0} - Using Culture:{1} , UICulture:{2}", nameof(AbpLocalizationHeaderRequestCultureProvider), culture, uiCulture);
+
+            return Task.FromResult(cultureResult);
         }
 
         /// <summary>

--- a/src/Abp.AspNetCore/AspNetCore/Localization/AbpUserRequestCultureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Localization/AbpUserRequestCultureProvider.cs
@@ -1,12 +1,13 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using Abp.Configuration;
-using Abp.Runtime.Session;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
-using Abp.Localization;
+using Abp.Configuration;
 using Abp.Extensions;
+using Abp.Localization;
+using Abp.Runtime.Session;
+using Castle.Core.Logging;
 using JetBrains.Annotations;
 
 namespace Abp.AspNetCore.Localization
@@ -15,6 +16,12 @@ namespace Abp.AspNetCore.Localization
     {
         public CookieRequestCultureProvider CookieProvider { get; set; }
         public AbpLocalizationHeaderRequestCultureProvider HeaderProvider { get; set; }
+        public ILogger Logger { get; set; }
+
+        public AbpUserRequestCultureProvider()
+        {
+            Logger = NullLogger.Instance;
+        }
 
         public override async Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
         {
@@ -26,24 +33,46 @@ namespace Abp.AspNetCore.Localization
 
             var settingManager = httpContext.RequestServices.GetRequiredService<ISettingManager>();
 
-            var culture = await settingManager.GetSettingValueForUserAsync(
+            var userCulture = await settingManager.GetSettingValueForUserAsync(
                 LocalizationSettingNames.DefaultLanguage,
                 abpSession.TenantId,
                 abpSession.UserId.Value,
                 fallbackToDefault: false
             );
 
-            if (!culture.IsNullOrEmpty())
+            if (!userCulture.IsNullOrEmpty())
             {
-                return new ProviderCultureResult(culture, culture);
+                Logger.DebugFormat("{0} - Read from user settings", nameof(AbpUserRequestCultureProvider));
+                Logger.DebugFormat("Using Culture:{0} , UICulture:{1}", userCulture, userCulture);
+                return new ProviderCultureResult(userCulture, userCulture);
             }
 
-            var result = await GetResultOrNull(httpContext, CookieProvider) ??
-                         await GetResultOrNull(httpContext, HeaderProvider);
+            ProviderCultureResult result = null;
+            var cookieResult = await GetResultOrNull(httpContext, CookieProvider);
+            if (cookieResult != null && cookieResult.Cultures.Any())
+            {
+                var cookieCulture = cookieResult.Cultures.First().Value;
+                var cookieUICulture = cookieResult.UICultures.First().Value;
+
+                Logger.DebugFormat("{0} - Read from cookie", nameof(AbpUserRequestCultureProvider));
+                Logger.DebugFormat("Using Culture:{0} , UICulture:{1}", cookieCulture, cookieUICulture);
+
+                result = cookieResult;
+            }
 
             if (result == null || !result.Cultures.Any())
             {
-                return null;
+                var headerResult = await GetResultOrNull(httpContext, HeaderProvider);
+                if (headerResult != null && headerResult.Cultures.Any())
+                {
+                    var headerCulture = headerResult.Cultures.First().Value;
+                    var headerUICulture = headerResult.UICultures.First().Value;
+
+                    Logger.DebugFormat("{0} - Read from header", nameof(AbpUserRequestCultureProvider));
+                    Logger.DebugFormat("Using Culture:{0} , UICulture:{1}", headerCulture, headerUICulture);
+
+                    result = headerResult;
+                }
             }
 
             //Try to set user's language setting from cookie if available.

--- a/src/Abp.AspNetCore/AspNetCore/Localization/AbpUserRequestCultureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Localization/AbpUserRequestCultureProvider.cs
@@ -48,6 +48,7 @@ namespace Abp.AspNetCore.Localization
             }
 
             ProviderCultureResult result = null;
+            string cultureName = null;
             var cookieResult = await GetResultOrNull(httpContext, CookieProvider);
             if (cookieResult != null && cookieResult.Cultures.Any())
             {
@@ -58,6 +59,7 @@ namespace Abp.AspNetCore.Localization
                 Logger.DebugFormat("Using Culture:{0} , UICulture:{1}", cookieCulture, cookieUICulture);
 
                 result = cookieResult;
+                cultureName = cookieCulture ?? cookieUICulture;
             }
 
             if (result == null || !result.Cultures.Any())
@@ -72,15 +74,19 @@ namespace Abp.AspNetCore.Localization
                     Logger.DebugFormat("Using Culture:{0} , UICulture:{1}", headerCulture, headerUICulture);
 
                     result = headerResult;
+                    cultureName = headerCulture ?? headerUICulture;
                 }
             }
 
-            //Try to set user's language setting from cookie if available.
-            await settingManager.ChangeSettingForUserAsync(
-                abpSession.ToUserIdentifier(),
-                LocalizationSettingNames.DefaultLanguage,
-                result.Cultures.First().Value
-            );
+            if (!cultureName.IsNullOrEmpty())
+            {
+                //Try to set user's language setting from cookie/header if available.
+                await settingManager.ChangeSettingForUserAsync(
+                    abpSession.ToUserIdentifier(),
+                    LocalizationSettingNames.DefaultLanguage,
+                    cultureName
+                );
+            }
 
             return result;
         }


### PR DESCRIPTION
Fixes #4801

- add more logging in
  - `AbpLocalizationHeaderRequestCultureProvider`
  - `AbpDefaultRequestCultureProvider`
  - `AbpUserRequestCultureProvider`
- check culture before saving into user setting