### PR TITLE
Update ParseHeaderValue method

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Localization/AbpLocalizationHeaderRequestCultureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Localization/AbpLocalizationHeaderRequestCultureProvider.cs
@@ -7,6 +7,11 @@ using Castle.Core.Logging;
 
 namespace Abp.AspNetCore.Localization
 {
+    // Inspired from https://github.com/aspnet/AspNetCore/blob/master/src/Middleware/Localization/src/CookieRequestCultureProvider.cs
+    /// <summary>
+    /// Retrieves <see cref="CookieRequestCultureProvider.DefaultCookieName"/> from request header
+    /// Additionally, it allows value without culture prefix
+    /// </summary>
     public class AbpLocalizationHeaderRequestCultureProvider : RequestCultureProvider
     {
         public ILogger Logger { get; set; }
@@ -45,10 +50,10 @@ namespace Abp.AspNetCore.Localization
         }
 
         /// <summary>
-        /// Parses a <see cref="RequestCulture"/> from the specified cookie value.
+        /// Parses a <see cref="RequestCulture"/> from the specified header value.
         /// Returns <c>null</c> if parsing fails.
         /// </summary>
-        /// <param name="value">The cookie value to parse.</param>
+        /// <param name="value">The header value to parse.</param>
         /// <returns>The <see cref="RequestCulture"/> or <c>null</c> if parsing fails.</returns>
         public static ProviderCultureResult ParseHeaderValue(string value)
         {
@@ -70,15 +75,35 @@ namespace Abp.AspNetCore.Localization
             }
 
             var potentialCultureName = parts[0];
-            var potentialUiCultureName = parts[1];
+            var potentialUICultureName = parts[1];
 
-            if (!potentialCultureName.StartsWith(_culturePrefix) || !potentialUiCultureName.StartsWith(_uiCulturePrefix))
+            if (!potentialCultureName.StartsWith(_culturePrefix) || !potentialUICultureName.StartsWith(_uiCulturePrefix))
             {
                 return null;
             }
 
             var cultureName = potentialCultureName.Substring(_culturePrefix.Length);
-            var uiCultureName = potentialUiCultureName.Substring(_uiCulturePrefix.Length);
+            var uiCultureName = potentialUICultureName.Substring(_uiCulturePrefix.Length);
+            var isEmptyCulture = string.IsNullOrWhiteSpace(cultureName);
+            var isEmptyUICulture = string.IsNullOrWhiteSpace(uiCultureName);
+
+            if (isEmptyCulture && isEmptyUICulture)
+            {
+                // No values specified for either so no match
+                return null;
+            }
+
+            if (!isEmptyCulture && isEmptyUICulture)
+            {
+                // Value for culture but not for UI culture so default to culture value for both
+                uiCultureName = cultureName;
+            }
+
+            if (isEmptyCulture && !isEmptyUICulture)
+            {
+                // Value for UI culture but not for culture so default to UI culture value for both
+                cultureName = uiCultureName;
+            }
 
             return new ProviderCultureResult(cultureName, uiCultureName);
         }


### PR DESCRIPTION
Fixes #https://github.com/aspnetboilerplate/aspnetboilerplate/issues/4862

When a request is sent with header: `.AspNetCore.Culture: c=null|uic=null`.

`AbpLocalizationHeaderRequestCultureProvider` will return `ProviderCultureResult` with `null`,`null`.

Since the implementation of `AbpLocalizationHeaderRequestCultureProvider` was originated from [CookieRequestCultureProvider ](https://github.com/aspnet/AspNetCore/blob/master/src/Middleware/Localization/src/CookieRequestCultureProvider.cs), we should patch the updates from AspNetCore code base.


