### PR TITLE
Remove read ip from header

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
@@ -43,14 +43,8 @@ namespace Abp.AspNetCore.Mvc.Auditing
             {
                 var httpContext = _httpContextAccessor.HttpContext ?? _httpContext;
 
-                var clientIp = httpContext?.Request?.Headers["HTTP_X_FORWARDED_FOR"].ToString();
+                return httpContext?.Connection?.RemoteIpAddress?.ToString();
 
-                if (clientIp.IsNullOrEmpty())
-                {
-                    clientIp = httpContext?.Connection?.RemoteIpAddress?.ToString();
-                }
-
-                return clientIp.Remove(clientIp.IndexOf(':'));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
We don't need to explicitly read ip from the header
https://github.com/aspnetboilerplate/aspnetboilerplate/pull/4988#issuecomment-549320792