### PR TITLE
Add ASP.NET Core Generic Host support

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/AbpServiceCollectionExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/AbpServiceCollectionExtensions.cs
@@ -51,7 +51,7 @@ namespace Abp.AspNetCore
         /// <typeparam name="TStartupModule">Startup module of the application which depends on other used modules. Should be derived from <see cref="AbpModule"/>.</typeparam>
         /// <param name="services">Services.</param>
         /// <param name="optionsAction">An action to get/modify options</param>
-        public static void AddAbpWithoutCreateServiceProvider<TStartupModule>(this IServiceCollection services, [CanBeNull] Action<AbpBootstrapperOptions> optionsAction = null)
+        public static void AddAbpWithoutCreatingServiceProvider<TStartupModule>(this IServiceCollection services, [CanBeNull] Action<AbpBootstrapperOptions> optionsAction = null)
             where TStartupModule : AbpModule
         {
             var abpBootstrapper = AddAbpBootstrapper<TStartupModule>(services, optionsAction);

--- a/src/Abp.AspNetCore/AspNetCore/AbpServiceCollectionExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/AbpServiceCollectionExtensions.cs
@@ -45,6 +45,20 @@ namespace Abp.AspNetCore
             return WindsorRegistrationHelper.CreateServiceProvider(abpBootstrapper.IocManager.IocContainer, services);
         }
 
+        /// <summary>
+        /// Integrates ABP to AspNet Core without creating a IServiceProvider.
+        /// </summary>
+        /// <typeparam name="TStartupModule">Startup module of the application which depends on other used modules. Should be derived from <see cref="AbpModule"/>.</typeparam>
+        /// <param name="services">Services.</param>
+        /// <param name="optionsAction">An action to get/modify options</param>
+        public static void AddAbpWithoutCreateServiceProvider<TStartupModule>(this IServiceCollection services, [CanBeNull] Action<AbpBootstrapperOptions> optionsAction = null)
+            where TStartupModule : AbpModule
+        {
+            var abpBootstrapper = AddAbpBootstrapper<TStartupModule>(services, optionsAction);
+
+            ConfigureAspNetCore(services, abpBootstrapper.IocManager);
+        }
+
         private static void ConfigureAspNetCore(IServiceCollection services, IIocResolver iocResolver)
         {
             //See https://github.com/aspnet/Mvc/issues/3936 to know why we added these services.

--- a/src/Abp.AspNetCore/AspNetCore/Dependency/AbpCastleWindsorHostBuilderExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Dependency/AbpCastleWindsorHostBuilderExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Castle.Windsor;
+using Castle.Windsor.MsDependencyInjection;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Abp.AspNetCore.Dependency
+{
+    public static class AbpCastleWindsorHostBuilderExtensions
+    {
+        /// <summary>
+        /// Uses WindsorServiceProviderFactory as service provider factory with given windsorContainer
+        /// </summary>
+        /// <param name="hostBuilder"></param>
+        /// <param name="windsorContainer"></param>
+        /// <returns></returns>
+        public static IHostBuilder UseCastleWindsor(this IHostBuilder hostBuilder, [NotNull]IWindsorContainer windsorContainer)
+        {
+            Check.NotNull(windsorContainer, nameof(windsorContainer));
+
+            return hostBuilder
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(windsorContainer);
+                })
+                .UseServiceProviderFactory(new WindsorServiceProviderFactory());
+        }
+    }
+}


### PR DESCRIPTION
Resolves #4976 

Created `UseCastleWindsor ` and `AddAbpWithoutRegisteringServices ` extension methods.

**New Program.cs:**

```csharp
public class Program
{
	public static void Main(string[] args)
	{
		CreateHostBuilder(args).Build().Run();
	}

	internal static IHostBuilder CreateHostBuilder(string[] args) =>
		Host.CreateDefaultBuilder(args)
			.ConfigureWebHostDefaults(webBuilder =>
			{
				webBuilder.UseStartup<Startup>();
			})
			.UseCastleWindsor(IocManager.Instance.IocContainer);
}
```

**New Startup.cs:**

```csharp
public class Startup
{
	// Other code blocks...
	
	public void ConfigureServices(IServiceCollection services)
	{
		// Other code blocks...

		// Configure Abp and Dependency Injection
		services.AddAbpWithoutRegisteringServices<YourWebModule>(
			// Configure Log4Net logging
			options => options.IocManager.IocContainer.AddFacility<LoggingFacility>(
				f => f.UseAbpLog4Net().WithConfig("log4net.config")
			)
		);
	}

	public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
	{
		// Other code blocks...
	}
}
```