### PR TITLE
Update entity history test

### DIFF
--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -866,12 +866,24 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
         }
 
         [Fact]
+        public void Should_Not_Write_History_For_Audited_Entity_By_Default()
+        {
+            //Arrange
+            UsingDbContext((context) =>
+            {
+                context.Countries.Add(new Country { CountryCode = "My Country" });
+                context.SaveChanges();
+            });
+
+            //Assert
+            _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
+        }
+
+        [Fact]
         public void Should_Not_Write_History_For_Not_Audited_Entities_Shadow_Property()
         {
-            Resolve<IEntityHistoryConfiguration>().IsEnabled = true;
-            Resolve<IEntityHistoryConfiguration>().Selectors.Clear();
+            // PermissionSetting has Discriminator column (shadow property) for RolePermissionSetting
 
-            _entityHistoryStore.ClearReceivedCalls();
             //Arrange
             UsingDbContext((context) =>
             {
@@ -886,26 +898,10 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 context.SaveChanges();
             });
 
-            _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
-        }
-
-        [Fact]
-        public void Should_Not_Write_History_For_Full_Audited_Entity()
-        {
-            Resolve<IEntityHistoryConfiguration>().IsEnabled = true;
-
-            _entityHistoryStore.ClearReceivedCalls();
-
-            //Arrange
-            UsingDbContext((context) =>
-            {
-                context.Countries.Add(new Country() { CountryCode = "My Country" });
-                context.SaveChanges();
-            });
-
             //Assert
             _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
         }
+
         #endregion
 
         private int CreateBlogAndGetId()

--- a/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs
@@ -566,6 +566,7 @@ namespace Abp.Zero.EntityHistory
         [Fact]
         public void Should_Not_Write_History_For_Audited_Entity_By_Default()
         {
+            //Arrange
             UsingDbContext((context) =>
             {
                 context.Countries.Add(new Country { CountryCode = "My Country" });
@@ -579,8 +580,9 @@ namespace Abp.Zero.EntityHistory
         [Fact]
         public void Should_Not_Write_History_For_Not_Audited_Entities_Shadow_Property()
         {
-            // PermissionSetting has Dscriminator Column (Shadow Property) for RolePermissionSetting
+            // PermissionSetting has Discriminator column (shadow property) for RolePermissionSetting
 
+            //Arrange
             UsingDbContext((context) =>
             {
                 var role = context.Roles.FirstOrDefault();
@@ -594,9 +596,9 @@ namespace Abp.Zero.EntityHistory
                 context.SaveChanges();
             });
 
+            //Assert
             _entityHistoryStore.DidNotReceive().Save(Arg.Any<EntityChangeSet>());
         }
-
 
         #endregion
 


### PR DESCRIPTION
Update entity history test cases that was missed out in #5151

`test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs` should have the same tests as 
`test/Abp.ZeroCore.Tests/Zero/EntityHistory/SimpleEntityHistory_Test.cs`


