### PR TITLE
Normalize simple types of DateTime(asp net core 3.x)

### DIFF
--- a/test/Abp.AspNetCore.Tests/App/Controllers/SimpleTestController.cs
+++ b/test/Abp.AspNetCore.Tests/App/Controllers/SimpleTestController.cs
@@ -145,5 +145,29 @@ namespace Abp.AspNetCore.App.Controllers
         {
             return input.Date.Kind.ToString().ToLower();
         }
+
+        [HttpGet]
+        public string GetSimpleTypeDateTimeKind(DateTime date)
+        {
+            return date.Date.Kind.ToString().ToLower();
+        }
+
+        [HttpGet]
+        public string GetNotNormalizedSimpleTypeKind([DisableDateTimeNormalization]DateTime date)
+        {
+            return date.Date.Kind.ToString().ToLower();
+        }
+
+        [HttpGet]
+        public string GetNullableSimpleTypeDateTimeKind(DateTime? date)
+        {
+            return date.Value.Kind.ToString().ToLower();
+        }
+
+        [HttpGet]
+        public string GetNotNormalizedNullableSimpleTypeDateTimeKind([DisableDateTimeNormalization]DateTime? date)
+        {
+            return date.Value.Date.Kind.ToString().ToLower();
+        }
     }
 }

--- a/test/Abp.AspNetCore.Tests/Tests/DateTimeModelBinder_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/DateTimeModelBinder_Tests.cs
@@ -128,6 +128,92 @@ namespace Abp.AspNetCore.Tests
             response.Result.ShouldBe(expectedKind.ToLower());
         }
 
+        [Theory]
+        [InlineData("2016-04-13T08:58:10.526Z", "utc")]
+        [InlineData("2016-04-13T08:58:10.526", "local")]
+        [InlineData("2016-04-13 08:58:10.526Z", "utc")]
+        [InlineData("2016-04-13 08:58:10.526", "local")]
+        [InlineData("2016-04-13 08:58:10.526", "unspecified")]
+        public async Task Controller_Should_Receive_Correct_DateTimeKind_For_Current_ClockProvider_SimpleType(string date, string expectedKind)
+        {
+            Clock.Provider = StringToClockProvider(expectedKind);
+
+            var response = await GetResponseAsObjectAsync<AjaxResponse<string>>(
+                GetUrl<SimpleTestController>(
+                    nameof(SimpleTestController.GetSimpleTypeDateTimeKind),
+                    new
+                    {
+                        date
+                    }
+                )
+            );
+
+            response.Result.ShouldBe(expectedKind.ToLower());
+        }
+
+        [Theory]
+        [InlineData("2016-04-13T08:58:10.526Z", "local")]
+        [InlineData("2016-04-13T08:58:10.526", "unspecified")]
+        [InlineData("2016-04-13 08:58:10.526Z", "local")]
+        [InlineData("2016-04-13 08:58:10.526", "unspecified")]
+        public async Task Controller_Should_Receive_Correct_DateTimeKind_For_Current_ClockProvider_When_Not_Normalized_Property_SimpleType(string date, string expectedKind)
+        {
+            var response = await GetResponseAsObjectAsync<AjaxResponse<string>>(
+                GetUrl<SimpleTestController>(
+                    nameof(SimpleTestController.GetNotNormalizedSimpleTypeKind),
+                    new
+                    {
+                        date
+                    }
+                )
+            );
+
+            response.Result.ToLower().ShouldBe(expectedKind.ToLower());
+        }
+
+        [Theory]
+        [InlineData("2016-04-13T08:58:10.526Z", "utc")]
+        [InlineData("2016-04-13T08:58:10.526", "local")]
+        [InlineData("2016-04-13 08:58:10.526Z", "utc")]
+        [InlineData("2016-04-13 08:58:10.526", "local")]
+        [InlineData("2016-04-13 08:58:10.526", "unspecified")]
+        public async Task Controller_Should_Receive_Correct_DateTimeKind_For_Current_ClockProvider_NullableSimpleType(string date, string expectedKind)
+        {
+            Clock.Provider = StringToClockProvider(expectedKind);
+
+            var response = await GetResponseAsObjectAsync<AjaxResponse<string>>(
+                GetUrl<SimpleTestController>(
+                    nameof(SimpleTestController.GetNullableSimpleTypeDateTimeKind),
+                    new
+                    {
+                        date
+                    }
+                )
+            );
+
+            response.Result.ShouldBe(expectedKind.ToLower());
+        }
+
+        [Theory]
+        [InlineData("2016-04-13T08:58:10.526Z", "local")]
+        [InlineData("2016-04-13T08:58:10.526", "unspecified")]
+        [InlineData("2016-04-13 08:58:10.526Z", "local")]
+        [InlineData("2016-04-13 08:58:10.526", "unspecified")]
+        public async Task Controller_Should_Receive_Correct_DateTimeKind_For_Current_ClockProvider_When_Not_Normalized_Property_NullableSimpleType(string date, string expectedKind)
+        {
+            var response = await GetResponseAsObjectAsync<AjaxResponse<string>>(
+                GetUrl<SimpleTestController>(
+                    nameof(SimpleTestController.GetNotNormalizedNullableSimpleTypeDateTimeKind),
+                    new
+                    {
+                        date
+                    }
+                )
+            );
+
+            response.Result.ToLower().ShouldBe(expectedKind.ToLower());
+        }
+
         private IClockProvider StringToClockProvider(string dateTimeKind)
         {
             if (dateTimeKind == "local")


### PR DESCRIPTION
For the following services
````
[HttpGet]
public string GetSimpleTypeDateTimeKind(DateTime date)
{
	return date.Date.Kind.ToString().ToLower();
}

[HttpGet]
public string GetNotNormalizedSimpleTypeKind([DisableDateTimeNormalization]DateTime date)
{
	return date.Date.Kind.ToString().ToLower();
}

[HttpGet]
public string GetNullableSimpleTypeDateTimeKind(DateTime? date)
{
	return date.Value.Kind.ToString().ToLower();
}

[HttpGet]
public string GetNotNormalizedNullableSimpleTypeDateTimeKind([DisableDateTimeNormalization]DateTime? date)
{
	return date.Value.Date.Kind.ToString().ToLower();
}
```