### PR TITLE
fix localization dictionary providers

### DIFF
--- a/src/Abp/Localization/Dictionaries/Json/JsonEmbeddedFileLocalizationDictionaryProvider.cs
+++ b/src/Abp/Localization/Dictionaries/Json/JsonEmbeddedFileLocalizationDictionaryProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using Abp.Localization.Dictionaries.Xml;
 
 namespace Abp.Localization.Dictionaries.Json
 {
@@ -34,12 +33,12 @@ namespace Abp.Localization.Dictionaries.Json
             _rootNamespace = rootNamespace;
         }
 
-        public override void Initialize(string sourceName)
+        protected override void InitializeDictionaries()
         {
             var allCultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures);
             var resourceNames = _assembly.GetManifestResourceNames().Where(resouceName =>
-                allCultureInfos.Any(culture => resouceName.EndsWith($"{sourceName}.json", true, null) ||
-                                               resouceName.EndsWith($"{sourceName}-{culture.Name}.json", true,
+                allCultureInfos.Any(culture => resouceName.EndsWith($"{SourceName}.json", true, null) ||
+                                               resouceName.EndsWith($"{SourceName}-{culture.Name}.json", true,
                                                    null))).ToList();
             foreach (var resourceName in resourceNames)
             {
@@ -48,24 +47,7 @@ namespace Abp.Localization.Dictionaries.Json
                     using (var stream = _assembly.GetManifestResourceStream(resourceName))
                     {
                         var jsonString = Utf8Helper.ReadStringFromStream(stream);
-
-                        var dictionary = CreateJsonLocalizationDictionary(jsonString);
-                        if (Dictionaries.ContainsKey(dictionary.CultureInfo.Name))
-                        {
-                            throw new AbpInitializationException(sourceName + " source contains more than one dictionary for the culture: " + dictionary.CultureInfo.Name);
-                        }
-
-                        Dictionaries[dictionary.CultureInfo.Name] = dictionary;
-
-                        if (resourceName.EndsWith(sourceName + ".json"))
-                        {
-                            if (DefaultDictionary != null)
-                            {
-                                throw new AbpInitializationException("Only one default localization dictionary can be for source: " + sourceName);
-                            }
-
-                            DefaultDictionary = dictionary;
-                        }
+                        InitializeDictionary(CreateJsonLocalizationDictionary(jsonString), isDefault: resourceName.EndsWith(SourceName + ".json"));
                     }
                 }
             }

--- a/src/Abp/Localization/Dictionaries/Json/JsonFileLocalizationDictionaryProvider.cs
+++ b/src/Abp/Localization/Dictionaries/Json/JsonFileLocalizationDictionaryProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using Abp.Localization.Dictionaries.Xml;
 using Abp.Localization.Sources;
 
 namespace Abp.Localization.Dictionaries.Json
@@ -19,30 +18,14 @@ namespace Abp.Localization.Dictionaries.Json
         {
             _directoryPath = directoryPath;
         }
-        
-        public override void Initialize(string sourceName)
+
+        protected override void InitializeDictionaries()
         {
             var fileNames = Directory.GetFiles(_directoryPath, "*.json", SearchOption.TopDirectoryOnly);
 
             foreach (var fileName in fileNames)
             {
-                var dictionary = CreateJsonLocalizationDictionary(fileName);
-                if (Dictionaries.ContainsKey(dictionary.CultureInfo.Name))
-                {
-                    throw new AbpInitializationException(sourceName + " source contains more than one dictionary for the culture: " + dictionary.CultureInfo.Name);
-                }
-
-                Dictionaries[dictionary.CultureInfo.Name] = dictionary;
-
-                if (fileName.EndsWith(sourceName + ".json"))
-                {
-                    if (DefaultDictionary != null)
-                    {
-                        throw new AbpInitializationException("Only one default localization dictionary can be for source: " + sourceName);
-                    }
-
-                    DefaultDictionary = dictionary;
-                }
+                InitializeDictionary(CreateJsonLocalizationDictionary(fileName), isDefault: fileName.EndsWith(SourceName + ".json"));
             }
         }
 

--- a/src/Abp/Localization/Dictionaries/LocalizationDictionaryProviderBase.cs
+++ b/src/Abp/Localization/Dictionaries/LocalizationDictionaryProviderBase.cs
@@ -15,9 +15,10 @@ namespace Abp.Localization.Dictionaries
             Dictionaries = new Dictionary<string, ILocalizationDictionary>();
         }
 
-        public virtual void Initialize(string sourceName)
+        public void Initialize(string sourceName)
         {
             SourceName = sourceName;
+            InitializeDictionaries();
         }
 
         public void Extend(ILocalizationDictionary dictionary)
@@ -36,6 +37,10 @@ namespace Abp.Localization.Dictionaries
             {
                 existingDictionary[localizedString.Name] = localizedString.Value;
             }
+        }
+
+        protected virtual void InitializeDictionaries()
+        {
         }
     }
 }

