### PR TITLE
Use repositories instead of loading all navigation entities.

### DIFF
--- a/src/Abp.ZeroCore/Authorization/Roles/AbpRoleStore.cs
+++ b/src/Abp.ZeroCore/Authorization/Roles/AbpRoleStore.cs
@@ -31,7 +31,9 @@ namespace Abp.Authorization.Roles
         where TUser : AbpUser<TUser>
     {
         public ILogger Logger { get; set; }
-        
+
+        public IAsyncQueryableExecuter AsyncQueryableExecuter { get; set; }
+
         /// <summary>
         /// Gets or sets the <see cref="IdentityErrorDescriber"/> for any error that occurred with the current operation.
         /// </summary>
@@ -51,23 +53,21 @@ namespace Abp.Authorization.Roles
         private readonly IUnitOfWorkManager _unitOfWorkManager;
         private readonly IRepository<RolePermissionSetting, long> _rolePermissionSettingRepository;
         private readonly IRepository<RoleClaim, long> _roleClaimRepository;
-        private readonly IAsyncQueryableExecuter _asyncQueryableExecuter;
 
         public AbpRoleStore(
             IUnitOfWorkManager unitOfWorkManager,
             IRepository<TRole> roleRepository, 
             IRepository<RolePermissionSetting, long> rolePermissionSettingRepository, 
-            IRepository<RoleClaim, long> roleClaimRepository, 
-            IAsyncQueryableExecuter asyncQueryableExecuter)
+            IRepository<RoleClaim, long> roleClaimRepository)
         {
             _unitOfWorkManager = unitOfWorkManager;
             _roleRepository = roleRepository;
             _rolePermissionSettingRepository = rolePermissionSettingRepository;
             _roleClaimRepository = roleClaimRepository;
-            _asyncQueryableExecuter = asyncQueryableExecuter;
 
             ErrorDescriber = new IdentityErrorDescriber();
             Logger = NullLogger.Instance;
+            AsyncQueryableExecuter = NullAsyncQueryableExecuter.Instance;
         }
 
         /// <summary>Saves the current store.</summary>
@@ -315,7 +315,7 @@ namespace Abp.Authorization.Roles
 
             Check.NotNull(role, nameof(role));
 
-            return await _asyncQueryableExecuter.ToListAsync(_roleClaimRepository.GetAll()
+            return await AsyncQueryableExecuter.ToListAsync(_roleClaimRepository.GetAll()
                 .Where(x => x.RoleId == role.Id).Select(c => new Claim(c.ClaimType, c.ClaimValue)));
         }
 

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserManager.cs
@@ -45,6 +45,8 @@ namespace Abp.Authorization.Users
             }
         }
 
+        public IAsyncQueryableExecuter AsyncQueryableExecuter { get; set; }
+
         public ILocalizationManager LocalizationManager { get; set; }
 
         protected string LocalizationSourceName { get; set; }
@@ -68,7 +70,6 @@ namespace Abp.Authorization.Users
         private readonly IOrganizationUnitSettings _organizationUnitSettings;
         private readonly ISettingManager _settingManager;
         private readonly IOptions<IdentityOptions> _optionsAccessor;
-        private readonly IAsyncQueryableExecuter _asyncQueryableExecuter;
 
         public AbpUserManager(
             AbpRoleManager<TRole, TUser> roleManager,
@@ -88,8 +89,7 @@ namespace Abp.Authorization.Users
             IRepository<UserOrganizationUnit, long> userOrganizationUnitRepository,
             IRepository<UserRole, long> userRoleRepository,
             IOrganizationUnitSettings organizationUnitSettings,
-            ISettingManager settingManager, 
-            IAsyncQueryableExecuter asyncQueryableExecuter)
+            ISettingManager settingManager)
             : base(
                 userStore,
                 optionsAccessor,
@@ -109,13 +109,13 @@ namespace Abp.Authorization.Users
             _userRoleRepository = userRoleRepository;
             _organizationUnitSettings = organizationUnitSettings;
             _settingManager = settingManager;
-            _asyncQueryableExecuter = asyncQueryableExecuter;
             _optionsAccessor = optionsAccessor;
 
             AbpUserStore = userStore;
             RoleManager = roleManager;
             LocalizationManager = NullLocalizationManager.Instance;
             LocalizationSourceName = AbpZeroConsts.LocalizationSourceName;
+            AsyncQueryableExecuter = NullAsyncQueryableExecuter.Instance;
         }
 
         public override async Task<IdentityResult> CreateAsync(TUser user)
