### PR TITLE
Fix Entity History Retrieve the correct owner

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -71,16 +71,16 @@ namespace Abp.EntityHistory
                 if (!shouldAuditEntity.HasValue && entityEntry.Metadata.IsOwned())
                 {
                     // Check if owner entity has auditing attribute
-                    var foreignKey = entityEntry.Metadata.GetForeignKeys().First();
-                    var ownerEntity = foreignKey.PrincipalEntityType.ClrType;
+                    var ownerForeignKey = entityEntry.Metadata.GetForeignKeys().First(fk => fk.IsOwnership);
+                    var ownerEntityType = ownerForeignKey.PrincipalEntityType.ClrType;
 
-                    shouldAuditOwnerEntity = IsTypeOfAuditedEntity(ownerEntity);
+                    shouldAuditOwnerEntity = IsTypeOfAuditedEntity(ownerEntityType);
                     if (shouldAuditOwnerEntity.HasValue && !shouldAuditOwnerEntity.Value)
                     {
                         continue;
                     }
 
-                    var ownerPropertyInfo = foreignKey.PrincipalToDependent.PropertyInfo;
+                    var ownerPropertyInfo = ownerForeignKey.PrincipalToDependent.PropertyInfo;
                     shouldAuditOwnerProperty = IsAuditedPropertyInfo(ownerPropertyInfo);
                     if (shouldAuditOwnerProperty.HasValue && !shouldAuditOwnerProperty.Value)
                     {

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Advertisement.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Advertisement.cs
@@ -1,9 +1,19 @@
 ﻿using Abp.Domain.Entities;
+using System.Collections.Generic;
 
 namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
 {
     public class Advertisement : Entity
     {
         public string Banner { get; set; }
+
+        public ICollection<AdvertisementFeedback> Feedbacks { get; set; }
+    }
+
+    public class AdvertisementFeedback
+    {
+        public int AdvertisementId { get; set; }
+
+        public int CommentId { get; set; }
     }
 }

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Blog.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Blog.cs
@@ -18,6 +18,8 @@ namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
 
         public BlogEx More { get; set; }
 
+        public ICollection<BlogPromotion> Promotions { get; set; }
+
         public ICollection<Post> Posts { get; set; }
 
         public Blog()
@@ -57,5 +59,14 @@ namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
     public class BlogEx
     {
         public string BloggerName { get; set; }
+    }
+
+    public class BlogPromotion
+    {
+        public int BlogId { get; set; }
+
+        public int AdvertisementId { get; set; }
+
+        public string Title { get; set; }
     }
 }

--- a/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
+++ b/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
@@ -52,6 +52,29 @@ namespace Abp.ZeroCore.SampleApp.EntityFramework
 
             modelBuilder.Entity<Blog>().OwnsOne(x => x.More);
 
+            modelBuilder.Entity<Blog>().OwnsMany(x => x.Promotions, b => 
+            {
+                b.WithOwner().HasForeignKey(bp => bp.BlogId);
+                b.Property<int>("Id");
+                b.HasKey("Id");
+
+                b.HasOne<Blog>()
+                 .WithOne()
+                 .HasForeignKey<BlogPromotion>(bp => bp.AdvertisementId)
+                 .IsRequired();
+            });
+
+            modelBuilder.Entity<Advertisement>().OwnsMany(a => a.Feedbacks, b =>
+            {
+                b.WithOwner().HasForeignKey(af => af.AdvertisementId);
+                b.Property<int>("Id");
+                b.HasKey("Id");
+
+                b.HasOne<Comment>()
+                 .WithOne()
+                 .HasForeignKey<AdvertisementFeedback>(af => af.CommentId);
+            });
+
             modelBuilder.Entity<Book>().ToTable("Books");
             modelBuilder.Entity<Book>().Property(e => e.Id).ValueGeneratedNever();
 

--- a/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestBase.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestBase.cs
@@ -50,8 +50,9 @@ namespace Abp.Zero
                 context =>
                 {
                     var blog1 = new Blog("test-blog-1", "http://testblog1.myblogs.com", "blogger-1");
+                    var blog2 = new Blog() { Name = "test-blog-2" };
 
-                    context.Blogs.Add(blog1);
+                    context.Blogs.AddRange(blog1, blog2);
                     context.SaveChanges();
 
                     var post1 = new Post { Blog = blog1, Title = "test-post-1-title", Body = "test-post-1-body" };
@@ -66,8 +67,9 @@ namespace Abp.Zero
                     context.Comments.Add(comment1);
 
                     var advertisement1 = new Advertisement { Banner = "test-advertisement-1" };
+                    var advertisement2 = new Advertisement { Banner = "test-advertisement-2" };
 
-                    context.Advertisements.Add(advertisement1);
+                    context.Advertisements.AddRange(advertisement1, advertisement2);
                 });
         }
 

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -570,10 +570,9 @@ namespace Abp.Zero.EntityHistory
             {
                 s.EntityChanges.Count.ShouldBe(1);
 
-                var entityChange = s.EntityChanges[0];
+                var entityChange = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Post).FullName);
                 entityChange.ChangeType.ShouldBe(EntityChangeType.Updated);
                 entityChange.EntityId.ShouldBe(post1Id.ToJsonString(false, false));
