### PR TITLE
Entity history auditing entity

### DIFF
--- a/src/Abp/Domain/Entities/Auditing/CreationAuditedAggregateRoot.cs
+++ b/src/Abp/Domain/Entities/Auditing/CreationAuditedAggregateRoot.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Abp.Auditing;
 using Abp.Timing;
 
 namespace Abp.Domain.Entities.Auditing
@@ -18,6 +19,7 @@ namespace Abp.Domain.Entities.Auditing
     /// </summary>
     /// <typeparam name="TPrimaryKey">Type of the primary key of the entity</typeparam>
     [Serializable]
+    [Audited]
     public abstract class CreationAuditedAggregateRoot<TPrimaryKey> : AggregateRoot<TPrimaryKey>, ICreationAudited
     {
         /// <summary>

--- a/src/Abp/Domain/Entities/Auditing/CreationAuditedEntity.cs
+++ b/src/Abp/Domain/Entities/Auditing/CreationAuditedEntity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Abp.Auditing;
 using Abp.Timing;
 
 namespace Abp.Domain.Entities.Auditing
@@ -18,6 +19,7 @@ namespace Abp.Domain.Entities.Auditing
     /// </summary>
     /// <typeparam name="TPrimaryKey">Type of the primary key of the entity</typeparam>
     [Serializable]
+    [Audited]
     public abstract class CreationAuditedEntity<TPrimaryKey> : Entity<TPrimaryKey>, ICreationAudited
     {
         /// <summary>

--- a/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
+++ b/test/Abp.Zero.SampleApp.EntityFramework/EntityFramework/AppDbContext.cs
@@ -14,19 +14,21 @@ namespace Abp.Zero.SampleApp.EntityFramework
     {
         public DbSet<Book> Books { get; set; }
 
+        public DbSet<Author> Authors { get; set; }
+
+        public DbSet<Store> Stores { get; set; }
+        
         public DbSet<Advertisement> Advertisements { get; set; }
 
         public DbSet<Blog> Blogs { get; set; }
-
-        public DbSet<Post> Posts { get; set; }
 
         public DbSet<Category> Categories { get; set; }
 
         public DbSet<Comment> Comments { get; set; }
 
-        public DbSet<Author> Authors { get; set; }
+        public DbSet<Post> Posts { get; set; }
 
-        public DbSet<Store> Stores { get; set; }
+        public DbSet<Reaction> Reactions { get; set; }
 
         public DbSet<UserTestEntity> UserTestEntities { get; set; }
 

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -25,6 +25,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         private readonly IRepository<Blog> _blogRepository;
         private readonly IRepository<Post, Guid> _postRepository;
         private readonly IRepository<Comment> _commentRepository;
+        private readonly IRepository<Reaction> _reactionRepository;
 
         private IEntityHistoryStore _entityHistoryStore;
 
@@ -34,6 +35,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             _blogRepository = Resolve<IRepository<Blog>>();
             _postRepository = Resolve<IRepository<Post, Guid>>();
             _commentRepository = Resolve<IRepository<Comment>>();
+            _reactionRepository = Resolve<IRepository<Reaction>>();
 
             var user = GetDefaultTenantAdmin();
             AbpSession.TenantId = user.TenantId;
@@ -52,6 +54,135 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         }
 
         #region CASES WRITE HISTORY
+
+        [Fact]
+        public void Should_Write_History_For_Creation_Audited_Entities()
+        {
+            int? reactionId = null;
+
+            WithUnitOfWork(() =>
+            {
+                var reaction = new Reaction { Name = "test-reaction-2" };
+                reactionId = _reactionRepository.InsertAndGetId(reaction);
+            });
+
+            Predicate<EntityChangeSet> predicate = s =>
+            {
+                s.EntityChanges.Count.ShouldBe(1);
+
+                var entityChange = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Reaction).FullName);
+                entityChange.ChangeType.ShouldBe(EntityChangeType.Created);
+                entityChange.EntityId.ShouldBe(reactionId.ToJsonString());
+                entityChange.PropertyChanges.Count.ShouldBe(4);
+
+                var propertyChange1 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.Name));
+                propertyChange1.NewValue.ShouldBe("test-reaction-2".ToJsonString(false, false));
+                propertyChange1.OriginalValue.ShouldBeNull();
+                propertyChange1.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.Name)).PropertyType.FullName);
+
+                var propertyChange2 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.CreatorUserId));
+                propertyChange2.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange2.OriginalValue.ShouldBeNull();
+                propertyChange2.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.CreatorUserId)).PropertyType.FullName);
+
+                var propertyChange3 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.CreationTime));
+                propertyChange3.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange3.OriginalValue.ShouldBeNull();
+                propertyChange3.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.CreationTime)).PropertyType.FullName);
+
+                var propertyChange4 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.IsDeleted));
+                propertyChange4.NewValue.ShouldBe("false");
+                propertyChange4.OriginalValue.ShouldBeNull();
+                propertyChange4.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.IsDeleted)).PropertyType.FullName);
+
+                return true;
+            };
+
+            _entityHistoryStore.Received().Save(Arg.Is<EntityChangeSet>(s => predicate(s)));
+        }
+
+        [Fact]
+        public void Should_Write_History_For_Modification_Audited_Entities()
+        {
+            Reaction reaction = null;
+
+            WithUnitOfWork(() =>
+            {
+                reaction = _reactionRepository.Single(r => r.Name == "test-reaction-1");
+                reaction.Name = "test-reaction-1-updated";
+                _reactionRepository.Update(reaction);
+            });
+
+            Predicate<EntityChangeSet> predicate = s =>
+            {
+                s.EntityChanges.Count.ShouldBe(1);
+
+                var entityChange = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Reaction).FullName);
+                entityChange.ChangeType.ShouldBe(EntityChangeType.Updated);
+                entityChange.EntityId.ShouldBe(reaction.Id.ToJsonString());
+                entityChange.PropertyChanges.Count.ShouldBe(3);
+
+                var propertyChange1 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.Name));
+                propertyChange1.NewValue.ShouldBe("test-reaction-1-updated".ToJsonString(false, false));
+                propertyChange1.OriginalValue.ShouldBe("test-reaction-1".ToJsonString(false, false));
+                propertyChange1.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.Name)).PropertyType.FullName);
+
+                var propertyChange2 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.LastModifierUserId));
+                propertyChange2.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange2.OriginalValue.ShouldBeNull();
+                propertyChange2.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.LastModifierUserId)).PropertyType.FullName);
+
+                var propertyChange3 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.LastModificationTime));
+                propertyChange3.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange3.OriginalValue.ShouldBeNull();
+                propertyChange3.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.LastModificationTime)).PropertyType.FullName);
+
+                return true;
+            };
+
+            _entityHistoryStore.Received().Save(Arg.Is<EntityChangeSet>(s => predicate(s)));
+        }
+
+        [Fact]
+        public void Should_Write_History_For_Deletion_Audited_Entities()
+        {
+            Reaction reaction = null;
+
+            WithUnitOfWork(() =>
+            {
+                reaction = _reactionRepository.Single(r => r.Name == "test-reaction-1");
+                _reactionRepository.Delete(reaction);
+            });
+
+            Predicate<EntityChangeSet> predicate = s =>
+            {
+                s.EntityChanges.Count.ShouldBe(1);
+
+                var entityChange = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Reaction).FullName);
+                entityChange.ChangeType.ShouldBe(EntityChangeType.Deleted);
+                entityChange.EntityId.ShouldBe(reaction.Id.ToJsonString());
+                entityChange.PropertyChanges.Count.ShouldBe(3);
+
+                var propertyChange1 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.IsDeleted));
+                propertyChange1.NewValue.ShouldBe("true");
+                propertyChange1.OriginalValue.ShouldBe("false");
+                propertyChange1.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.IsDeleted)).PropertyType.FullName);
+
+                var propertyChange2 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.DeleterUserId));
+                propertyChange2.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange2.OriginalValue.ShouldBeNull();
+                propertyChange2.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.DeleterUserId)).PropertyType.FullName);
+
+                var propertyChange3 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Reaction.DeletionTime));
+                propertyChange3.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange3.OriginalValue.ShouldBeNull();
+                propertyChange3.PropertyTypeFullName.ShouldBe(typeof(Reaction).GetProperty(nameof(Reaction.DeletionTime)).PropertyType.FullName);
+
+                return true;
+            };
+
+            _entityHistoryStore.Received().Save(Arg.Is<EntityChangeSet>(s => predicate(s)));
+        }
 
         [Fact]
         public void Should_Write_History_For_Tracked_Entities_Create()

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -438,8 +438,9 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         public void Should_Write_History_For_Audited_Property_Foreign_Key()
         {
             /* Post.BlogId has Audited attribute. */
-
             var blogId = CreateBlogAndGetId();
+            _entityHistoryStore.ClearReceivedCalls();
+
             Guid post1Id = Guid.Empty;
 
             WithUnitOfWork(() =>
@@ -460,12 +461,22 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 var entityChange = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Post).FullName);
                 entityChange.ChangeType.ShouldBe(EntityChangeType.Updated);
                 entityChange.EntityId.ShouldBe(post1Id.ToJsonString());