@@ -651,7 +651,7 @@ namespace Abp.Authorization.Users
         public virtual async Task<IdentityResult> SetRolesAsync(TUser user, string[] roleNames)
         {
             var userRoles =
-                await _asyncQueryableExecuter.ToListAsync(_userRoleRepository.GetAll().Where(x => x.UserId == user.Id));
+                await AsyncQueryableExecuter.ToListAsync(_userRoleRepository.GetAll().Where(x => x.UserId == user.Id));
 
             //Remove from removed roles
             foreach (var userRole in userRoles)

--- a/src/Abp.ZeroCore/Authorization/Users/AbpUserStore.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpUserStore.cs
@@ -50,6 +50,8 @@ namespace Abp.Authorization.Users
         /// </summary>
         public IdentityErrorDescriber ErrorDescriber { get; set; }
 
+        public IAsyncQueryableExecuter AsyncQueryableExecuter { get; set; }
+
         /// <summary>
         /// Gets or sets a flag indicating if changes should be persisted after CreateAsync, UpdateAsync and DeleteAsync are called.
         /// </summary>
@@ -66,7 +68,6 @@ namespace Abp.Authorization.Users
 
         private readonly IRepository<TRole> _roleRepository;
         private readonly IRepository<UserRole, long> _userRoleRepository;
-        private readonly IAsyncQueryableExecuter _asyncQueryableExecuter;
         private readonly IRepository<UserLogin, long> _userLoginRepository;
         private readonly IRepository<UserClaim, long> _userClaimRepository;
         private readonly IRepository<UserToken, long> _userTokenRepository;
@@ -80,7 +81,6 @@ namespace Abp.Authorization.Users
             IUnitOfWorkManager unitOfWorkManager,
             IRepository<TUser, long> userRepository,
             IRepository<TRole> roleRepository,
-            IAsyncQueryableExecuter asyncQueryableExecuter,
             IRepository<UserRole, long> userRoleRepository,
             IRepository<UserLogin, long> userLoginRepository,
             IRepository<UserClaim, long> userClaimRepository,
@@ -92,7 +92,6 @@ namespace Abp.Authorization.Users
             _unitOfWorkManager = unitOfWorkManager;
             UserRepository = userRepository;
             _roleRepository = roleRepository;
-            _asyncQueryableExecuter = asyncQueryableExecuter;
             _userRoleRepository = userRoleRepository;
             _userLoginRepository = userLoginRepository;
             _userClaimRepository = userClaimRepository;
@@ -104,6 +103,7 @@ namespace Abp.Authorization.Users
             AbpSession = NullAbpSession.Instance;
             ErrorDescriber = new IdentityErrorDescriber();
             Logger = NullLogger.Instance;
+            AsyncQueryableExecuter = NullAsyncQueryableExecuter.Instance;
         }
 
         /// <summary>Saves the current store.</summary>
@@ -713,12 +713,12 @@ namespace Abp.Authorization.Users
 
             Check.NotNull(user, nameof(user)); ;
 
