### PR TITLE
Ensure OrganizationUnit.Code is unique.

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/Zero/EntityFrameworkCore/AbpZeroCommonDbContext.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/Zero/EntityFrameworkCore/AbpZeroCommonDbContext.cs
@@ -274,7 +274,7 @@ namespace Abp.Zero.EntityFrameworkCore
 
             modelBuilder.Entity<OrganizationUnit>(b =>
             {
-                b.HasIndex(e => new { e.TenantId, e.Code });
+                b.HasIndex(e => new { e.TenantId, e.Code }).IsUnique();
             });
 
             modelBuilder.Entity<PermissionSetting>(b =>


### PR DESCRIPTION
There are some sense to make duplicated OrganizationUnit.Code:
1. Multiple creating organization unit requests at the same time.
2. Call `OrganizationUnitManager.Create` method multiple times to create multiple organization unit without `DbContext.SaveChange` each time.

The duplicated codes will cause some critical result if my entities belongs to an organization unit (filter by code or permission control by code). So I think it should be prevented completely.