-                entityChange.PropertyChanges.Count.ShouldBe(1);
+                entityChange.PropertyChanges.Count.ShouldBe(3);
 
-                var propertyChange = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.BlogId));
-                propertyChange.NewValue.ShouldBe("2");
-                propertyChange.OriginalValue.ShouldBe("1");
-                propertyChange.PropertyTypeFullName.ShouldBe(typeof(Post).GetProperty(nameof(Post.BlogId)).PropertyType.FullName);
+                var propertyChange1 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.BlogId));
+                propertyChange1.NewValue.ShouldBe("2");
+                propertyChange1.OriginalValue.ShouldBe("1");
+                propertyChange1.PropertyTypeFullName.ShouldBe(typeof(Post).GetProperty(nameof(Post.BlogId)).PropertyType.FullName);
+
+                var propertyChange2 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.LastModifierUserId));
+                propertyChange2.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange2.OriginalValue.ShouldBeNull();
+                propertyChange2.PropertyTypeFullName.ShouldBe(typeof(Post).GetProperty(nameof(Post.LastModifierUserId)).PropertyType.FullName);
+
+                var propertyChange3 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.LastModificationTime));
+                propertyChange3.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange3.OriginalValue.ShouldBeNull();
+                propertyChange3.PropertyTypeFullName.ShouldBe(typeof(Post).GetProperty(nameof(Post.LastModificationTime)).PropertyType.FullName);
 
                 return true;
             };