-            var userRoles = await _asyncQueryableExecuter.ToListAsync(from userRole in _userRoleRepository.GetAll()
+            var userRoles = await AsyncQueryableExecuter.ToListAsync(from userRole in _userRoleRepository.GetAll()
                                                                       join role in _roleRepository.GetAll() on userRole.RoleId equals role.Id
                                                                       where userRole.UserId == user.Id
                                                                       select role.Name);
 
-            var userOrganizationUnitRoles = await _asyncQueryableExecuter.ToListAsync(
+            var userOrganizationUnitRoles = await AsyncQueryableExecuter.ToListAsync(
                 from userOu in _userOrganizationUnitRepository.GetAll()
                 join roleOu in _organizationUnitRoleRepository.GetAll() on userOu.OrganizationUnitId equals roleOu
                     .OrganizationUnitId
@@ -742,12 +742,12 @@ namespace Abp.Authorization.Users
 
             Check.NotNull(user, nameof(user)); ;
 
-            var userRoles = _asyncQueryableExecuter.ToList(from userRole in _userRoleRepository.GetAll()
+            var userRoles = AsyncQueryableExecuter.ToList(from userRole in _userRoleRepository.GetAll()
                                                                       join role in _roleRepository.GetAll() on userRole.RoleId equals role.Id
                                                                       where userRole.UserId == user.Id
                                                                       select role.Name);
 
-            var userOrganizationUnitRoles = _asyncQueryableExecuter.ToList(
+            var userOrganizationUnitRoles = AsyncQueryableExecuter.ToList(
                 from userOu in _userOrganizationUnitRepository.GetAll()
                 join roleOu in _organizationUnitRoleRepository.GetAll() on userOu.OrganizationUnitId equals roleOu
                     .OrganizationUnitId
@@ -822,7 +822,7 @@ namespace Abp.Authorization.Users
 
             Check.NotNull(user, nameof(user));
 
-            return await _asyncQueryableExecuter.ToListAsync(_userClaimRepository.GetAll()
+            return await AsyncQueryableExecuter.ToListAsync(_userClaimRepository.GetAll()
                 .Where(x => x.UserId == user.Id)
                 .Select(c => new Claim(c.ClaimType, c.ClaimValue)));
         }
@@ -1082,7 +1082,7 @@ namespace Abp.Authorization.Users
 
             Check.NotNull(user, nameof(user));
 
-            return await _asyncQueryableExecuter.ToListAsync(_userLoginRepository.GetAll()
+            return await AsyncQueryableExecuter.ToListAsync(_userLoginRepository.GetAll()
                 .Where(x => x.UserId == user.Id)
                 .Select(l => new UserLoginInfo(l.LoginProvider, l.ProviderKey, l.LoginProvider)));
         }
@@ -1130,7 +1130,7 @@ namespace Abp.Authorization.Users
                               userLogin.TenantId == AbpSession.TenantId
                         select user;
 
-            return _asyncQueryableExecuter.FirstOrDefaultAsync(query);
+            return AsyncQueryableExecuter.FirstOrDefaultAsync(query);
         }
 
         /// <summary>
@@ -1157,7 +1157,7 @@ namespace Abp.Authorization.Users
                               userLogin.TenantId == AbpSession.TenantId
                         select user;
 
-            return _asyncQueryableExecuter.FirstOrDefault(query);
+            return AsyncQueryableExecuter.FirstOrDefault(query);
         }
 
         /// <summary>
@@ -1938,7 +1938,7 @@ namespace Abp.Authorization.Users
                         where userclaims.ClaimValue == claim.Value && userclaims.ClaimType == claim.Type && userclaims.TenantId == AbpSession.TenantId
                         select user;
 
-            return await _asyncQueryableExecuter.ToListAsync(query);
+            return await AsyncQueryableExecuter.ToListAsync(query);
         }
 
         /// <summary>
@@ -1961,7 +1961,7 @@ namespace Abp.Authorization.Users
                         where userclaims.ClaimValue == claim.Value && userclaims.ClaimType == claim.Type && userclaims.TenantId == AbpSession.TenantId
                         select user;
 
-            return _asyncQueryableExecuter.ToList(query);
+            return AsyncQueryableExecuter.ToList(query);
         }
 
         /// <summary>
@@ -1994,7 +1994,7 @@ namespace Abp.Authorization.Users
                         where userrole.RoleId.Equals(role.Id)
                         select user;
 
-            return await _asyncQueryableExecuter.ToListAsync(query);
+            return await AsyncQueryableExecuter.ToListAsync(query);
         }
 
         /// <summary>
@@ -2027,7 +2027,7 @@ namespace Abp.Authorization.Users
                         where userrole.RoleId.Equals(role.Id)
                         select user;
 
-            return _asyncQueryableExecuter.ToList(query);
+            return AsyncQueryableExecuter.ToList(query);
         }
 
         /// <summary>