-                entityChange.EntityTypeFullName.ShouldBe(typeof(Post).FullName);
                 entityChange.PropertyChanges.Count.ShouldBe(1);
 
                 var propertyChange = entityChange.PropertyChanges.Single();
@@ -590,7 +589,7 @@ namespace Abp.Zero.EntityHistory
         {
             /* Comment has Audited attribute. */
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var comment1 = _commentRepository.Single(b => b.Content == "test-comment-1-content");
                 var post2 = _postRepository.Single(b => b.Body == "test-post-2-body");
@@ -598,9 +597,7 @@ namespace Abp.Zero.EntityHistory
                 // Change foreign key by assigning navigation property
                 comment1.Post = post2;
                 _commentRepository.Update(comment1);
-
-                uow.Complete();
-            }
+            });
 
             Predicate<EntityChangeSet> predicate = s =>
             {
@@ -625,15 +622,13 @@ namespace Abp.Zero.EntityHistory
         {
             /* Blog.Name has DisableAuditing attribute. */
 
-            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            WithUnitOfWork(() =>
             {
                 var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
 
                 blog1.Name = null;
                 _blogRepository.Update(blog1);
-
-                uow.Complete();
-            }
+            });
 
             Predicate<EntityChangeSet> predicate = s =>
             {

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -257,10 +257,9 @@ namespace Abp.Zero.EntityHistory
             {
                 s.EntityChanges.Count.ShouldBe(1);
 
-                var entityChangeBlog = s.EntityChanges[0];
+                var entityChangeBlog = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Blog).FullName);
                 entityChangeBlog.ChangeType.ShouldBe(EntityChangeType.Updated);
                 entityChangeBlog.EntityId.ShouldBe(entityChangeBlog.EntityEntry.As<EntityEntry>().Entity.As<IEntity>().Id.ToJsonString(false, false));
-                entityChangeBlog.EntityTypeFullName.ShouldBe(typeof(Blog).FullName);
                 entityChangeBlog.PropertyChanges.Count.ShouldBe(1);
 
                 var propertyChangeUrl = entityChangeBlog.PropertyChanges.Single(pc => pc.PropertyName == nameof(Blog.Url));
@@ -275,39 +274,173 @@ namespace Abp.Zero.EntityHistory
         }
 
         [Fact]
