### PR TITLE
Do not store IHttpContextAccessor.HttpContext in a field.

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
@@ -18,22 +18,19 @@ namespace Abp.AspNetCore.Mvc.Auditing
 
         private readonly IHttpContextAccessor _httpContextAccessor;
 
-        private readonly HttpContext _httpContext;
-
         /// <summary>
         /// Creates a new <see cref="HttpContextClientInfoProvider"/>.
         /// </summary>
         public HttpContextClientInfoProvider(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor;
-            _httpContext = httpContextAccessor.HttpContext;
 
             Logger = NullLogger.Instance;
         }
 
         protected virtual string GetBrowserInfo()
         {
-            var httpContext = _httpContextAccessor.HttpContext ?? _httpContext;
+            var httpContext = _httpContextAccessor.HttpContext;
             return httpContext?.Request?.Headers?["User-Agent"];
         }
 
@@ -41,7 +38,7 @@ namespace Abp.AspNetCore.Mvc.Auditing
         {
             try
             {
-                var httpContext = _httpContextAccessor.HttpContext ?? _httpContext;
+                var httpContext = _httpContextAccessor.HttpContext;
 
                 return httpContext?.Connection?.RemoteIpAddress?.ToString();
 


### PR DESCRIPTION
Resolve #5098

https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AspNetCoreGuidance.md#do-not-store-ihttpcontextaccessorhttpcontext-in-a-field