### PR TITLE
Added multi-lingual object mapping language fallback from region-lang…

### DIFF
--- a/src/Abp.AutoMapper/AutoMapper/AutoMapExtensions.cs
+++ b/src/Abp.AutoMapper/AutoMapper/AutoMapExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Abp.Configuration;
 using Abp.Dependency;
@@ -6,6 +7,8 @@ using Abp.Domain.Entities;
 using Abp.Localization;
 using AutoMapper;
 using System.Linq;
+using Abp.Collections.Extensions;
+using Abp.Extensions;
 
 namespace Abp.AutoMapper
 {
@@ -39,7 +42,7 @@ namespace Abp.AutoMapper
         }
 
         public static CreateMultiLingualMapResult<TMultiLingualEntity, TTranslation, TDestination> CreateMultiLingualMap<TMultiLingualEntity, TMultiLingualEntityPrimaryKey, TTranslation, TDestination>(
-            this IMapperConfigurationExpression configuration, MultiLingualMapContext multiLingualMapContext)
+            this IMapperConfigurationExpression configuration, MultiLingualMapContext multiLingualMapContext, bool fallbackToParentCultures = false)
             where TTranslation : class, IEntityTranslation<TMultiLingualEntity, TMultiLingualEntityPrimaryKey>
             where TMultiLingualEntity : IMultiLingualEntity<TTranslation>
         {
@@ -48,13 +51,11 @@ namespace Abp.AutoMapper
             result.TranslationMap = configuration.CreateMap<TTranslation, TDestination>();
             result.EntityMap = configuration.CreateMap<TMultiLingualEntity, TDestination>().BeforeMap((source, destination, context) =>
             {
-                // when no translation is available, all translation properties will just stay null
-                if (source.Translations == null)
+                if (source.Translations.IsNullOrEmpty())
                 {
                     return;
                 }
 
-                // check for region specific language, e.g. 'en-US'
                 var translation = source.Translations.FirstOrDefault(pt => pt.Language == CultureInfo.CurrentUICulture.Name);
                 if (translation != null)
                 {
@@ -62,12 +63,14 @@ namespace Abp.AutoMapper
                     return;
                 }
 
-                // check for language, e.g. 'en'
-                translation = source.Translations.FirstOrDefault(pt => pt.Language == CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
-                if (translation != null)
+                if (fallbackToParentCultures)
                 {
-                    context.Mapper.Map(translation, destination);
-                    return;
+                    translation = GeTranslationBasedOnCulturalRecursive<TMultiLingualEntity, TMultiLingualEntityPrimaryKey, TTranslation>(CultureInfo.CurrentUICulture.Parent, source.Translations, 0);
+                    if (translation != null)
+                    {
+                        context.Mapper.Map(translation, destination);
+                        return;
+                    }
                 }
 
                 var defaultLanguage = multiLingualMapContext.SettingManager.GetSettingValue(LocalizationSettingNames.DefaultLanguage);
@@ -89,11 +92,27 @@ namespace Abp.AutoMapper
             return result;
         }
 
-        public static CreateMultiLingualMapResult<TMultiLingualEntity, TTranslation, TDestination> CreateMultiLingualMap<TMultiLingualEntity, TTranslation, TDestination>(this IMapperConfigurationExpression configuration, MultiLingualMapContext multiLingualMapContext)
+        private const int MaxCultureFallbackDepth = 5;
+
+        private static TTranslation GeTranslationBasedOnCulturalRecursive<TMultiLingualEntity, TMultiLingualEntityPrimaryKey, TTranslation>(CultureInfo culture, ICollection<TTranslation> translations, int currentDepth)
+            where TTranslation : class, IEntityTranslation<TMultiLingualEntity, TMultiLingualEntityPrimaryKey>
+        {
+            if (culture == null || culture.Name.IsNullOrWhiteSpace() || translations.IsNullOrEmpty() || currentDepth > MaxCultureFallbackDepth)
+            {
+                return null;
+            }
+
+            var translation = translations.FirstOrDefault(pt => pt.Language.Equals(culture.Name, StringComparison.OrdinalIgnoreCase));
+            return translation ?? GeTranslationBasedOnCulturalRecursive<TMultiLingualEntity, TMultiLingualEntityPrimaryKey, TTranslation>(culture.Parent, translations, currentDepth + 1);
+        }
+
+        public static CreateMultiLingualMapResult<TMultiLingualEntity, TTranslation, TDestination> CreateMultiLingualMap<TMultiLingualEntity, TTranslation, TDestination>(this IMapperConfigurationExpression configuration,
+            MultiLingualMapContext multiLingualMapContext,
+            bool fallbackToParentCultures = false)
             where TTranslation : class, IEntity, IEntityTranslation<TMultiLingualEntity, int>
             where TMultiLingualEntity : IMultiLingualEntity<TTranslation>
         {
-            return configuration.CreateMultiLingualMap<TMultiLingualEntity, int, TTranslation, TDestination>(multiLingualMapContext);
+            return configuration.CreateMultiLingualMap<TMultiLingualEntity, int, TTranslation, TDestination>(multiLingualMapContext, fallbackToParentCultures);
         }
     }
 }

--- a/test/Abp.ZeroCore.SampleApp/AbpZeroCoreSampleAppModule.cs
+++ b/test/Abp.ZeroCore.SampleApp/AbpZeroCoreSampleAppModule.cs
@@ -59,14 +59,14 @@ namespace Abp.ZeroCore.SampleApp
     {
         public static void CreateMappings(IMapperConfigurationExpression configuration, MultiLingualMapContext context)
         {
-            configuration.CreateMultiLingualMap<Product, ProductTranslation, ProductListDto>(context);
+            configuration.CreateMultiLingualMap<Product, ProductTranslation, ProductListDto>(context, true);
 
             configuration.CreateMap<ProductCreateDto, Product>();
             configuration.CreateMap<ProductUpdateDto, Product>();
 
             configuration.CreateMap<ProductTranslationDto, ProductTranslation>();
 
-            configuration.CreateMultiLingualMap<Order, OrderTranslation, OrderListDto>(context)
+            configuration.CreateMultiLingualMap<Order, OrderTranslation, OrderListDto>(context, true)
                 .EntityMap.ForMember(dest => dest.ProductCount, opt => opt.MapFrom(src => src.Products.Count));
         }
     }

--- a/test/Abp.ZeroCore.Tests/Zero/MultiLingual/MultiLingual_Mapping_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/MultiLingual/MultiLingual_Mapping_Tests.cs
@@ -63,6 +63,64 @@ namespace Abp.Zero.MultiLingual
         }
 
         [Fact]