-        public void Should_Write_History_For_Audited_Entities_Update_Owned()
+        public void Should_Write_History_For_Owned_Entities_Of_Audited_Entities_Create()
         {
-            /* Blog has Audited attribute. */
+            // Blog is the owner of BlogPromotion and has Audited attribute.
+            // Advertisement is not the owner of BlogPromotion.
+            // Therefore, BlogPromotion should follow Blog and have entity history.
 
+            //Arrange
             int blog1Id;
-            var newValue = "blogger-2";
-            string originalValue;
+            int advertisement1Id;
+            int advertisement2Id;
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                // Owned entities are not available via DbContext -> DbSet,
+                var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
+                blog1Id = blog1.Id;
+                blog1.Promotions.Count.ShouldBe(0);
 
+                var advertisement1 = _advertisementRepository.Single(a => a.Banner == "test-advertisement-1");
+                advertisement1Id = advertisement1.Id;
+                var advertisement2 = _advertisementRepository.Single(a => a.Banner == "test-advertisement-2");
+                advertisement2Id = advertisement2.Id;
+
+                blog1.Promotions.Add(new BlogPromotion { AdvertisementId = advertisement1.Id });
+                blog1.Promotions.Add(new BlogPromotion { AdvertisementId = advertisement2.Id });
+                uow.Complete();
+            };
+
+            //Assert
+            WithUnitOfWork(() =>
+            {
+                // Owned entities are not available via DbContext -> DbSet,
+                var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
+                blog1.Promotions.Count.ShouldBe(2);
+            });
+
+            Predicate<EntityChangeSet> predicate = s =>
+            {
+                s.EntityChanges.Count.ShouldBe(2);
+
+                // The primary key (Id) of BlogPromotion is a shadow property and BlogId being the foreign key to its owner, Blog,
+                // EF Core is keeping the values of PK of Blog and FK (BlogId) of BlogPromotion the same
+                // PK of BlogPromotion is unique across different owners, e.g. Blog1 has BlogPromotion1, BlogPromotion2 and Blog2 has BlogPromotion3
+                // See https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types
+
+                // We assume that are 2 BlogPromotion being created sequentially for Blog 1
+                const int blog1Promotion1Id = 1;
+                const int blog1Promotion2Id = 2;
+
+                var entityChange1 = s.EntityChanges.Single(ec => 
+                    ec.EntityTypeFullName == typeof(BlogPromotion).FullName
+                    && ec.EntityId == blog1Promotion1Id.ToJsonString(false, false)
+                );
+                entityChange1.ChangeType.ShouldBe(EntityChangeType.Created);
+                entityChange1.PropertyChanges.Count.ShouldBe(2);
+
+                var propertyChange1 = entityChange1.PropertyChanges.Single(pc => pc.PropertyName == nameof(BlogPromotion.BlogId));
+                propertyChange1.OriginalValue.ShouldBeNull();
+                propertyChange1.NewValue.ShouldBe(blog1Id.ToJsonString(false, false));
+                propertyChange1.PropertyTypeFullName.ShouldBe(typeof(BlogPromotion).GetProperty(nameof(BlogPromotion.BlogId)).PropertyType.FullName);
+
+                var propertyChange2 = entityChange1.PropertyChanges.Single(pc => pc.PropertyName == nameof(BlogPromotion.AdvertisementId));
+                propertyChange2.OriginalValue.ShouldBeNull();
+                propertyChange2.NewValue.ShouldBe(advertisement1Id.ToJsonString(false, false));
+                propertyChange2.PropertyTypeFullName.ShouldBe(typeof(BlogPromotion).GetProperty(nameof(BlogPromotion.AdvertisementId)).PropertyType.FullName);
+
+                var entityChange2 = s.EntityChanges.Single(ec =>
+                    ec.EntityTypeFullName == typeof(BlogPromotion).FullName
+                    && ec.EntityId == blog1Promotion2Id.ToJsonString(false, false)
+                );
+                entityChange2.ChangeType.ShouldBe(EntityChangeType.Created);
+                entityChange2.PropertyChanges.Count.ShouldBe(2);
+
+                var propertyChange3 = entityChange2.PropertyChanges.Single(pc => pc.PropertyName == nameof(BlogPromotion.BlogId));
+                propertyChange3.OriginalValue.ShouldBeNull();
+                propertyChange3.NewValue.ShouldBe(blog1Id.ToJsonString(false, false));
+                propertyChange3.PropertyTypeFullName.ShouldBe(typeof(BlogPromotion).GetProperty(nameof(BlogPromotion.BlogId)).PropertyType.FullName);
+
+                var propertyChange4 = entityChange2.PropertyChanges.Single(pc => pc.PropertyName == nameof(BlogPromotion.AdvertisementId));
+                propertyChange4.OriginalValue.ShouldBeNull();
+                propertyChange4.NewValue.ShouldBe(advertisement2Id.ToJsonString(false, false));
+                propertyChange4.PropertyTypeFullName.ShouldBe(typeof(BlogPromotion).GetProperty(nameof(BlogPromotion.AdvertisementId)).PropertyType.FullName);
+
+                return true;
+            };
+
+            _entityHistoryStore.Received().Save(Arg.Is<EntityChangeSet>(s => predicate(s)));
+        }
+
+        [Fact]
+        public void Should_Write_History_For_Owned_Entities_Of_Audited_Entities_Update()
+        {
+            // Blog is the owner of BlogPromotion and has Audited attribute.
+            // Advertisement is not the owner of BlogPromotion.
+            // Therefore, BlogPromotion should follow Blog and have entity history.
+
+            //Arrange
+            int advertisement2Id;
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                // Owned entities are not available via DbContext -> DbSet,
+                var blog2 = _blogRepository.Single(b => b.Name == "test-blog-2");
+                blog2.Promotions.Count.ShouldBe(0);
+
+                var advertisement1 = _advertisementRepository.Single(a => a.Banner == "test-advertisement-1");
+                blog2.Promotions.Add(new BlogPromotion { AdvertisementId = advertisement1.Id });
+
+                uow.Complete();
+
+                blog2.Promotions.Count.ShouldBe(1);
+            };
+            using (var uow = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                // Owned entities are not available via DbContext -> DbSet,
+                var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
+                blog1.Promotions.Count.ShouldBe(0);
+
+                var advertisement2 = _advertisementRepository.Single(a => a.Banner == "test-advertisement-2");
+                advertisement2Id = advertisement2.Id;
+
+                blog1.Promotions.Add(new BlogPromotion { AdvertisementId = advertisement2.Id, Title = "test-promotion-2" });
+                uow.Complete();
+
+                blog1.Promotions.Count.ShouldBe(1);
+            };
+            _entityHistoryStore.ClearReceivedCalls();
+
+            //Act
             using (var uow = Resolve<IUnitOfWorkManager>().Begin())
             {
                 var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
-                blog1Id = blog1.Id;
 
-                originalValue = blog1.More.BloggerName;
-                blog1.More.BloggerName = newValue;
-
+                var blog1Promotion2 = blog1.Promotions.Single(p => p.AdvertisementId == advertisement2Id);
+                blog1Promotion2.Title = "test-promotion-2-updated";
                 uow.Complete();
-            }
+            };
 
