### PR TITLE
Obsolete client cache attribute

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
@@ -12,6 +12,7 @@ namespace Abp.AspNetCore.Configuration
     {
         public WrapResultAttribute DefaultWrapResultAttribute { get; }
 
+        [Obsolete]
         public IClientCacheAttribute DefaultClientCacheAttribute { get; set; }
 
         public UnitOfWorkAttribute DefaultUnitOfWorkAttribute { get; }

--- a/src/Abp.AspNetCore/AspNetCore/Configuration/IAbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/IAbpAspNetCoreConfiguration.cs
@@ -12,6 +12,7 @@ namespace Abp.AspNetCore.Configuration
     {
         WrapResultAttribute DefaultWrapResultAttribute { get; }
 
+        [Obsolete]
         IClientCacheAttribute DefaultClientCacheAttribute { get; set; }
 
         UnitOfWorkAttribute DefaultUnitOfWorkAttribute { get; }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Caching/AllowClientCacheAttribute.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Caching/AllowClientCacheAttribute.cs
@@ -1,8 +1,10 @@
 using Abp.Extensions;
 using Microsoft.AspNetCore.Mvc.Filters;
+using System;
 
 namespace Abp.AspNetCore.Mvc.Results.Caching
 {
+    [Obsolete]
     public class AllowClientCacheAttribute : IClientCacheAttribute
     {
         public ClientCacheScope? Scope { get; }

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Caching/ClientCacheScope.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Caching/ClientCacheScope.cs
@@ -1,5 +1,8 @@
-﻿namespace Abp.AspNetCore.Mvc.Results.Caching
+﻿using System;
+
+namespace Abp.AspNetCore.Mvc.Results.Caching
 {
+    [Obsolete]
     public enum ClientCacheScope
     {
         Public,

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Caching/IClientCacheAttribute.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Caching/IClientCacheAttribute.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Mvc.Filters;
+using System;
 
 namespace Abp.AspNetCore.Mvc.Results.Caching
 {
+    [Obsolete]
     public interface IClientCacheAttribute
     {
         void Apply(ResultExecutingContext context);

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Caching/NoClientCacheAttribute.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/Caching/NoClientCacheAttribute.cs
@@ -1,8 +1,10 @@
 ﻿using Abp.AspNetCore.Mvc.Extensions;
 using Microsoft.AspNetCore.Mvc.Filters;
+using System;
 
 namespace Abp.AspNetCore.Mvc.Results.Caching
 {
+    [Obsolete]
     public class NoClientCacheAttribute : IClientCacheAttribute
     {
         /// <summary>


### PR DESCRIPTION
Since a396051e74b7da646be8133ca0b40b0c2b0b0f90, we no longer support `ClientCacheAttribute`,  CacheControl can now be achieved with #5418 