### PR TITLE
Fix EF6 Entity History Helper GetEntityId

### DIFF
--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -135,7 +135,8 @@ namespace Abp.EntityHistory
         protected virtual string GetEntityId(DbEntityEntry entityEntry, EntityType entityType)
         {
             var primaryKey = entityType.KeyProperties.First();
-            return entityEntry.Property(primaryKey.Name)?.GetNewValue()?.ToJsonString();
+            var property = entityEntry.Property(primaryKey.Name);
+            return (property.GetNewValue() ?? property.GetOriginalValue())?.ToJsonString();
         }
 
         [CanBeNull]


### PR DESCRIPTION
Since https://github.com/aspnetboilerplate/aspnetboilerplate/pull/4813, we are returning `null` for
- new value when in deleted state
- original value when in added state

We should ensure `GetEntityId` always read from new value then original value (since Entity Id is needed in-regardless of entity state)

