### PR TITLE
Update image for AppVeyor to allow .NET Core 3.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 configuration: Release
-image: Visual Studio 2017
+image: Visual Studio 2019
 pull_requests:
   do_not_increment_build_number: true
   

--- a/build.cake
+++ b/build.cake
@@ -86,7 +86,7 @@ Task("Run-Unit-Tests")
     {
       foreach (string targetFramework in testProject.Item2)
       {
-        Information($"Test execution started for target frameowork: {targetFramework}...");
+        Information($"Test execution started for target framework: {targetFramework}...");
         var testProj = GetFiles($"./test/**/*{testProject.Item1}.csproj").First();
         DotNetCoreTest(testProj.FullPath, new DotNetCoreTestSettings { Configuration = "Release", Framework = targetFramework });                              
       }

--- a/build.cake
+++ b/build.cake
@@ -20,30 +20,30 @@ var msBuildPathX64 = (vsLatest==null)
 
 var testProjects = new List<Tuple<string, string[]>>
                 {
-                    new Tuple<string, string[]>("Abp.AspNetCore.Tests", new[] { "net461", "netcoreapp2.2" }),
-                    new Tuple<string, string[]>("Abp.AutoMapper.Tests", new[] { "net461", "netcoreapp2.2" }),
-                    new Tuple<string, string[]>("Abp.Castle.Log4Net.Tests", new[] { "net461", "netcoreapp2.2" }),
+                    new Tuple<string, string[]>("Abp.AspNetCore.Tests", new[] { "net461", "netcoreapp3.1" }),
+                    new Tuple<string, string[]>("Abp.AutoMapper.Tests", new[] { "net461", "netcoreapp3.1" }),
+                    new Tuple<string, string[]>("Abp.Castle.Log4Net.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.Dapper.NHibernate.Tests", new[] { "net461"}),
                     new Tuple<string, string[]>("Abp.Dapper.Tests", new[] { "net461" }),
                     new Tuple<string, string[]>("Abp.EntityFramework.GraphDiff.Tests", new[] { "net461" }),
                     new Tuple<string, string[]>("Abp.EntityFramework.Tests", new[] { "net461" }),
-                    new Tuple<string, string[]>("Abp.EntityFrameworkCore.Dapper.Tests", new[] { "netcoreapp2.2" }),
-                    new Tuple<string, string[]>("Abp.EntityFrameworkCore.Tests", new[] { "net461", "netcoreapp2.2" }),
-                    new Tuple<string, string[]>("Abp.MailKit.Tests", new[] { "net461", "netcoreapp2.2" }),
-                    new Tuple<string, string[]>("Abp.MemoryDb.Tests", new[] { "net461", "netcoreapp2.2" }),
+                    new Tuple<string, string[]>("Abp.EntityFrameworkCore.Dapper.Tests", new[] { "netcoreapp3.1" }),
+                    new Tuple<string, string[]>("Abp.EntityFrameworkCore.Tests", new[] { "net461", "netcoreapp3.1" }),
+                    new Tuple<string, string[]>("Abp.MailKit.Tests", new[] { "net461", "netcoreapp3.1" }),
+                    new Tuple<string, string[]>("Abp.MemoryDb.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.NHibernate.Tests", new[] { "net461" }),
                     new Tuple<string, string[]>("Abp.Quartz.Tests", new[] { "net461" }),
-                    new Tuple<string, string[]>("Abp.RedisCache.Tests", new[] { "net461", "netcoreapp2.2" }),
+                    new Tuple<string, string[]>("Abp.RedisCache.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.TestBase.SampleApplication.Tests", new[] { "net461" }),
-                    new Tuple<string, string[]>("Abp.Tests", new[] { "net461", "netcoreapp2.2" }),
+                    new Tuple<string, string[]>("Abp.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.Web.Api.Tests", new[] { "net461" }),
-                    new Tuple<string, string[]>("Abp.Web.Common.Tests", new[] { "net461", "netcoreapp2.2" }),
+                    new Tuple<string, string[]>("Abp.Web.Common.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.Web.Mvc.Tests", new[] { "net461" }),
                     new Tuple<string, string[]>("Abp.Web.Tests", new[] { "net461" }),
                     new Tuple<string, string[]>("Abp.Zero.SampleApp.NHibernateTests", new[] { "net461" }),
                     new Tuple<string, string[]>("Abp.Zero.SampleApp.Tests", new[] { "net461" }),
-                    new Tuple<string, string[]>("Abp.ZeroCore.Tests", new[] { "netcoreapp2.2" }),
-                    new Tuple<string, string[]>("Abp.ZeroCore.IdentityServer4.Tests", new[] { "netcoreapp2.2" })
+                    new Tuple<string, string[]>("Abp.ZeroCore.Tests", new[] { "netcoreapp3.1" }),
+                    new Tuple<string, string[]>("Abp.ZeroCore.IdentityServer4.Tests", new[] { "netcoreapp3.1" })
                 };
                       
 

--- a/build.cake
+++ b/build.cake
@@ -20,7 +20,7 @@ var msBuildPathX64 = (vsLatest==null)
 
 var testProjects = new List<Tuple<string, string[]>>
                 {
-                    new Tuple<string, string[]>("Abp.AspNetCore.Tests", new[] { "net461", "netcoreapp3.1" }),
+                    new Tuple<string, string[]>("Abp.AspNetCore.Tests", new[] { "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.AutoMapper.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.Castle.Log4Net.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.Dapper.NHibernate.Tests", new[] { "net461"}),
@@ -28,7 +28,7 @@ var testProjects = new List<Tuple<string, string[]>>
                     new Tuple<string, string[]>("Abp.EntityFramework.GraphDiff.Tests", new[] { "net461" }),
                     new Tuple<string, string[]>("Abp.EntityFramework.Tests", new[] { "net461" }),
                     new Tuple<string, string[]>("Abp.EntityFrameworkCore.Dapper.Tests", new[] { "netcoreapp3.1" }),
-                    new Tuple<string, string[]>("Abp.EntityFrameworkCore.Tests", new[] { "net461", "netcoreapp3.1" }),
+                    new Tuple<string, string[]>("Abp.EntityFrameworkCore.Tests", new[] { "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.MailKit.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.MemoryDb.Tests", new[] { "net461", "netcoreapp3.1" }),
                     new Tuple<string, string[]>("Abp.NHibernate.Tests", new[] { "net461" }),

--- a/build.cake
+++ b/build.cake
@@ -16,7 +16,7 @@ var branch = Argument("branch", EnvironmentVariable("APPVEYOR_REPO_BRANCH"));
 var vsLatest  = VSWhereLatest();
 var msBuildPathX64 = (vsLatest==null)
                             ? null
-                            : vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/amd64/MSBuild.exe");
+                            : vsLatest.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
 
 var testProjects = new List<Tuple<string, string[]>>
                 {

--- a/build.ps1
+++ b/build.ps1
@@ -33,7 +33,7 @@ Param(
 
 $CakeVersion = "0.23.0"
 $DotNetChannel = "Current";
-$DotNetVersion = "2.2.103";
+$DotNetVersion = "3.1.100";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
+using System.Threading;
 using Abp.Application.Editions;
 using Abp.Application.Features;
 using Abp.Zero.SampleApp.TPH;
@@ -121,6 +122,8 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             Resolve<IEntityHistoryConfiguration>().Selectors.Add("Selected", typeof(Advertisement));
 
             var justNow = Clock.Now;
+            Thread.Sleep(1);
+
             WithUnitOfWork(() =>
             {
                 _advertisementRepository.InsertAndGetId(new Advertisement { Banner = "tracked-advertisement" });
@@ -210,6 +213,8 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             Resolve<IEntityHistoryConfiguration>().Selectors.Add("Selected", typeof(Student));
 
             var justNow = Clock.Now;
+            Thread.Sleep(1);
+
             var student = new Student()
             {
                 Name = "TestName",
@@ -322,6 +327,8 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
             });
 
             var justNow = Clock.Now;
+            Thread.Sleep(1);
+
             var blog2Id = CreateBlogAndGetId();
 
             UsingDbContext((context) =>


### PR DESCRIPTION
This should fix AppVeyor checks.

e.g. failed check: https://ci.appveyor.com/project/hikalkan/aspnetboilerplate/builds/29676556