### PR TITLE
Lack of string interpolation

### DIFF
--- a/src/Abp/Domain/Entities/Caching/MayHaveTenantEntityCache.cs
+++ b/src/Abp/Domain/Entities/Caching/MayHaveTenantEntityCache.cs
@@ -46,7 +46,7 @@ namespace Abp.Domain.Entities.Caching
 
         public override string ToString()
         {
-            return "MayHaveTenantEntityCache {CacheName}";
+            return $"MayHaveTenantEntityCache {CacheName}";
         }
     }
 }


### PR DESCRIPTION
There is no string interpolation symbol "$" in MayHaveTenantEntityCache. I add this.