--- a/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
+++ b/test/Abp.Zero.SampleApp.Tests/TestDatas/InitialTestBlogBuilder.cs
@@ -34,6 +34,9 @@ namespace Abp.Zero.SampleApp.Tests.TestDatas
 
             var advertisement1 = new Advertisement { Banner = "test-advertisement-1" };
             _context.Advertisements.Add(advertisement1);
+
+            var reaction1 = new Reaction { Name = "test-reaction-1" };
+            _context.Reactions.Add(reaction1);
         }
     }
 }

--- a/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Post.cs
@@ -7,7 +7,7 @@ using Abp.Domain.Entities;
 
 namespace Abp.Zero.SampleApp.EntityHistory
 {
-    public class Post : AuditedEntity<Guid>, ISoftDelete, IMayHaveTenant
+    public class Post : FullAuditedEntity<Guid>, IMayHaveTenant
     {
         [Required]
         public virtual Blog Blog { get; set; }
@@ -20,8 +20,6 @@ namespace Abp.Zero.SampleApp.EntityHistory
         public string Title { get; set; }
 
         public string Body { get; set; }
-
-        public bool IsDeleted { get; set; }
 
         public int? TenantId { get; set; }
 

--- a/test/Abp.Zero.SampleApp/EntityHistory/Reaction.cs
+++ b/test/Abp.Zero.SampleApp/EntityHistory/Reaction.cs
@@ -1,0 +1,9 @@
+﻿using Abp.Domain.Entities.Auditing;
+
+namespace Abp.Zero.SampleApp.EntityHistory
+{
+    public class Reaction : FullAuditedAggregateRoot
+    {
+        public string Name { get; set; }
+    }
+}

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Reaction.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Reaction.cs
@@ -1,0 +1,9 @@
+﻿using Abp.Domain.Entities.Auditing;
+
+namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
+{
+    public class Reaction : FullAuditedAggregateRoot
+    {
+        public string Name { get; set; }
+    }
+}

--- a/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
+++ b/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-using Abp.IdentityServer4;
+﻿using Abp.IdentityServer4;
 using Abp.Zero.EntityFrameworkCore;
 using Abp.ZeroCore.SampleApp.Core;
 using Abp.ZeroCore.SampleApp.Core.BookStore;
@@ -23,6 +22,8 @@ namespace Abp.ZeroCore.SampleApp.EntityFramework
         public DbSet<Category> Categories { get; set; }
 
         public DbSet<Comment> Comments { get; set; }
+
+        public DbSet<Reaction> Reactions { get; set; }
 
         public DbSet<Product> Products { get; set; }
 

--- a/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestBase.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestBase.cs
@@ -68,6 +68,10 @@ namespace Abp.Zero
                     var advertisement1 = new Advertisement { Banner = "test-advertisement-1" };
 
                     context.Advertisements.Add(advertisement1);
+
+                    var reaction1 = new Reaction { Name = "test-reaction-1" };
+
+                    context.Reactions.Add(reaction1);
                 });
         }
 

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -440,14 +440,25 @@ namespace Abp.Zero.EntityHistory
             {
                 s.EntityChanges.Count.ShouldBe(1);
 
-                var entityChange = s.EntityChanges[0];
+                var entityChange = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Post).FullName);
                 entityChange.ChangeType.ShouldBe(EntityChangeType.Updated);