+        public async Task CreateMultiLingualMap_RegionSpecificLanguage_ShouldFallbackToGlobalLanguage()
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-GB");
+
+            var products = await _productAppService.GetProducts();
+            products.ShouldNotBeNull();
+
+            products.Items.Count.ShouldBe(3);
+            var product1 = products.Items[0];
+            var product2 = products.Items[1];
+            var product3 = products.Items[2];
+
+            product1.Language.ShouldBe("en");
+            product1.Name.ShouldBe("Watch");
+
+            product2.Language.ShouldBe("en");
+            product2.Name.ShouldBe("Bike");
+
+            product3.Language.ShouldBe("it");
+            product3.Name.ShouldBe("Giornale");
+        }
+
+        [Fact]
+        public async Task CreateMultiLingualMap_NoTranslations_ShouldStillMapObject()
+        {
+            /*
+             *  When no translation is available, it should still map the
+             */
+
+            UsingDbContext(context =>
+            {
+                context.ProductTranslations.RemoveRange(context.ProductTranslations.ToList());
+            });
+
+            CultureInfo.CurrentUICulture = new CultureInfo("en-GB");
+
+            var products = await _productAppService.GetProducts();
+            products.ShouldNotBeNull();
+
+            products.Items.Count.ShouldBe(3);
+            var product1 = products.Items[0];
+            var product2 = products.Items[1];
+            var product3 = products.Items[2];
+
+            product1.Language.ShouldBe(null);
+            product1.Name.ShouldBe(null);
+            product1.Price.ShouldBe(10);
+
+            product2.Language.ShouldBe(null);
+            product2.Name.ShouldBe(null);
+            product2.Price.ShouldBe(99);
+
+            product3.Language.ShouldBe(null);
+            product3.Name.ShouldBe(null);
+            product3.Price.ShouldBe(15);
+        }
+
+        [Fact]
         public async Task CreateMultiLingualMap_Tests_Dont_Override_MultiLingual_Entity_Id()
         {
             CultureInfo.CurrentUICulture = new CultureInfo("tr");


### PR DESCRIPTION
Related: #5512 

Multi-lingual object mapping

- Added fallback from region-langauge (e.g. 'en-US') to global language (eg. 'en').
- Added nullcheck to allow mapping when no translation is available

**Impact**

Users who use the automapper extension CreateMultiLingualMap() can now also use it if they have short language codes instead of region specifc codes for their application languages. 