### PR TITLE
add ipv6 support to web client info provider 

### DIFF
--- a/src/Abp.Web/Auditing/IPEndPointHelper.cs
+++ b/src/Abp.Web/Auditing/IPEndPointHelper.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Globalization;
+using System.Net;
+
+namespace Abp.Auditing
+{
+    internal class IPEndPointHelper
+    {
+        // Backport IPEndPoint Parsing methods back to .net 4.x
+        // Reference https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+        internal static bool TryParse(string s, out IPEndPoint result)
+        {
+            return TryParse(s.AsSpan(), out result);
+        }
+
+        internal static bool TryParse(ReadOnlySpan<char> s, out IPEndPoint result)
+        {
+            int addressLength = s.Length;  // If there's no port then send the entire string to the address parser
+            int lastColonPos = s.LastIndexOf(':');
+
+            // Look to see if this is an IPv6 address with a port.
+            if (lastColonPos > 0)
+            {
+                if (s[lastColonPos - 1] == ']')
+                {
+                    addressLength = lastColonPos;
+                }
+                // Look to see if this is IPv4 with a port (IPv6 will have another colon)
+                else if (s.Slice(0, lastColonPos).LastIndexOf(':') == -1)
+                {
+                    addressLength = lastColonPos;
+                }
+            }
+
+            if (IPAddress.TryParse(s.Slice(0, addressLength).ToString(), out IPAddress address))
+            {
+                uint port = 0;
+                if (addressLength == s.Length ||
+                    (uint.TryParse(s.Slice(addressLength + 1).ToString(), NumberStyles.None, CultureInfo.InvariantCulture, out port) && port <= IPEndPoint.MaxPort))
+
+                {
+                    result = new IPEndPoint(address, (int)port);
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        internal static IPEndPoint Parse(string s)
+        {
+            if (s == null)
+            {
+                throw new ArgumentNullException(nameof(s));
+            }
+
+            return Parse(s.AsSpan());
+        }
+
+        internal static IPEndPoint Parse(ReadOnlySpan<char> s)
+        {
+            if (TryParse(s, out IPEndPoint result))
+            {
+                return result;
+            }
+
+            throw new FormatException("An invalid IPEndPoint was specified.");
+        }
+    }
+}

--- a/src/Abp.Web/Auditing/WebClientInfoProvider.cs
+++ b/src/Abp.Web/Auditing/WebClientInfoProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Web;
@@ -10,7 +11,7 @@ namespace Abp.Auditing
     {
         public string BrowserInfo => GetBrowserInfo();
 
-        public string ClientIpAddress => GetClientIpAddress();
+        public string ClientIpAddress => GetClientIpAddress()?.ToString();
 
         public string ComputerName => GetComputerName();
 
@@ -26,7 +27,7 @@ namespace Abp.Auditing
 
         protected virtual string GetBrowserInfo()
         {
-            var httpContext = HttpContext.Current;
+            var httpContext = GetCurrentHttpContext();
             if (httpContext?.Request.Browser == null)
             {
                 return null;
@@ -37,36 +38,42 @@ namespace Abp.Auditing
                    httpContext.Request.Browser.Platform;
         }
 
-        protected virtual string GetClientIpAddress()
+        protected virtual IPAddress GetClientIpAddress()
         {
-            var httpContext = HttpContext.Current;
+            var httpContext = GetCurrentHttpContext();
             if (httpContext?.Request.ServerVariables == null)
             {
                 return null;
             }
 
-            var clientIp = httpContext.Request.ServerVariables["HTTP_X_FORWARDED_FOR"] ??
-                           httpContext.Request.ServerVariables["REMOTE_ADDR"];
-
-            // Remove port if present
-            clientIp = clientIp.Contains(":") ? clientIp.Remove(clientIp.IndexOf(':')) : clientIp;
+            IPAddress clientIpAddress = null;
 
             try
             {
-                foreach (var hostAddress in Dns.GetHostAddresses(clientIp))
+                // Header Format => X-Forwarded-For: <client>, <proxy1>, <proxy2>
+                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+                // X_FORWARDED_FOR header is being prefixed with HTTP
+                // https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms524602(v=vs.90)#obtaining-server-variables
+                var forwardIpAddress = httpContext.Request.ServerVariables["HTTP_X_FORWARDED_FOR"]?.Split(',').FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(forwardIpAddress))
                 {
-                    if (hostAddress.AddressFamily == AddressFamily.InterNetwork)
-                    {
-                        return hostAddress.ToString();
-                    }
+                    clientIpAddress = IPEndPointHelper.Parse(forwardIpAddress).Address;
                 }
 
-                foreach (var hostAddress in Dns.GetHostAddresses(Dns.GetHostName()))
+                // Remote Ip Address is separated into REMOTE_ADDR & REMOTE_PORT
+                var remoteIpAddress = httpContext.Request.ServerVariables["REMOTE_ADDR"];
+                if (clientIpAddress == null && !string.IsNullOrWhiteSpace(remoteIpAddress))
                 {
-                    if (hostAddress.AddressFamily == AddressFamily.InterNetwork)
-                    {
-                        return hostAddress.ToString();
-                    }
+                    clientIpAddress = IPAddress.Parse(remoteIpAddress);
+                }
+
+                if (clientIpAddress == null && httpContext.Request.IsLocal)
+                {
+                    clientIpAddress = Dns.GetHostAddresses(Dns.GetHostName()).FirstOrDefault(address =>
+                        {
+                            return address.AddressFamily.HasFlag(AddressFamily.InterNetwork | AddressFamily.InterNetworkV6);
+                        }
+                    );
                 }
             }
             catch (Exception ex)
@@ -74,12 +81,12 @@ namespace Abp.Auditing
                 Logger.Debug(ex.ToString());
             }
 
-            return clientIp;
+            return clientIpAddress;
         }
 
         protected virtual string GetComputerName()
         {
-            var httpContext = HttpContext.Current;
+            var httpContext = GetCurrentHttpContext();
             if (httpContext == null || !httpContext.Request.IsLocal)
             {
                 return null;
@@ -87,12 +94,17 @@ namespace Abp.Auditing
 
             try
             {
-                return Dns.GetHostEntry(IPAddress.Parse(GetClientIpAddress())).HostName;
+                return Dns.GetHostEntry(GetClientIpAddress()).HostName;
             }
             catch
             {
                 return null;
             }
+        }
+
+        public virtual HttpContextBase GetCurrentHttpContext()
+        {
+            return new HttpContextWrapper(HttpContext.Current);
         }
     }
 }

--- a/test/Abp.Web.Tests/Auditing/Client_Info_Provider_Tests.cs
+++ b/test/Abp.Web.Tests/Auditing/Client_Info_Provider_Tests.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Specialized;
+using System.Web;
+using Abp.Auditing;
+using Abp.TestBase;
+using NSubstitute;
+using NSubstitute.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Web.Tests.Auditing
+{
+    public class Client_Info_Provider_Tests : AbpIntegratedTestBase<AbpWebModule>
+    {
+        private readonly WebClientInfoProvider _clientInfoProvider;
+
+        public Client_Info_Provider_Tests()
+        {
+            _clientInfoProvider = Substitute.ForPartsOf<WebClientInfoProvider>();
+        }
+        
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData("::1", "::1")]
+        [InlineData("127.0.0.1", "127.0.0.1")]
+        [InlineData("0:0:0:0:0:0:0:1", "::1")]
+        public void Should_Save_Remote_Address_From_Server_Variable(string remote_address, string clientIpAddress)
+        {
+            var serverVariables = new NameValueCollection
+            {
+                { "REMOTE_ADDR", remote_address }
+            };
+
+            MockHttpContext(serverVariables);
+
+            _clientInfoProvider.ClientIpAddress.ShouldBe(clientIpAddress);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData("::1", "::1")]
+        [InlineData("127.0.0.1", "127.0.0.1")]
+        [InlineData("127.0.0.1, 192.168.1.1", "127.0.0.1")]
+        [InlineData("127.0.0.1:8888", "127.0.0.1")]
+        [InlineData("0:0:0:0:0:0:0:1", "::1")]
+        [InlineData("0:0:0:0:0:0:0:1, 0:0:0:0:0:ffff:c0a8:101", "::1")]
+        [InlineData("[0:0:0:0:0:0:0:1]:8888", "::1")]
+        public void Should_Save_Http_X_Forwarded_For_From_Server_Variable(string forwarded_for, string clientIpAddress)
+        {
+            var serverVariables = new NameValueCollection
+            {
+                { "HTTP_X_FORWARDED_FOR", forwarded_for }
+            };
+
+            MockHttpContext(serverVariables);
+
+            _clientInfoProvider.ClientIpAddress.ShouldBe(clientIpAddress);
+        }
+
+        private void MockHttpContext(NameValueCollection serverVariables = null)
+        {
+            var mockHttpRequest = Substitute.For<HttpRequestBase>();
+            if (serverVariables != null)
+            {
+                mockHttpRequest.ServerVariables.Returns(serverVariables);
+            }
+            var mockHttpContext = Substitute.For<HttpContextBase>();
+            mockHttpContext.Request.Returns(mockHttpRequest);
+
+            _clientInfoProvider.Configure().GetCurrentHttpContext().Returns(mockHttpContext);
+        }
+    }
+}

--- a/test/Abp.Web.Tests/EntityHistory/EntityHistory_Reason_Tests.cs
+++ b/test/Abp.Web.Tests/EntityHistory/EntityHistory_Reason_Tests.cs
@@ -6,7 +6,7 @@ using Abp.Web.EntityHistory;
 using Shouldly;
 using Xunit;
 
-namespace Abp.Web.Tests
+namespace Abp.Web.Tests.EntityHistory
 {
     public class EntityHistory_Reason_Tests : AbpIntegratedTestBase<AbpWebModule>
     {


### PR DESCRIPTION
Resolve #5282 

- Backport `IPEndPoint.Parse` from dotnet repository https://github.com/dotnet/corefx/pull/33119 into `IPEndPointHelper`
  - `IPEndpoint` supports IP Address with port number where `IPAddress` only supports ip address.
  - `IPEndpoint.Parse` only released on net core 3.0 not .net 4.8
- Use `HttpContextWrapper` to wrap around `HttpContext.Current`