### PR TITLE
Application will not use disabled languages by default

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/AbpApplicationBuilderExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/AbpApplicationBuilderExtensions.cs
@@ -97,6 +97,12 @@ namespace Abp.AspNetCore
                     .Select(l => CultureInfo.GetCultureInfo(l.Name))
                     .ToArray();
 
+                if (iocResolver.IsRegistered<ILogger<RequestLocalizationOptions>>())
+                {
+                    using var logger = iocResolver.ResolveAsDisposable<ILogger<RequestLocalizationOptions>>();
+                    logger.Object.LogInformation($"Supported Request Localization Cultures: {string.Join(",", supportedCultures.Select(c => c))}");
+                }
+
                 var options = new RequestLocalizationOptions
                 {
                     SupportedCultures = supportedCultures,

--- a/src/Abp.AspNetCore/AspNetCore/AbpApplicationBuilderExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/AbpApplicationBuilderExtensions.cs
@@ -93,7 +93,7 @@ namespace Abp.AspNetCore
             using (var languageManager = iocResolver.ResolveAsDisposable<ILanguageManager>())
             {
                 var supportedCultures = languageManager.Object
-                    .GetLanguages()
+                    .GetActiveLanguages()
                     .Select(l => CultureInfo.GetCultureInfo(l.Name))
                     .ToArray();
 

--- a/src/Abp.AspNetCore/AspNetCore/AbpApplicationBuilderExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/AbpApplicationBuilderExtensions.cs
@@ -99,10 +99,11 @@ namespace Abp.AspNetCore
 
                 if (iocResolver.IsRegistered<ILogger<RequestLocalizationOptions>>())
                 {
-                    using var logger = iocResolver.ResolveAsDisposable<ILogger<RequestLocalizationOptions>>();
-                    logger.Object.LogInformation($"Supported Request Localization Cultures: {string.Join(",", supportedCultures.Select(c => c))}");
+                    using (var logger = iocResolver.ResolveAsDisposable<ILogger<RequestLocalizationOptions>>())
+                    {
+                        logger.Object.LogInformation($"Supported Request Localization Cultures: {string.Join(",", supportedCultures.Select(c => c))}");                
+                    }
                 }
-
                 var options = new RequestLocalizationOptions
                 {
                     SupportedCultures = supportedCultures,

--- a/src/Abp.AspNetCore/AspNetCore/AbpApplicationBuilderExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/AbpApplicationBuilderExtensions.cs
@@ -101,9 +101,10 @@ namespace Abp.AspNetCore
                 {
                     using (var logger = iocResolver.ResolveAsDisposable<ILogger<RequestLocalizationOptions>>())
                     {
-                        logger.Object.LogInformation($"Supported Request Localization Cultures: {string.Join(",", supportedCultures.Select(c => c))}");                
+                        logger.Object.LogInformation($"Supported Request Localization Cultures: {string.Join(",", supportedCultures.Select(c => c))}");
                     }
                 }
+
                 var options = new RequestLocalizationOptions
                 {
                     SupportedCultures = supportedCultures,

--- a/src/Abp.FluentValidation/FluentValidation/AbpFluentValidationLanguageManager.cs
+++ b/src/Abp.FluentValidation/FluentValidation/AbpFluentValidationLanguageManager.cs
@@ -18,7 +18,7 @@ namespace Abp.FluentValidation
             if (!configuration.LocalizationSourceName.IsNullOrEmpty())
             {
                 var source = localizationManager.GetSource(configuration.LocalizationSourceName);
-                var languages = languageManager.GetLanguages();
+                var languages = languageManager.GetActiveLanguages();
 
                 AddAllTranslations(source, languages);
             }

--- a/src/Abp.Web.Common/Web/Configuration/AbpUserConfigurationBuilder.cs
+++ b/src/Abp.Web.Common/Web/Configuration/AbpUserConfigurationBuilder.cs
@@ -114,7 +114,7 @@ namespace Abp.Web.Configuration
         protected virtual AbpUserLocalizationConfigDto GetUserLocalizationConfig()
         {
             var currentCulture = CultureInfo.CurrentUICulture;
-            var languages = LanguageManager.GetLanguages();
+            var languages = LanguageManager.GetActiveLanguages();
 
             var config = new AbpUserLocalizationConfigDto
             {

--- a/src/Abp.Web.Common/Web/Localization/LocalizationScriptManager.cs
+++ b/src/Abp.Web.Common/Web/Localization/LocalizationScriptManager.cs
@@ -50,7 +50,7 @@ namespace Abp.Web.Localization
             script.AppendLine();
             script.Append("    abp.localization.languages = [");
 
-            var languages = _languageManager.GetLanguages();
+            var languages = _languageManager.GetActiveLanguages();
             for (var i = 0; i < languages.Count; i++)
             {
                 var language = languages[i];

--- a/src/Abp.Zero.Common/Localization/ApplicationLanguageManager.cs
+++ b/src/Abp.Zero.Common/Localization/ApplicationLanguageManager.cs
@@ -57,6 +57,11 @@ namespace Abp.Localization
             return (await GetLanguageDictionaryAsync(tenantId)).Values.ToImmutableList();
         }
 
+        public virtual async Task<IReadOnlyList<ApplicationLanguage>> GetActiveLanguagesAsync(int? tenantId)
+        {
+            return (await GetLanguagesAsync(tenantId)).Where(l => !l.IsDisabled).ToImmutableList();
+        }
+
         /// <summary>
         /// Gets list of all languages available to given tenant (or null for host)
         /// </summary>
@@ -64,6 +69,11 @@ namespace Abp.Localization
         public virtual IReadOnlyList<ApplicationLanguage> GetLanguages(int? tenantId)
         {
             return (GetLanguageDictionary(tenantId)).Values.ToImmutableList();
+        }
+
+        public virtual IReadOnlyList<ApplicationLanguage> GetActiveLanguages(int? tenantId)
+        {
+            return GetLanguages(tenantId).Where(l => !l.IsDisabled).ToImmutableList();
         }
 
         /// <summary>

--- a/src/Abp.Zero.Common/Localization/ApplicationLanguageProvider.cs
+++ b/src/Abp.Zero.Common/Localization/ApplicationLanguageProvider.cs
@@ -57,6 +57,20 @@ namespace Abp.Localization
 
             return languageInfos;
         }
+        /// <summary>
+        /// Gets the active languages for current tenant.
+        /// </summary>
+        public IReadOnlyList<LanguageInfo> GetActiveLanguages()
+        {
+            var languageInfos = _applicationLanguageManager.GetLanguages(AbpSession.TenantId)
+               .OrderBy(l => l.DisplayName)
+               .Select(l => l.ToLanguageInfo())
+               .ToList();
+
+            SetDefaultLanguage(languageInfos);
+
+            return languageInfos;
+        }
 
         private async Task SetDefaultLanguageAsync(List<LanguageInfo> languageInfos)
         {

--- a/src/Abp.Zero.Common/Localization/ApplicationLanguageProvider.cs
+++ b/src/Abp.Zero.Common/Localization/ApplicationLanguageProvider.cs
@@ -62,7 +62,7 @@ namespace Abp.Localization
         /// </summary>
         public IReadOnlyList<LanguageInfo> GetActiveLanguages()
         {
-            var languageInfos = _applicationLanguageManager.GetLanguages(AbpSession.TenantId)
+            var languageInfos = _applicationLanguageManager.GetActiveLanguages(AbpSession.TenantId)
                .OrderBy(l => l.DisplayName)
                .Select(l => l.ToLanguageInfo())
                .ToList();

--- a/src/Abp.Zero.Common/Localization/IApplicationLanguageManager.cs
+++ b/src/Abp.Zero.Common/Localization/IApplicationLanguageManager.cs
@@ -15,10 +15,22 @@ namespace Abp.Localization
         Task<IReadOnlyList<ApplicationLanguage>> GetLanguagesAsync(int? tenantId);
 
         /// <summary>
+        /// Gets list of all active languages available to given tenant (or null for host)
+        /// </summary>
+        /// <param name="tenantId">TenantId or null for host</param>
+        Task<IReadOnlyList<ApplicationLanguage>> GetActiveLanguagesAsync(int? tenantId);
+
+        /// <summary>
         /// Gets list of all languages available to given tenant (or null for host)
         /// </summary>
         /// <param name="tenantId">TenantId or null for host</param>
         IReadOnlyList<ApplicationLanguage> GetLanguages(int? tenantId);
+
+        /// <summary>
+        /// Gets list of all active languages available to given tenant (or null for host)
+        /// </summary>
+        /// <param name="tenantId">TenantId or null for host</param>
+        IReadOnlyList<ApplicationLanguage> GetActiveLanguages(int? tenantId);
 
         /// <summary>
         /// Adds a new language.

--- a/src/Abp.Zero.Common/Localization/MultiTenantLocalizationDictionaryProvider.cs
+++ b/src/Abp.Zero.Common/Localization/MultiTenantLocalizationDictionaryProvider.cs
@@ -51,7 +51,7 @@ namespace Abp.Localization
 
         protected virtual IDictionary<string, ILocalizationDictionary> GetDictionaries()
         {
-            var languages = _languageManager.GetLanguages();
+            var languages = _languageManager.GetActiveLanguages();
 
             foreach (var language in languages)
             {
@@ -63,7 +63,7 @@ namespace Abp.Localization
 
         protected virtual ILocalizationDictionary GetDefaultDictionary()
         {
-            var languages = _languageManager.GetLanguages();
+            var languages = _languageManager.GetActiveLanguages();
             if (!languages.Any())
             {
                 throw new AbpException("No language defined!");

--- a/src/Abp/Localization/DefaultLanguageProvider.cs
+++ b/src/Abp/Localization/DefaultLanguageProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Abp.Configuration.Startup;
 using Abp.Dependency;
 
@@ -17,6 +18,11 @@ namespace Abp.Localization
         public IReadOnlyList<LanguageInfo> GetLanguages()
         {
             return _configuration.Languages.ToImmutableList();
+        }
+
+        public IReadOnlyList<LanguageInfo> GetActiveLanguages()
+        {
+            return _configuration.Languages.Where(l => !l.IsDisabled).ToImmutableList();
         }
     }
 }

--- a/src/Abp/Localization/ILanguageManager.cs
+++ b/src/Abp/Localization/ILanguageManager.cs
@@ -7,5 +7,7 @@ namespace Abp.Localization
         LanguageInfo CurrentLanguage { get; }
 
         IReadOnlyList<LanguageInfo> GetLanguages();
+
+        IReadOnlyList<LanguageInfo> GetActiveLanguages();
     }
 }

--- a/src/Abp/Localization/ILanguageProvider.cs
+++ b/src/Abp/Localization/ILanguageProvider.cs
@@ -5,5 +5,7 @@ namespace Abp.Localization
     public interface ILanguageProvider
     {
         IReadOnlyList<LanguageInfo> GetLanguages();
+
+        IReadOnlyList<LanguageInfo> GetActiveLanguages();
     }
 }

--- a/src/Abp/Localization/LanguageManager.cs
+++ b/src/Abp/Localization/LanguageManager.cs
@@ -22,6 +22,11 @@ namespace Abp.Localization
             return _languageProvider.GetLanguages();
         }
 
+        public IReadOnlyList<LanguageInfo> GetActiveLanguages()
+        {
+            return _languageProvider.GetActiveLanguages();
+        }
+
         private LanguageInfo GetCurrentLanguage()
         {
             var languages = _languageProvider.GetLanguages();

--- a/test/Abp.Tests/Localization/DefaultLanguageProvider_Test.cs
+++ b/test/Abp.Tests/Localization/DefaultLanguageProvider_Test.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using Abp.Localization;
+using Abp.Modules;
+using Abp.Reflection.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Tests.Localization
+{
+    public class DefaultLanguageProvider_Test : TestBaseWithLocalIocManager
+    {
+        public DefaultLanguageProvider_Test()
+        {
+            LocalIocManager.Register<ILanguageProvider, DefaultLanguageProvider>();
+            var bootstrapper = AbpBootstrapper.Create<DefaultLanguageProviderLangModule>(options =>
+            {
+                options.IocManager = LocalIocManager;
+            });
+
+            bootstrapper.Initialize();
+        }
+
+        [Fact]
+        public void Should_Get_Languages()
+        {
+            var languageProvider = LocalIocManager.Resolve<ILanguageProvider>();
+
+            var allLanguages = languageProvider.GetLanguages();
+            allLanguages.Count.ShouldBe(2);
+        }
+
+        [Fact]
+        public void Should_Get_Active_Languages()
+        {
+            var languageProvider = LocalIocManager.Resolve<ILanguageProvider>();
+
+            var activeLanguages = languageProvider.GetActiveLanguages();
+            activeLanguages.Count.ShouldBe(1);
+            activeLanguages.Single().Name.ShouldBe("en");
+        }
+    }
+
+    public class DefaultLanguageProviderLangModule : AbpModule
+    {
+        public override void PreInitialize()
+        {
+            Configuration.Localization.Languages.Add(new LanguageInfo("en", "English", isDefault: true));
+            Configuration.Localization.Languages.Add(new LanguageInfo("tr", "Türkçe", isDisabled: true));
+        }
+
+        public override void Initialize()
+        {
+            IocManager.RegisterAssemblyByConvention(typeof(DefaultLanguageProviderLangModule).GetAssembly());
+        }
+    }
+}

--- a/test/Abp.Zero.SampleApp.Tests/Localization/ApplicationLanguageManager_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Localization/ApplicationLanguageManager_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Abp.Domain.Repositories;
 using Abp.Localization;
 using Abp.Zero.SampleApp.MultiTenancy;
 using Shouldly;
@@ -12,11 +13,13 @@ namespace Abp.Zero.SampleApp.Tests.Localization
     {
         private readonly Tenant _defaultTenant;
         private readonly IApplicationLanguageManager _languageManager;
+        private readonly IRepository<ApplicationLanguage> _applicationLanguageRepository;
 
         public ApplicationLanguageManager_Tests()
         {
             _defaultTenant = GetDefaultTenant();
             _languageManager = Resolve<IApplicationLanguageManager>();
+            _applicationLanguageRepository = Resolve<IRepository<ApplicationLanguage>>();
         }
 
         [Fact]
@@ -71,6 +74,32 @@ namespace Abp.Zero.SampleApp.Tests.Localization
             var languages = await _languageManager.GetLanguagesAsync(null);
             languages.Count.ShouldBe(2);
             languages.FirstOrDefault(l => l.Name == "tr").ShouldBeNull();
+        }
+        [Fact]
+        public async Task Should_Get_Host_Active_Languages()
+        {
+            await Should_Get_Only_Active_Languages(null);
+        }
+
+        [Fact]
+        public async Task Should_Get_Tenant_Active_Languages()
+        {
+            await Should_Get_Only_Active_Languages(_defaultTenant.Id);
+        }
+
+        private async Task Should_Get_Only_Active_Languages(int? tenantId)
+        {
+            var allLanguages = await _languageManager.GetLanguagesAsync(tenantId);
+            allLanguages.ShouldNotBeEmpty("Can not check that without any languages");
+
+            await WithUnitOfWorkAsync(async () =>
+            {
+                var language = await _applicationLanguageRepository.GetAsync(allLanguages.First().Id);
+                language.IsDisabled = true;
+            });
+
+            var activeLanguages = await _languageManager.GetActiveLanguagesAsync(tenantId);
+            activeLanguages.Count.ShouldBe(allLanguages.Count - 1);
         }
     }
 }


### PR DESCRIPTION
Application will only use active languages. 

Note: Since we can not change `app.UseRequestLocalization(options);` localization options at runtime, you should restart your website after you disable language not to support disabled language.

closes #4886