### PR TITLE
Fix entity history selectors configuration

### DIFF
--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -82,9 +82,11 @@ namespace Abp.EntityHistory
                     continue;
                 }
 
-                var shouldSaveAuditedPropertiesOnly = !shouldAuditEntity.HasValue && !entityEntry.IsCreated() && !entityEntry.IsDeleted();
-                var entitySet = GetEntitySet(objectContext, entityType);
+                var isAuditableEntity = shouldAuditEntity.HasValue && shouldAuditEntity.Value;
+                var isTrackableEntity = shouldTrackEntity.HasValue && shouldTrackEntity.Value;
+                var shouldSaveAuditedPropertiesOnly = !isAuditableEntity && !isTrackableEntity;
 
+                var entitySet = GetEntitySet(objectContext, entityType);
                 var propertyChanges = new List<EntityPropertyChange>();
                 propertyChanges.AddRange(GetPropertyChanges(entityEntry, entityType, entitySet, shouldSaveAuditedPropertiesOnly));
                 propertyChanges.AddRange(GetRelationshipChanges(entityEntry, entityType, entitySet, relationshipChanges, shouldSaveAuditedPropertiesOnly));

--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -61,13 +61,14 @@ namespace Abp.EntityHistory
                 }
 
                 var shouldAuditEntity = IsTypeOfAuditedEntity(typeOfEntity);
-                bool? shouldAuditOwnerProperty = null;
-                bool? shouldAuditOwnerEntity = null;
                 if (shouldAuditEntity.HasValue && !shouldAuditEntity.Value)
                 {
                     continue;
                 }
-                else if (!shouldAuditEntity.HasValue && entityEntry.Metadata.IsOwned())
+                
+                bool? shouldAuditOwnerEntity = null;
+                bool? shouldAuditOwnerProperty = null;
+                if (!shouldAuditEntity.HasValue && entityEntry.Metadata.IsOwned())
                 {
                     // Check if owner entity has auditing attribute
                     var foreignKey = entityEntry.Metadata.GetForeignKeys().First();
@@ -93,9 +94,11 @@ namespace Abp.EntityHistory
                     continue;
                 }
 
-                var shouldSaveAuditedPropertiesOnly = !(shouldAuditEntity.HasValue || shouldAuditOwnerEntity.HasValue || shouldAuditOwnerProperty.HasValue) &&
-                                                      !entityEntry.IsCreated() &&
-                                                      !entityEntry.IsDeleted();
+                var isAuditableEntity = (shouldAuditEntity.HasValue && shouldAuditEntity.Value) ||
+                                        (shouldAuditOwnerEntity.HasValue && shouldAuditOwnerEntity.Value) || 
+                                        (shouldAuditOwnerProperty.HasValue && shouldAuditOwnerProperty.Value);
+                var isTrackableEntity = shouldTrackEntity.HasValue && shouldTrackEntity.Value;
+                var shouldSaveAuditedPropertiesOnly = !isAuditableEntity && !isTrackableEntity;
                 var propertyChanges = GetPropertyChanges(entityEntry, shouldSaveAuditedPropertiesOnly);
                 if (propertyChanges.Count == 0)
                 {

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -392,29 +392,15 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             {
                 s.EntityChanges.Count.ShouldBe(2);
 
+                /* Post is not in Configuration.Selectors */
+                /* Post.Blog has Audited attribute */
                 var entityChangePost = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Post).FullName);
                 entityChangePost.ChangeType.ShouldBe(EntityChangeType.Created);
-                entityChangePost.PropertyChanges.Count.ShouldBe(5);
+                entityChangePost.PropertyChanges.Count.ShouldBe(1);
 
                 var propertyChange1 = entityChangePost.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.BlogId));
                 propertyChange1.OriginalValue.ShouldBeNull();
                 propertyChange1.NewValue.ShouldNotBeNull();
-
-                var propertyChange2 = entityChangePost.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.Title));
-                propertyChange2.OriginalValue.ShouldBeNull();
-                propertyChange2.NewValue.ShouldNotBeNull();
-
-                var propertyChange3 = entityChangePost.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.Body));
-                propertyChange3.OriginalValue.ShouldBeNull();
-                propertyChange3.NewValue.ShouldNotBeNull();
-
-                var propertyChange4 = entityChangePost.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.IsDeleted));
-                propertyChange4.OriginalValue.ShouldBeNull();
-                propertyChange4.NewValue.ShouldNotBeNull();
-
-                var propertyChange5 = entityChangePost.PropertyChanges.Single(pc => pc.PropertyName == nameof(Post.CreationTime));
-                propertyChange5.OriginalValue.ShouldBeNull();
-                propertyChange5.NewValue.ShouldNotBeNull();
 
                 /* Blog has Audited attribute. */
                 var entityChangeBlog = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Blog).FullName);

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -130,6 +130,39 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         }
 
         [Fact]
+        public void Should_Write_History_For_Tracked_Entities_Update()
+        {
+            /* Advertisement does not have Audited attribute. */
+            Resolve<IEntityHistoryConfiguration>().Selectors.Add("Selected", typeof(Advertisement));
+
+            WithUnitOfWork(() =>
+            {
+                var advertisement1 = _advertisementRepository.Single(a => a.Banner == "test-advertisement-1");
+                advertisement1.Banner = "test-advertisement-1-updated";
+                _advertisementRepository.Update(advertisement1);
+            });
+
+            Predicate<EntityChangeSet> predicate = s =>
+            {
+                s.EntityChanges.Count.ShouldBe(1);
+
+                var entityChange = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Advertisement).FullName);
+                entityChange.ChangeType.ShouldBe(EntityChangeType.Updated);
+                entityChange.EntityId.ShouldBe(entityChange.EntityEntry.As<DbEntityEntry>().Entity.As<IEntity>().Id.ToJsonString());
+                entityChange.PropertyChanges.Count.ShouldBe(1);
+
+                var propertyChange = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(Advertisement.Banner));
+                propertyChange.NewValue.ShouldBe("test-advertisement-1-updated".ToJsonString());
+                propertyChange.OriginalValue.ShouldBe("test-advertisement-1".ToJsonString());
+                propertyChange.PropertyTypeFullName.ShouldBe(typeof(Advertisement).GetProperty(nameof(Advertisement.Banner)).PropertyType.FullName);
+
+                return true;
+            };
+
+            _entityHistoryStore.Received().Save(Arg.Is<EntityChangeSet>(s => predicate(s)));
+        }
+
+        [Fact]
         public void Should_Write_History_For_Audited_Entities_Create()
         {
             /* Blog has Audited attribute. */
@@ -473,6 +506,24 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
 
             var newValue = "http://testblog1-changed.myblogs.com";
             var originalValue = UpdateBlogUrlAndGetOriginalValue(newValue);
+
+            _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
+        }
+
+        [Fact]
+        public void Should_Not_Write_History_If_Not_Audited_And_Not_Selected()
+        {
+            /* Advertisement does not have Audited attribute. */
+
+            Resolve<IEntityHistoryConfiguration>().Selectors.Clear();
+            
+            WithUnitOfWork(() =>
+            {
+                _advertisementRepository.Insert(new Advertisement
+                {
+                    Banner = "not-selected-advertisement"
+                });
+            });
 
             _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
         }


### PR DESCRIPTION
Resolve #4948 

#### Before
- Record All Properties for Audited/Created/Deleted Entity
- Record only Audited Properties for Tracked/Untracked Entity

#### After
- Record All Properties for Audited/Tracked Entity
- Record only Audited Properties for Untracked Entity
