### PR TITLE
Update entity history reason provider's workaround 

### DIFF
--- a/src/Abp/EntityHistory/EntityChangeSetReasonProviderBase.cs
+++ b/src/Abp/EntityHistory/EntityChangeSetReasonProviderBase.cs
@@ -1,4 +1,5 @@
 ﻿using Abp.Runtime;
+using Castle.Core.Logging;
 using System;
 
 namespace Abp.EntityHistory
@@ -9,12 +10,15 @@ namespace Abp.EntityHistory
 
         public abstract string Reason { get; }
 
+        public ILogger Logger { get; set; }
+
         protected ReasonOverride OverridedValue => ReasonOverrideScopeProvider.GetValue(ReasonOverrideContextKey);
         protected IAmbientScopeProvider<ReasonOverride> ReasonOverrideScopeProvider { get; }
 
         protected EntityChangeSetReasonProviderBase(IAmbientScopeProvider<ReasonOverride> reasonOverrideScopeProvider)
         {
             ReasonOverrideScopeProvider = reasonOverrideScopeProvider;
+            Logger = NullLogger.Instance;
         }
 
         public IDisposable Use(string reason)


### PR DESCRIPTION
Following the conversation in https://github.com/aspnet/AspNetCore/issues/2718#issuecomment-482347489

The issue has been fixed in net core 3.x. However, chance of the fix being backported back to net core 2.x is unknown.

For now, we should cherry pick the [fixes](https://github.com/aspnet/AspNetCore/commit/187e89f6f0ee67728a50f987d63234c1900130fd) from net core team.