+            WithUnitOfWork(() =>
+            {
+                // Owned entities are not available via DbContext -> DbSet,
+                var blog1 = _blogRepository.Single(b => b.Name == "test-blog-1");
+                blog1.Promotions.Count.ShouldBe(1);
+            });
+
+            //Assert
             Predicate<EntityChangeSet> predicate = s =>
             {
                 s.EntityChanges.Count.ShouldBe(1);
 
-                var entityChange = s.EntityChanges[0];
-                entityChange.ChangeType.ShouldBe(EntityChangeType.Updated);
-                entityChange.EntityId.ShouldBe(blog1Id.ToJsonString(false, false));
-                entityChange.EntityTypeFullName.ShouldBe(typeof(BlogEx).FullName);
-                entityChange.PropertyChanges.Count.ShouldBe(1);
+                // The primary key (Id) of BlogPromotion is a shadow property and BlogId being the foreign key to its owner, Blog,
+                // EF Core is keeping the values of PK of Blog and FK (BlogId) of BlogPromotion the same
+                // PK of BlogPromotion is unique across different owners, e.g. Blog1 has BlogPromotion1, BlogPromotion2 and Blog2 has BlogPromotion3
+                // See https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types
 
-                var propertyChange = entityChange.PropertyChanges.Single(pc => pc.PropertyName == nameof(BlogEx.BloggerName));
-                propertyChange.NewValue.ShouldBe(newValue.ToJsonString(false, false));
-                propertyChange.OriginalValue.ShouldBe(originalValue.ToJsonString(false, false));
-                propertyChange.PropertyTypeFullName.ShouldBe(typeof(BlogEx).GetProperty(nameof(BlogEx.BloggerName)).PropertyType.FullName);
+                // We assume that are 2 BlogPromotion (with Id 1, 2) being created sequentially for Blog 2 and Blog 1 respectively
+                const int blog1Promotion2Id = 2;
+
+                var entityChange1 = s.EntityChanges.Single(ec =>
+                    ec.EntityTypeFullName == typeof(BlogPromotion).FullName
+                    && ec.EntityId == blog1Promotion2Id.ToJsonString(false, false)
+                );
+                entityChange1.ChangeType.ShouldBe(EntityChangeType.Updated);
+                entityChange1.PropertyChanges.Count.ShouldBe(1);
+
+               var propertyChange1 = entityChange1.PropertyChanges.Single(pc => pc.PropertyName == nameof(BlogPromotion.Title));
+                propertyChange1.OriginalValue.ShouldBe("test-promotion-2".ToJsonString(false, false));
+                propertyChange1.NewValue.ShouldBe("test-promotion-2-updated".ToJsonString(false, false));
+                propertyChange1.PropertyTypeFullName.ShouldBe(typeof(BlogPromotion).GetProperty(nameof(BlogPromotion.Title)).PropertyType.FullName);
 
                 return true;
             };
@@ -594,6 +727,25 @@ namespace Abp.Zero.EntityHistory
                     RoleId = role.Id
                 });
                 context.SaveChanges();
+            });
+
+            //Assert
+            _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
+        }
+
+        [Fact]
+        public void Should_Not_Write_History_For_Owned_Entities_Of_Non_Audited_Entities_Create()
+        {
+            // Advertisement is the owner of AdvertisementFeedback and does not have Audited attribute.
+            // Comment is not the owner of AdvertisementFeedback.
+            // Therefore, AdvertisementFeedback should follow Advertisement and not have entity history.
+
+            WithUnitOfWork(() =>
+            {
+                var advertisement1 = _advertisementRepository.Single(a => a.Banner == "test-advertisement-1");
+                var comment1 = _commentRepository.Single(b => b.Content == "test-comment-1-content");
+
+                advertisement1.Feedbacks.Add(new AdvertisementFeedback { AdvertisementId = advertisement1.Id, CommentId = comment1.Id });
             });
 
             //Assert


### PR DESCRIPTION
Resolves #5234

When owned type being configured with multiple foreign keys, we need to make sure Entity History read `Audited` attribute from owner entity via the correct foreign key.