### PR TITLE
Update Nuke Build to version 0.24.8, fix AzurePipelines suffix breaking change

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@
 #
 #     - To trigger manual generation invoke:
 #
-#         nuke --configure-build-server --host AzurePipelines
+#         nuke --generate-configuration AzurePipelines --host AzurePipelines
 #
 # </auto-generated>
 # ------------------------------------------------------------------------------

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -21,7 +21,6 @@ using static Nuke.Common.Tools.NuGet.NuGetTasks;
 [UnsetVisualStudioEnvironmentVariables]
 [MSBuildVerbosityMapping]
 [AzurePipelines(
-    "",
     AzurePipelinesImage.WindowsLatest,
     InvokedTargets = new[] {nameof(Test)},
     ExcludedTargets = new[] {nameof(Clean)},

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nuke.Common" Version="0.24.7" />
+    <PackageReference Include="Nuke.Common" Version="0.24.8" />
 
     <PackageReference Include="Microsoft.Build" Version="16.5.0" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.5.0" />


### PR DESCRIPTION
Reverts aspnetboilerplate/aspnetboilerplate#5420

See https://github.com/nuke-build/nuke/pull/424#discussion_r401945417

We should consider reverting the previous fix when upgrading to 0.24.8 
https://github.com/nuke-build/nuke/pull/456