--- a/src/Abp/Localization/Dictionaries/LocalizationDictionaryProviderBase.cs
+++ b/src/Abp/Localization/Dictionaries/LocalizationDictionaryProviderBase.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Abp.Localization.Dictionaries.Xml
+namespace Abp.Localization.Dictionaries
 {
     public abstract class LocalizationDictionaryProviderBase : ILocalizationDictionaryProvider
     {

--- a/src/Abp/Localization/Dictionaries/LocalizationDictionaryProviderBase.cs
+++ b/src/Abp/Localization/Dictionaries/LocalizationDictionaryProviderBase.cs
@@ -42,5 +42,26 @@ namespace Abp.Localization.Dictionaries
         protected virtual void InitializeDictionaries()
         {
         }
+
+        protected virtual void InitializeDictionary<TDictionary>(TDictionary dictionary, bool isDefault = false)
+            where TDictionary : ILocalizationDictionary
+        {
+            if (Dictionaries.ContainsKey(dictionary.CultureInfo.Name))
+            {
+                throw new AbpInitializationException(SourceName + " source contains more than one dictionary for the culture: " + dictionary.CultureInfo.Name);
+            }
+
+            Dictionaries[dictionary.CultureInfo.Name] = dictionary;
+
+            if (isDefault)
+            {
+                if (DefaultDictionary != null)
+                {
+                    throw new AbpInitializationException("Only one default localization dictionary can be for source: " + SourceName);
+                }
+
+                DefaultDictionary = dictionary;
+            }
+        }
     }
 }

--- a/src/Abp/Localization/Dictionaries/Xml/XmlEmbeddedFileLocalizationDictionaryProvider.cs
+++ b/src/Abp/Localization/Dictionaries/Xml/XmlEmbeddedFileLocalizationDictionaryProvider.cs
@@ -11,7 +11,7 @@ namespace Abp.Localization.Dictionaries.Xml
     {
         private readonly Assembly _assembly;
         private readonly string _rootNamespace;
-        
+
         /// <summary>
         /// Creates a new <see cref="XmlEmbeddedFileLocalizationDictionaryProvider"/> object.
         /// </summary>
@@ -23,12 +23,12 @@ namespace Abp.Localization.Dictionaries.Xml
             _rootNamespace = rootNamespace;
         }
 
-        public override void Initialize(string sourceName)
+        protected override void InitializeDictionaries()
         {
             var allCultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures);
             var resourceNames = _assembly.GetManifestResourceNames().Where(resouceName =>
-                allCultureInfos.Any(culture => resouceName.EndsWith($"{sourceName}.xml", true, null) ||
-                                               resouceName.EndsWith($"{sourceName}-{culture.Name}.xml", true,
+                allCultureInfos.Any(culture => resouceName.EndsWith($"{SourceName}.xml", true, null) ||
+                                               resouceName.EndsWith($"{SourceName}-{culture.Name}.xml", true,
                                                    null))).ToList();
             foreach (var resourceName in resourceNames)
             {
@@ -37,24 +37,7 @@ namespace Abp.Localization.Dictionaries.Xml
                     using (var stream = _assembly.GetManifestResourceStream(resourceName))
                     {
                         var xmlString = Utf8Helper.ReadStringFromStream(stream);
-
-                        var dictionary = CreateXmlLocalizationDictionary(xmlString);
-                        if (Dictionaries.ContainsKey(dictionary.CultureInfo.Name))
-                        {
-                            throw new AbpInitializationException(sourceName + " source contains more than one dictionary for the culture: " + dictionary.CultureInfo.Name);
-                        }
-
-                        Dictionaries[dictionary.CultureInfo.Name] = dictionary;
-
-                        if (resourceName.EndsWith(sourceName + ".xml"))
-                        {
-                            if (DefaultDictionary != null)
-                            {
-                                throw new AbpInitializationException("Only one default localization dictionary can be for source: " + sourceName);
-                            }
-
-                            DefaultDictionary = dictionary;
-                        }
+                        InitializeDictionary(CreateXmlLocalizationDictionary(xmlString), isDefault: resourceName.EndsWith(SourceName + ".xml"));
                     }
                 }
             }

--- a/src/Abp/Localization/Dictionaries/Xml/XmlFileLocalizationDictionaryProvider.cs
+++ b/src/Abp/Localization/Dictionaries/Xml/XmlFileLocalizationDictionaryProvider.cs
@@ -19,29 +19,13 @@ namespace Abp.Localization.Dictionaries.Xml
             _directoryPath = directoryPath;
         }
 
-        public override void Initialize(string sourceName)
+        protected override void InitializeDictionaries()
         {
             var fileNames = Directory.GetFiles(_directoryPath, "*.xml", SearchOption.TopDirectoryOnly);
 
             foreach (var fileName in fileNames)
             {
-                var dictionary = CreateXmlLocalizationDictionary(fileName);
-                if (Dictionaries.ContainsKey(dictionary.CultureInfo.Name))
-                {
-                    throw new AbpInitializationException(sourceName + " source contains more than one dictionary for the culture: " + dictionary.CultureInfo.Name);
-                }
-
-                Dictionaries[dictionary.CultureInfo.Name] = dictionary;
-
-                if (fileName.EndsWith(sourceName + ".xml"))
-                {
-                    if (DefaultDictionary != null)
-                    {
-                        throw new AbpInitializationException("Only one default localization dictionary can be for source: " + sourceName);                        
-                    }
-
-                    DefaultDictionary = dictionary;
-                }
+                InitializeDictionary(CreateXmlLocalizationDictionary(fileName), isDefault: fileName.EndsWith(SourceName + ".xml"));
             }
         }
 


### PR DESCRIPTION
Follows up #2995

- [BREAKING] 
  - Replace overriable `Initialize(string sourceName)` with `InitializeDictionaries()`.
  - Reason being that we configure `SourceName` during `Initialize()` and `SourceName` was not and may not be set when overridden.
- [BREAKING] 
  - Move `LocalizationDictionaryProviderBase` from `Abp.Localization.Dictionaries.Xml` namespace into `Abp.Localization.Dictionaries`
- Move dictionary initialization code into `LocalizationDictionaryProviderBase`

