### PR TITLE
Documentation correction

### DIFF
--- a/doc/WebSite/Webhook-System.md
+++ b/doc/WebSite/Webhook-System.md
@@ -173,7 +173,7 @@ public async Task WebHookTest()
 
 private bool IsSignatureCompatible(string secret, string body)
 {
-    if (HttpContext.Request.Headers.ContainsKey("abp-webhook-signature"))
+    if (!HttpContext.Request.Headers.ContainsKey("abp-webhook-signature"))
     {
         return false;
     }


### PR DESCRIPTION
In the IsSignatureCompatible method, first if statement is wrong.