### PR TITLE
Update Redis serializer Serialize() return type

### DIFF
--- a/src/Abp.RedisCache.ProtoBuf/Runtime/Caching/Redis/ProtoBufRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache.ProtoBuf/Runtime/Caching/Redis/ProtoBufRedisCacheSerializer.cs
@@ -44,7 +44,7 @@ namespace Abp.Runtime.Caching.Redis
         /// <param name="type">Type of the object.</param>
         /// <returns>Returns a string representing the object instance that can be placed into the Redis cache.</returns>
         /// <seealso cref="IRedisCacheSerializer.Deserialize" />
-        public override string Serialize(object value, Type type)
+        public override RedisValue Serialize(object value, Type type)
         {
             if (!type.GetTypeInfo().IsDefined(typeof(ProtoContractAttribute), false))
             {

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/DefaultRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/DefaultRedisCacheSerializer.cs
@@ -36,7 +36,7 @@ namespace Abp.Runtime.Caching.Redis
         /// <param name="type">Type of the object.</param>
         /// <returns>Returns a string representing the object instance that can be placed into the Redis cache.</returns>
         /// <seealso cref="IRedisCacheSerializer.Deserialize" />
-        public virtual string Serialize(object value, Type type)
+        public virtual RedisValue Serialize(object value, Type type)
         {
             return JsonConvert.SerializeObject(AbpCacheData.Serialize(value));
         }

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/IRedisCacheSerializer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/IRedisCacheSerializer.cs
@@ -3,27 +3,31 @@ using StackExchange.Redis;
 
 namespace Abp.Runtime.Caching.Redis
 {
+    public interface IRedisCacheSerializer : IRedisCacheSerializer<object, RedisValue>
+    {
+    }
+
     /// <summary>
     ///     Interface to be implemented by all custom (de)serialization methods used when persisting and retrieving
     ///     objects from the Redis cache.
     /// </summary>
-    public interface IRedisCacheSerializer
+    public interface IRedisCacheSerializer<TSource, TDestination>
     {
         /// <summary>
-        ///     Creates an instance of the object from its serialized string representation.
-        /// </summary>
-        /// <param name="objbyte">String representation of the object from the Redis server.</param>
-        /// <returns>Returns a newly constructed object.</returns>
-        /// <seealso cref="Serialize" />
-        object Deserialize(RedisValue objbyte);
-
-        /// <summary>
-        ///     Produce a string representation of the supplied object.
+        ///     Produce a Redis representation of the supplied object.
         /// </summary>
         /// <param name="value">Instance to serialize.</param>
         /// <param name="type">Type of the object.</param>
-        /// <returns>Returns a string representing the object instance that can be placed into the Redis cache.</returns>
+        /// <returns>Returns object data in Redis representation that can be placed into the Redis cache.</returns>
         /// <seealso cref="Deserialize" />
-        string Serialize(object value, Type type);
+        TDestination Serialize(TSource value, Type type);
+
+        /// <summary>
+        ///     Creates an instance of the object from object data in Redis representation.
+        /// </summary>
+        /// <param name="objbyte">Object data in Redis representation.</param>
+        /// <returns>Returns a newly constructed object.</returns>
+        /// <seealso cref="Serialize" />
+        TSource Deserialize(TDestination objbyte);
     }
 }

--- a/test/Abp.RedisCache.Tests/DefaultRedisCacheSerializer_Tests.cs
+++ b/test/Abp.RedisCache.Tests/DefaultRedisCacheSerializer_Tests.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Abp.Runtime.Caching;
 using Abp.Runtime.Caching.Redis;
 using Abp.Tests;
-using Abp.Tests.Runtime.Caching;
 using Shouldly;
 using Xunit;
 
@@ -30,7 +28,7 @@ namespace Abp.RedisCache.Tests
             };
 
             var result = _redisCacheSerializer.Serialize(source, typeof(List<string>));
-            result.ShouldStartWith("{\"Payload\":\"[\\\"Stranger Things\\\",\\\"The OA\\\",\\\"Lost in Space\\\"]\",\"Type\":\"System.Collections.Generic.List`1[[System.String,");
+            result.ToString().ShouldStartWith("{\"Payload\":\"[\\\"Stranger Things\\\",\\\"The OA\\\",\\\"Lost in Space\\\"]\",\"Type\":\"System.Collections.Generic.List`1[[System.String,");
         }
 
         [Fact]
@@ -43,7 +41,7 @@ namespace Abp.RedisCache.Tests
             };
 
             var result = _redisCacheSerializer.Serialize(source, typeof(MyTestClass));
