### PR TITLE
Set EntityType to null before sending via SignalR

### DIFF
--- a/src/Abp.AspNetCore.SignalR/AspNetCore/SignalR/Notifications/SignalRRealTimeNotifier.cs
+++ b/src/Abp.AspNetCore.SignalR/AspNetCore/SignalR/Notifications/SignalRRealTimeNotifier.cs
@@ -52,6 +52,7 @@ namespace Abp.AspNetCore.SignalR.Notifications
                             continue;
                         }
 
+                        userNotification.Notification.EntityType = null; // Serialization of System.Type causes SignalR to disconnect. See https://github.com/aspnetboilerplate/aspnetboilerplate/issues/5230
                         signalRClient.SendAsync("getNotification", userNotification);
                     }
                 }
@@ -82,6 +83,7 @@ namespace Abp.AspNetCore.SignalR.Notifications
                             continue;
                         }
 
+                        userNotification.Notification.EntityType = null; // Serialization of System.Type causes SignalR to disconnect. See https://github.com/aspnetboilerplate/aspnetboilerplate/issues/5230
                         //signalRClient.SendAsync("getNotification", userNotification);
                         Threading.AsyncHelper.RunSync(() => signalRClient.SendAsync("getNotification", userNotification));
                     }

--- a/src/Abp/Notifications/TenantNotification.cs
+++ b/src/Abp/Notifications/TenantNotification.cs
@@ -29,6 +29,7 @@ namespace Abp.Notifications
         /// <summary>
         /// Gets or sets the type of the entity.
         /// </summary>
+        [Obsolete("(De)serialization of System.Type is bad and not supported. See https://github.com/dotnet/corefx/issues/42712")]
         public Type EntityType { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Fixes #5230 

# Investigation

To reproduce the issue, add a line in [aspnetboilerplate/module-zero-core-template's AccountController.cs#L450-L455](https://github.com/aspnetboilerplate/module-zero-core-template/blob/92f8bf5367d7d3238ce360276c2889b38cd57cdd/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Controllers/AccountController.cs#L450-L455):

```diff
  await _notificationPublisher.PublishAsync(
          "App.SimpleMessage",
          new MessageNotificationData(message),
+         entityIdentifier: new EntityIdentifier(typeof(Entity), 0),
          severity: NotificationSeverity.Info,
          userIds: new[] { defaultTenantAdmin, hostAdmin }
      );
```

To get the error (maybe silently caught inside SignalR), add a line at [SignalRRealTimeNotifier.cs#L55](https://github.com/aspnetboilerplate/aspnetboilerplate/blob/8d460dd9fe7297b99551adc9ed160290e8685582/src/Abp.AspNetCore.SignalR/AspNetCore/SignalR/Notifications/SignalRRealTimeNotifier.cs#L55):

```diff
+ JsonSerializer.Serialize(userNotification);
  signalRClient.SendAsync("getNotification", userNotification);
```

Error log:

```
WARN  2020-01-18 23:45:56,409 [27   ] Host.Controllers.SignalRRealTimeNotifier - Could not send notification to user: 2@1
WARN  2020-01-18 23:45:56,497 [27   ] Host.Controllers.SignalRRealTimeNotifier - System.Text.Json.JsonException: A possible object cycle was detected which is not supported. This can either be due to a cycle or if the object depth is larger than the maximum allowed depth of 0.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_SerializerCycleDetected(Int32 maxDepth)
   at System.Text.Json.JsonSerializer.Write(Utf8JsonWriter writer, Int32 originalWriterDepth, Int32 flushThreshold, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.JsonSerializer.WriteCore(Utf8JsonWriter writer, Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteCore(PooledByteBufferWriter output, Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteCoreString(Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.Serialize[TValue](TValue value, JsonSerializerOptions options)
   at AbpCompanyName.AbpProjectName.Web.Host.Controllers.SignalRRealTimeNotifier.SendNotificationsAsync(UserNotification[] userNotifications) in C:\Users\Aaron\Desktop\module-zero-core-template\aspnet-core\src\AbpCompanyName.AbpProjectName.Web.Mvc\Controllers\SignalRRealTimeNotifier.cs:line 63
System.Text.Json.JsonException: A possible object cycle was detected which is not supported. This can either be due to a cycle or if the object depth is larger than the maximum allowed depth of 0.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_SerializerCycleDetected(Int32 maxDepth)
   at System.Text.Json.JsonSerializer.Write(Utf8JsonWriter writer, Int32 originalWriterDepth, Int32 flushThreshold, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.JsonSerializer.WriteCore(Utf8JsonWriter writer, Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteCore(PooledByteBufferWriter output, Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteCoreString(Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.Serialize[TValue](TValue value, JsonSerializerOptions options)
   at AbpCompanyName.AbpProjectName.Web.Host.Controllers.SignalRRealTimeNotifier.SendNotificationsAsync(UserNotification[] userNotifications) in C:\Users\Aaron\Desktop\module-zero-core-template\aspnet-core\src\AbpCompanyName.AbpProjectName.Web.Mvc\Controllers\SignalRRealTimeNotifier.cs:line 63
```

# Root cause

(De)serialization of `System.Type` is bad and not supported. See https://github.com/dotnet/corefx/issues/42712.

# Solution

1. Set `EntityType` of `TenantNotification` to `null` before sending via SignalR.
2. Deprecate `EntityType` property of serializable class `TenantNotification`.