-                entityChange.EntityId.ShouldBe(post1Id.ToJsonString(false, false));
-                entityChange.EntityTypeFullName.ShouldBe(typeof(Post).FullName);
-                entityChange.PropertyChanges.Count.ShouldBe(1);
+                entityChange.EntityId.ShouldBe(post1Id.ToJsonString());
+                entityChange.PropertyChanges.Count.ShouldBe(3);
 
-                var propertyChange = entityChange.PropertyChanges.Single();
-                propertyChange.PropertyName.ShouldBe(nameof(Post.BlogId));
+                var propertyChange1 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.BlogId));
+                propertyChange1.NewValue.ShouldBe("2");
+                propertyChange1.OriginalValue.ShouldBe("1");
+                propertyChange1.PropertyTypeFullName.ShouldBe(typeof(Post).GetProperty(nameof(Post.BlogId)).PropertyType.FullName);
+
+                var propertyChange2 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.LastModifierUserId));
+                propertyChange2.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange2.OriginalValue.ShouldBeNull();
+                propertyChange2.PropertyTypeFullName.ShouldBe(typeof(Post).GetProperty(nameof(Post.LastModifierUserId)).PropertyType.FullName);
+
+                var propertyChange3 = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.LastModificationTime));
+                propertyChange3.NewValue.ShouldNotBeNullOrEmpty();
+                propertyChange3.OriginalValue.ShouldBeNull();
+                propertyChange3.PropertyTypeFullName.ShouldBe(typeof(Post).GetProperty(nameof(Post.LastModificationTime)).PropertyType.FullName);
 
                 return true;
             };


### PR DESCRIPTION
Resolves #4693

Follows up #4778

Adding `Audited` attribute to properties of Auditing Entities will be overkilled and causing side effects.

- adding `Audited` attribute to property will cause `PropertyChange` to be created in regardless whether there is changes in property (i.e property change of new value `null` and old value `null` will be create)

After considering this case, adding `Audited` attribute to Auditing Entities seems to be the appropriate approach.

- adding `Audited` attribute to entity will cause `EntityChange` to be created in regardless of whether there is any property with changes. However, if there is no properties with changes, only `EntityChange` being created with `PropertyChange` count == 0

- [x] ef6 test
- [x] efcore test

## Dependencies
~Waiting for these PRs to be merged~  They all merged. 
- ~#4843~ 
- ~#4870~ 
- ~#4900~