-            result.ShouldBe("{\"Payload\":\"{\\\"Field1\\\":42,\\\"Field2\\\":\\\"Stranger Things\\\"}\",\"Type\":\"Abp.RedisCache.Tests.DefaultRedisCacheSerializer_Tests+MyTestClass, Abp.RedisCache.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\"}");
+            result.ToString().ShouldBe("{\"Payload\":\"{\\\"Field1\\\":42,\\\"Field2\\\":\\\"Stranger Things\\\"}\",\"Type\":\"Abp.RedisCache.Tests.DefaultRedisCacheSerializer_Tests+MyTestClass, Abp.RedisCache.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\"}");
         }
 
         [Fact]

--- a/test/Abp.RedisCache.Tests/RedisCacheManager_Test.cs
+++ b/test/Abp.RedisCache.Tests/RedisCacheManager_Test.cs
@@ -8,41 +8,60 @@ using Castle.MicroKernel.Registration;
 using NSubstitute;
 using Xunit;
 using Shouldly;
+using StackExchange.Redis;
 
 namespace Abp.RedisCache.Tests
 {
     public class RedisCacheManager_Test : TestBaseWithLocalIocManager
     {
         private readonly ITypedCache<string, MyCacheItem> _cache;
+        private IAbpRedisCacheDatabaseProvider _redisDatabaseProvider;
+        private IRedisCacheSerializer _redisSerializer;
+        private IDatabase _redisDatabase;
 
         public RedisCacheManager_Test()
         {
             LocalIocManager.Register<AbpRedisCacheOptions>();
             LocalIocManager.Register<ICachingConfiguration, CachingConfiguration>();
-            LocalIocManager.Register<IAbpRedisCacheDatabaseProvider, AbpRedisCacheDatabaseProvider>();
+
+            _redisDatabase = Substitute.For<IDatabase>();
+            _redisDatabaseProvider = Substitute.For<IAbpRedisCacheDatabaseProvider>();
+            _redisDatabaseProvider.GetDatabase().Returns(_redisDatabase);
+            LocalIocManager.IocContainer.Register(Component.For<IAbpRedisCacheDatabaseProvider>().Instance(_redisDatabaseProvider).LifestyleSingleton());
+
             LocalIocManager.Register<ICacheManager, AbpRedisCacheManager>();
-            LocalIocManager.Register<IRedisCacheSerializer,DefaultRedisCacheSerializer>();
+            LocalIocManager.Register<IRedisCacheSerializer, DefaultRedisCacheSerializer>();
+            _redisSerializer = LocalIocManager.Resolve<IRedisCacheSerializer>();
+
             LocalIocManager.IocContainer.Register(Component.For<IAbpStartupConfiguration>().Instance(Substitute.For<IAbpStartupConfiguration>()));
 
-            var defaultSlidingExpireTime = TimeSpan.FromHours(24);
             LocalIocManager.Resolve<ICachingConfiguration>().Configure("MyTestCacheItems", cache =>
             {
-                cache.DefaultSlidingExpireTime = defaultSlidingExpireTime;
+                cache.DefaultSlidingExpireTime = TimeSpan.FromHours(24);
             });
 
             _cache = LocalIocManager.Resolve<ICacheManager>().GetCache<string, MyCacheItem>("MyTestCacheItems");
-            _cache.DefaultSlidingExpireTime.ShouldBe(defaultSlidingExpireTime);
         }
 
-        //[Theory]
-        //[InlineData("A", 42)]
-        //[InlineData("B", 43)]
+        [Fact]
+        public void Cache_Options_Configuration_Test()
+        {
+            _cache.DefaultSlidingExpireTime.ShouldBe(TimeSpan.FromHours(24));
+        }
+
+        [Theory]
+        [InlineData("A", 42)]
+        [InlineData("B", 43)]
         public void Simple_Get_Set_Test(string cacheKey, int cacheValue)
         {
             var item = _cache.Get(cacheKey, () => new MyCacheItem { Value = cacheValue });
 
             item.ShouldNotBe(null);
             item.Value.ShouldBe(cacheValue);
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem { Value = cacheValue }, typeof(MyCacheItem));
+            _redisDatabase.StringGet(Arg.Any<RedisKey>()).Returns(cachedObject);
+            _redisDatabase.Received().StringGet(Arg.Any<RedisKey>());
 
             _cache.GetOrDefault(cacheKey).Value.ShouldBe(cacheValue);
         }


### PR DESCRIPTION
Since the `Deserialize()` accepts a `RedisValue` type, `Serialize()` should be consistently returning `RedisValue` type as well

Reference https://stackexchange.github.io/StackExchange.Redis/KeysValues.html

Also, this PR will try to re-enable redis test