### PR TITLE
Change IMapper visibility from private to protected

### DIFF
--- a/src/Abp.AutoMapper/AutoMapper/AutoMapperObjectMapper.cs
+++ b/src/Abp.AutoMapper/AutoMapper/AutoMapperObjectMapper.cs
@@ -6,7 +6,7 @@ namespace Abp.AutoMapper
 {
     public class AutoMapperObjectMapper : IObjectMapper
     {
-        private readonly IMapper _mapper;
+        protected readonly IMapper _mapper;
 
         public AutoMapperObjectMapper(IMapper mapper)
         {

--- a/src/Abp.AutoMapper/AutoMapper/AutoMapperObjectMapper.cs
+++ b/src/Abp.AutoMapper/AutoMapper/AutoMapperObjectMapper.cs
@@ -6,7 +6,7 @@ namespace Abp.AutoMapper
 {
     public class AutoMapperObjectMapper : IObjectMapper
     {
-        protected readonly IMapper _mapper;
+        protected readonly IMapper Mapper;
 
         public AutoMapperObjectMapper(IMapper mapper)
         {


### PR DESCRIPTION
In order to simply the extension of the AutoMapperObjectMapper, this proposal want to promote the IMapper attribute to protected.
This allows to extend the IObjectMapper without realizing a new version of Abp.

See #4882 and #4885