### PR TITLE
Handle HttpContext being null

### DIFF
--- a/src/Abp.Web/Auditing/WebClientInfoProvider.cs
+++ b/src/Abp.Web/Auditing/WebClientInfoProvider.cs
@@ -104,7 +104,7 @@ namespace Abp.Auditing
 
         public virtual HttpContextBase GetCurrentHttpContext()
         {
-            return new HttpContextWrapper(HttpContext.Current);
+            return HttpContext.Current == null ? null : new HttpContextWrapper(HttpContext.Current);
         }
     }
 }


### PR DESCRIPTION
Regression from #5289 

We should handle HttpContext being null since HttpContextWrapper does not handle it