### PR TITLE
Move cache type casting from cache extensions into TypedCacheWrapper

### DIFF
--- a/src/Abp/Runtime/Caching/CacheExtensions.cs
+++ b/src/Abp/Runtime/Caching/CacheExtensions.cs
@@ -9,52 +9,61 @@ namespace Abp.Runtime.Caching
     /// </summary>
     public static class CacheExtensions
     {
+        public static ITypedCache<TKey, TValue> AsTyped<TKey, TValue>(this ICache cache)
+        {
+            return new TypedCacheWrapper<TKey, TValue>(cache);
+        }
+
+        [Obsolete]
         public static object Get(this ICache cache, string key, Func<object> factory)
         {
             return cache.Get(key, k => factory());
         }
 
+        [Obsolete]
         public static object[] Get(this ICache cache, string[] keys, Func<object> factory)
         {
             return keys.Select(key => cache.Get(key, k => factory())).ToArray();
         }
 
+        [Obsolete]
         public static Task<object> GetAsync(this ICache cache, string key, Func<Task<object>> factory)
         {
             return cache.GetAsync(key, k => factory());
         }
 
+        [Obsolete]
         public static Task<object[]> GetAsync(this ICache cache, string[] keys, Func<Task<object>> factory)
         {
             var tasks = keys.Select(key => cache.GetAsync(key, k => factory()));
             return Task.WhenAll(tasks);
         }
 
-        public static ITypedCache<TKey, TValue> AsTyped<TKey, TValue>(this ICache cache)
-        {
-            return new TypedCacheWrapper<TKey, TValue>(cache);
-        }
-
+        [Obsolete]
         public static TValue Get<TKey, TValue>(this ICache cache, TKey key, Func<TKey, TValue> factory)
         {
             return (TValue)cache.Get(key.ToString(), (k) => (object)factory(key));
         }
 
+        [Obsolete]
         public static TValue[] Get<TKey, TValue>(this ICache cache, TKey[] keys, Func<TKey, TValue> factory)
         {
             return keys.Select(key => (TValue)cache.Get(key.ToString(), (k) => (object)factory(key))).ToArray();
         }
 
+        [Obsolete]
         public static TValue Get<TKey, TValue>(this ICache cache, TKey key, Func<TValue> factory)
         {
             return cache.Get(key, (k) => factory());
         }
 
+        [Obsolete]
         public static TValue[] Get<TKey, TValue>(this ICache cache, TKey[] keys, Func<TValue> factory)
         {
             return keys.Select(key => cache.Get(key, (k) => factory())).ToArray();
         }
 
+        [Obsolete]
         public static async Task<TValue> GetAsync<TKey, TValue>(this ICache cache, TKey key, Func<TKey, Task<TValue>> factory)
         {
             var value = await cache.GetAsync(key.ToString(), async (keyAsString) =>
@@ -66,6 +75,7 @@ namespace Abp.Runtime.Caching
             return (TValue)value;
         }
 
+        [Obsolete]
         public static async Task<TValue[]> GetAsync<TKey, TValue>(this ICache cache, TKey[] keys, Func<TKey, Task<TValue>> factory)
         {
             var tasks = keys.Select(key =>
@@ -80,17 +90,20 @@ namespace Abp.Runtime.Caching
             return values.Select(value => (TValue)value).ToArray();
         }
 
+        [Obsolete]
         public static Task<TValue> GetAsync<TKey, TValue>(this ICache cache, TKey key, Func<Task<TValue>> factory)
         {
             return cache.GetAsync(key, (k) => factory());
         }
 
+        [Obsolete]
         public static Task<TValue[]> GetAsync<TKey, TValue>(this ICache cache, TKey[] keys, Func<Task<TValue>> factory)
         {
             var tasks = keys.Select(key => cache.GetAsync(key, (k) => factory()));
             return Task.WhenAll(tasks);
         }
 
+        [Obsolete]
         public static TValue GetOrDefault<TKey, TValue>(this ICache cache, TKey key)
         {
             var value = cache.GetOrDefault(key.ToString());
@@ -102,6 +115,7 @@ namespace Abp.Runtime.Caching
             return (TValue)value;
         }
 
+        [Obsolete]
         public static TValue[] GetOrDefault<TKey, TValue>(this ICache cache, TKey[] keys)
         {
             var values = keys.Select(key =>
@@ -117,6 +131,7 @@ namespace Abp.Runtime.Caching
             return values.ToArray();
         }
 
+        [Obsolete]
         public static async Task<TValue> GetOrDefaultAsync<TKey, TValue>(this ICache cache, TKey key)
         {
             var value = await cache.GetOrDefaultAsync(key.ToString());
@@ -128,6 +143,7 @@ namespace Abp.Runtime.Caching
             return (TValue)value;
         }
 
+        [Obsolete]
         public static async Task<TValue[]> GetOrDefaultAsync<TKey, TValue>(this ICache cache, TKey[] keys)
         {
             var tasks = keys.Select(async (key) =>

--- a/src/Abp/Runtime/Caching/CacheManagerBase.cs
+++ b/src/Abp/Runtime/Caching/CacheManagerBase.cs
@@ -11,7 +11,7 @@ namespace Abp.Runtime.Caching
     [Obsolete("Use CacheManagerBase<TCache> instead.")]
     public abstract class CacheManagerBase : CacheManagerBase<ICache>, ICacheManager
     {
-        public CacheManagerBase(ICachingConfiguration configuration) : base(configuration)
+        protected CacheManagerBase(ICachingConfiguration configuration) : base(configuration)
         {
         }
     }

--- a/test/Abp.Tests/Runtime/Caching/Memory/MemoryCacheManager_Tests.cs
+++ b/test/Abp.Tests/Runtime/Caching/Memory/MemoryCacheManager_Tests.cs
@@ -150,7 +150,8 @@ namespace Abp.Tests.Runtime.Caching.Memory
             {
                 return CacheManager
                     .GetCache("MyClientPropertyInjectsCache")
-                    .Get("A", () =>
+                    .AsTyped<string, int>()
+                    .Get("A", (k) =>
                     {
                         return value;
                     });


### PR DESCRIPTION
Making sure that cache type casting only happens within `TypedCacheWrapper`