@@ -2045,7 +2045,7 @@ namespace Abp.Authorization.Users
 
             Check.NotNull(user, nameof(user));
 
-            var token = await _asyncQueryableExecuter.FirstOrDefaultAsync(_userTokenRepository.GetAll()
+            var token = await AsyncQueryableExecuter.FirstOrDefaultAsync(_userTokenRepository.GetAll()
                 .Where(t => t.UserId == user.Id && t.LoginProvider == loginProvider && t.Name == name));
 
 
@@ -2143,7 +2143,7 @@ namespace Abp.Authorization.Users
 
             Check.NotNull(user, nameof(user));
 
-            return (await _asyncQueryableExecuter.FirstOrDefaultAsync(_userTokenRepository.GetAll()
+            return (await AsyncQueryableExecuter.FirstOrDefaultAsync(_userTokenRepository.GetAll()
                 .Where(t => t.UserId == user.Id && t.LoginProvider == loginProvider && t.Name == name)))?.Value;
         }
 
@@ -2161,7 +2161,7 @@ namespace Abp.Authorization.Users
 
             Check.NotNull(user, nameof(user));
 
-            return _asyncQueryableExecuter.FirstOrDefault(_userTokenRepository.GetAll()
+            return AsyncQueryableExecuter.FirstOrDefault(_userTokenRepository.GetAll()
                 .Where(t => t.UserId == user.Id && t.LoginProvider == loginProvider && t.Name == name))?.Value;
         }
 
@@ -2471,7 +2471,7 @@ namespace Abp.Authorization.Users
 
             Check.NotNull(user, nameof(user));
 
-            return await _asyncQueryableExecuter.AnyAsync(_userTokenRepository.GetAll().Where(t =>
+            return await AsyncQueryableExecuter.AnyAsync(_userTokenRepository.GetAll().Where(t =>
                 t.UserId == user.Id &&
                 t.LoginProvider == TokenValidityKeyProvider &&
                 t.Name == tokenValidityKey &&

--- a/test/Abp.ZeroCore.SampleApp/Core/_Service_Overrides.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/_Service_Overrides.cs
@@ -27,41 +27,20 @@ namespace Abp.ZeroCore.SampleApp.Core
 {
     public class UserManager : AbpUserManager<Role, User>
     {
-        public UserManager(
-            RoleManager roleManager,
-            UserStore userStore,
-            IOptions<IdentityOptions> optionsAccessor,
-            IPasswordHasher<User> passwordHasher,
-            IEnumerable<IUserValidator<User>> userValidators,
-            IEnumerable<IPasswordValidator<User>> passwordValidators,
-            ILookupNormalizer keyNormalizer,
-            IdentityErrorDescriber errors,
-            IServiceProvider services,
-            ILogger<UserManager> logger,
-            IPermissionManager permissionManager,
-            IUnitOfWorkManager unitOfWorkManager,
-            ICacheManager cacheManager,
+        public UserManager(AbpRoleManager<Role, User> roleManager, AbpUserStore<Role, User> userStore,
+            IOptions<IdentityOptions> optionsAccessor, IPasswordHasher<User> passwordHasher,
+            IEnumerable<IUserValidator<User>> userValidators, IEnumerable<IPasswordValidator<User>> passwordValidators,
+            ILookupNormalizer keyNormalizer, IdentityErrorDescriber errors, IServiceProvider services,
+            ILogger<UserManager<User>> logger, IPermissionManager permissionManager,
+            IUnitOfWorkManager unitOfWorkManager, ICacheManager cacheManager,
             IRepository<OrganizationUnit, long> organizationUnitRepository,
             IRepository<UserOrganizationUnit, long> userOrganizationUnitRepository,
-            IOrganizationUnitSettings organizationUnitSettings,
-            ISettingManager settingManager) : base(
-            roleManager,
-            userStore,
-            optionsAccessor,
-            passwordHasher,
-            userValidators,
-            passwordValidators,
-            keyNormalizer,
-            errors,
-            services,
-            logger,
-            permissionManager,
-            unitOfWorkManager,
-            cacheManager,
-            organizationUnitRepository,
-            userOrganizationUnitRepository,
-            organizationUnitSettings,
-            settingManager)
+            IRepository<UserRole, long> userRoleRepository, IOrganizationUnitSettings organizationUnitSettings,
+            ISettingManager settingManager, IAsyncQueryableExecuter asyncQueryableExecuter) : base(roleManager,
+            userStore, optionsAccessor, passwordHasher, userValidators, passwordValidators, keyNormalizer, errors,
+            services, logger, permissionManager, unitOfWorkManager, cacheManager, organizationUnitRepository,
+            userOrganizationUnitRepository, userRoleRepository, organizationUnitSettings, settingManager,
+            asyncQueryableExecuter)
         {
         }
     }
@@ -186,14 +165,11 @@ namespace Abp.ZeroCore.SampleApp.Core
 
     public class RoleStore : AbpRoleStore<Role, User>
     {
-        public RoleStore(
-            IUnitOfWorkManager unitOfWorkManager,
-            IRepository<Role> roleRepository,
-            IRepository<RolePermissionSetting, long> rolePermissionSettingRepository
-        ) : base(
-            unitOfWorkManager,
-            roleRepository,
-            rolePermissionSettingRepository)
+        public RoleStore(IUnitOfWorkManager unitOfWorkManager, IRepository<Role> roleRepository,
+            IRepository<RolePermissionSetting, long> rolePermissionSettingRepository,
+            IRepository<RoleClaim, long> roleClaimRepository, IAsyncQueryableExecuter asyncQueryableExecuter) : base(
+            unitOfWorkManager, roleRepository, rolePermissionSettingRepository, roleClaimRepository,
+            asyncQueryableExecuter)
         {
         }
     }
@@ -238,27 +214,15 @@ namespace Abp.ZeroCore.SampleApp.Core
 
     public class UserStore : AbpUserStore<Role, User>
     {
-        public UserStore(
-            IUnitOfWorkManager unitOfWorkManager,
-            IRepository<User, long> userRepository,
-            IRepository<Role> roleRepository,
-            IAsyncQueryableExecuter asyncQueryableExecuter,
-            IRepository<UserRole, long> userRoleRepository,
-            IRepository<UserLogin, long> userLoginRepository,
-            IRepository<UserClaim, long> userClaimRepository,
+        public UserStore(IUnitOfWorkManager unitOfWorkManager, IRepository<User, long> userRepository,
+            IRepository<Role> roleRepository, IAsyncQueryableExecuter asyncQueryableExecuter,
+            IRepository<UserRole, long> userRoleRepository, IRepository<UserLogin, long> userLoginRepository,
+            IRepository<UserClaim, long> userClaimRepository, IRepository<UserToken, long> userTokenRepository,
             IRepository<UserPermissionSetting, long> userPermissionSettingRepository,
             IRepository<UserOrganizationUnit, long> userOrganizationUnitRepository,
-            IRepository<OrganizationUnitRole, long> organizationUnitRoleRepository
-            ) : base(
-            unitOfWorkManager,
-            userRepository,
-            roleRepository,
-            asyncQueryableExecuter,
-            userRoleRepository,
-            userLoginRepository,
-            userClaimRepository,
-            userPermissionSettingRepository,
-            userOrganizationUnitRepository,
+            IRepository<OrganizationUnitRole, long> organizationUnitRoleRepository) : base(unitOfWorkManager,
+            userRepository, roleRepository, asyncQueryableExecuter, userRoleRepository, userLoginRepository,
+            userClaimRepository, userTokenRepository, userPermissionSettingRepository, userOrganizationUnitRepository,
             organizationUnitRoleRepository)
         {
         }

--- a/test/Abp.ZeroCore.SampleApp/Core/_Service_Overrides.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/_Service_Overrides.cs
@@ -27,20 +27,43 @@ namespace Abp.ZeroCore.SampleApp.Core
 {
     public class UserManager : AbpUserManager<Role, User>
     {
-        public UserManager(AbpRoleManager<Role, User> roleManager, AbpUserStore<Role, User> userStore,
-            IOptions<IdentityOptions> optionsAccessor, IPasswordHasher<User> passwordHasher,
-            IEnumerable<IUserValidator<User>> userValidators, IEnumerable<IPasswordValidator<User>> passwordValidators,
-            ILookupNormalizer keyNormalizer, IdentityErrorDescriber errors, IServiceProvider services,
-            ILogger<UserManager<User>> logger, IPermissionManager permissionManager,
-            IUnitOfWorkManager unitOfWorkManager, ICacheManager cacheManager,
+        public UserManager(
+            RoleManager roleManager,
+            UserStore userStore,
+            IOptions<IdentityOptions> optionsAccessor,
+            IPasswordHasher<User> passwordHasher,
+            IEnumerable<IUserValidator<User>> userValidators,
+            IEnumerable<IPasswordValidator<User>> passwordValidators,
+            ILookupNormalizer keyNormalizer,
+            IdentityErrorDescriber errors,
+            IServiceProvider services,
+            ILogger<UserManager> logger,
+            IPermissionManager permissionManager,
+            IUnitOfWorkManager unitOfWorkManager,
+            ICacheManager cacheManager,
             IRepository<OrganizationUnit, long> organizationUnitRepository,
             IRepository<UserOrganizationUnit, long> userOrganizationUnitRepository,
-            IRepository<UserRole, long> userRoleRepository, IOrganizationUnitSettings organizationUnitSettings,
-            ISettingManager settingManager, IAsyncQueryableExecuter asyncQueryableExecuter) : base(roleManager,
-            userStore, optionsAccessor, passwordHasher, userValidators, passwordValidators, keyNormalizer, errors,
-            services, logger, permissionManager, unitOfWorkManager, cacheManager, organizationUnitRepository,
-            userOrganizationUnitRepository, userRoleRepository, organizationUnitSettings, settingManager,
-            asyncQueryableExecuter)
+            IRepository<UserRole, long> userRoleRepository,
+            IOrganizationUnitSettings organizationUnitSettings,
+            ISettingManager settingManager) : base(
+            roleManager,
+            userStore,
+            optionsAccessor,
+            passwordHasher,
+            userValidators,
+            passwordValidators,
+            keyNormalizer,
+            errors,
+            services,
+            logger,
+            permissionManager,
+            unitOfWorkManager,
+            cacheManager,
+            organizationUnitRepository,
+            userOrganizationUnitRepository,
+            userRoleRepository,
+            organizationUnitSettings,
+            settingManager)
         {
         }
     }
@@ -165,11 +188,16 @@ namespace Abp.ZeroCore.SampleApp.Core
 
     public class RoleStore : AbpRoleStore<Role, User>
     {
-        public RoleStore(IUnitOfWorkManager unitOfWorkManager, IRepository<Role> roleRepository,
+        public RoleStore(
+            IUnitOfWorkManager unitOfWorkManager,
+            IRepository<Role> roleRepository,
             IRepository<RolePermissionSetting, long> rolePermissionSettingRepository,
-            IRepository<RoleClaim, long> roleClaimRepository, IAsyncQueryableExecuter asyncQueryableExecuter) : base(
-            unitOfWorkManager, roleRepository, rolePermissionSettingRepository, roleClaimRepository,
-            asyncQueryableExecuter)
+            IRepository<RoleClaim, long> roleClaimRepository
+        ) : base(
+            unitOfWorkManager,
+            roleRepository,
+            rolePermissionSettingRepository,
+            roleClaimRepository)
         {
         }
     }
@@ -214,15 +242,27 @@ namespace Abp.ZeroCore.SampleApp.Core
 
     public class UserStore : AbpUserStore<Role, User>
     {
-        public UserStore(IUnitOfWorkManager unitOfWorkManager, IRepository<User, long> userRepository,
-            IRepository<Role> roleRepository, IAsyncQueryableExecuter asyncQueryableExecuter,
-            IRepository<UserRole, long> userRoleRepository, IRepository<UserLogin, long> userLoginRepository,
-            IRepository<UserClaim, long> userClaimRepository, IRepository<UserToken, long> userTokenRepository,
+        public UserStore(
+            IUnitOfWorkManager unitOfWorkManager,
+            IRepository<User, long> userRepository,
+            IRepository<Role> roleRepository,
+            IRepository<UserRole, long> userRoleRepository,
+            IRepository<UserLogin, long> userLoginRepository,
+            IRepository<UserClaim, long> userClaimRepository,
+            IRepository<UserToken, long> userTokenRepository,
             IRepository<UserPermissionSetting, long> userPermissionSettingRepository,
             IRepository<UserOrganizationUnit, long> userOrganizationUnitRepository,
-            IRepository<OrganizationUnitRole, long> organizationUnitRoleRepository) : base(unitOfWorkManager,
-            userRepository, roleRepository, asyncQueryableExecuter, userRoleRepository, userLoginRepository,
-            userClaimRepository, userTokenRepository, userPermissionSettingRepository, userOrganizationUnitRepository,
+            IRepository<OrganizationUnitRole, long> organizationUnitRoleRepository
+        ) : base(
+            unitOfWorkManager,
+            userRepository,
+            roleRepository,
+            userRoleRepository,
+            userLoginRepository,
+            userClaimRepository,
+            userTokenRepository,
+            userPermissionSettingRepository,
+            userOrganizationUnitRepository,
             organizationUnitRoleRepository)
         {
         }

--- a/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Tokens_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Users/UserManager_Tokens_Tests.cs
@@ -31,6 +31,8 @@ namespace Abp.Zero.Users
                 var user = await _abpUserManager.GetUserByIdAsync(AbpSession.GetUserId());
                 var tokenValidityKey = Guid.NewGuid().ToString();
                 await _abpUserManager.AddTokenValidityKeyAsync(user, tokenValidityKey, DateTime.UtcNow.AddDays(1));
+                await _unitOfWorkManager.Current.SaveChangesAsync();
+
                 var isTokenValidityKeyValid = await _abpUserManager.IsTokenValidityKeyValidAsync(user, tokenValidityKey);
 
                 isTokenValidityKeyValid.ShouldBeTrue();
@@ -45,6 +47,8 @@ namespace Abp.Zero.Users
                 var user = await _abpUserManager.GetUserByIdAsync(AbpSession.GetUserId());
                 var tokenValidityKey = Guid.NewGuid().ToString();
                 await _abpUserManager.AddTokenValidityKeyAsync(user, tokenValidityKey, DateTime.UtcNow);
+                await _unitOfWorkManager.Current.SaveChangesAsync();
+
                 var isTokenValidityKeyValid = await _abpUserManager.IsTokenValidityKeyValidAsync(user, tokenValidityKey);
 
                 isTokenValidityKeyValid.ShouldBeFalse();


### PR DESCRIPTION
Resolve #5244

This may cause some **small breaking changes**.

The constructors of `AbpUserManager`, `AbpUserStore`, `AbpRoleStore `have changed.

If code similar to the `Should_Valid_Non_Expired_TokenValidityKey `method is used, it also needs to be changed.

see https://github.com/aspnetboilerplate/aspnetboilerplate/pull/5245/files#diff-d58dec66e34e80f7bd1a6374192f5302R50