### PR TITLE
Remove defensive logging in HttpRequestEntityChangeSetReasonProvider

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/EntityHistory/HttpRequestEntityChangeSetReasonProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/EntityHistory/HttpRequestEntityChangeSetReasonProvider.cs
@@ -46,7 +46,6 @@ namespace Abp.AspNetCore.EntityHistory
         {
             if (request == null)
             {
-                Logger.Debug("Unable to get URL from HttpRequest, fallback to null");
                 return null;
             }
 


### PR DESCRIPTION
Based on the following comments: 

https://github.com/aspnetboilerplate/aspnetboilerplate/issues/4946#issuecomment-545246439
https://github.com/aspnetboilerplate/aspnetboilerplate/issues/4946#issuecomment-545440016

Since we use safe navigation in `HttpContext?.Request`, having null value for `request` is expected. So we don't need additional logging to capture the case.