### PR TITLE
Support encoded return url in Abp Localization controller

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/AbpUrlHelper.cs
+++ b/src/Abp.AspNetCore/AspNetCore/AbpUrlHelper.cs
@@ -1,9 +1,11 @@
 using Abp.Extensions;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
+using System;
 
 namespace Abp.AspNetCore
 {
+    [Obsolete("Use Abp.Web.Http.UrlHelper instead")]
     public static class AbpUrlHelper
     {
         public static bool IsLocalUrl([NotNull] HttpRequest request, [NotNull] string url)

--- a/src/Abp.Web.Mvc/Web/Mvc/Controllers/Localization/AbpLocalizationController.cs
+++ b/src/Abp.Web.Mvc/Web/Mvc/Controllers/Localization/AbpLocalizationController.cs
@@ -1,23 +1,25 @@
-﻿using System.Security.Policy;
+﻿using System;
 using System.Web;
 using System.Web.Mvc;
 using Abp.Auditing;
-using Abp.Configuration;
 using Abp.Localization;
 using Abp.Runtime.Session;
 using Abp.Timing;
 using Abp.Web.Configuration;
+using Abp.Web.Http;
 using Abp.Web.Models;
 
 namespace Abp.Web.Mvc.Controllers.Localization
 {
     public class AbpLocalizationController : AbpController
     {
-        private readonly IAbpWebLocalizationConfiguration _webLocalizationConfiguration;
+        protected readonly IAbpWebLocalizationConfiguration WebLocalizationConfiguration;
+        protected IUrlHelper UrlHelper;
 
-        public AbpLocalizationController(IAbpWebLocalizationConfiguration webLocalizationConfiguration)
+        public AbpLocalizationController(IAbpWebLocalizationConfiguration webLocalizationConfiguration, IUrlHelper urlHelper)
         {
-            _webLocalizationConfiguration = webLocalizationConfiguration;
+            WebLocalizationConfiguration = webLocalizationConfiguration;
+            UrlHelper = urlHelper;
         }
 
         [DisableAuditing]
@@ -29,7 +31,7 @@ namespace Abp.Web.Mvc.Controllers.Localization
             }
 
             Response.Cookies.Add(
-                new HttpCookie(_webLocalizationConfiguration.CookieName, cultureName)
+                new HttpCookie(WebLocalizationConfiguration.CookieName, cultureName)
                 {
                     Expires = Clock.Now.AddYears(2),
                     Path = Request.ApplicationPath
@@ -50,9 +52,13 @@ namespace Abp.Web.Mvc.Controllers.Localization
                 return Json(new AjaxResponse(), JsonRequestBehavior.AllowGet);
             }
 
-            if (!string.IsNullOrWhiteSpace(returnUrl) && Request.Url != null && AbpUrlHelper.IsLocalUrl(Request.Url, returnUrl))
+            if (!string.IsNullOrWhiteSpace(returnUrl))
             {
-                return Redirect(returnUrl);
+                var localPath = UrlHelper.LocalPathAndQuery(Uri.EscapeUriString(returnUrl), Request.Url.Host, Request.Url.Port);
+                if (!string.IsNullOrWhiteSpace(localPath))
+                {
+                    return Redirect(Uri.UnescapeDataString(localPath));
+                }
             }
 
             return Redirect(Request.ApplicationPath);

--- a/src/Abp.Web/Web/AbpUrlHelper.cs
+++ b/src/Abp.Web/Web/AbpUrlHelper.cs
@@ -4,6 +4,7 @@ using JetBrains.Annotations;
 
 namespace Abp.Web
 {
+    [Obsolete("Use Abp.Web.Http.UrlHelper instead")]
     public static class AbpUrlHelper
     {
         public static bool IsLocalUrl([NotNull] Uri requestUri, [NotNull] string url)

--- a/src/Abp/Web/Http/AbpUrlHelper.cs
+++ b/src/Abp/Web/Http/AbpUrlHelper.cs
@@ -1,0 +1,64 @@
+using System;
+using Abp.Dependency;
+using JetBrains.Annotations;
+
+namespace Abp.Web.Http
+{
+    public class AbpUrlHelper : IUrlHelper, ISingletonDependency
+    {
+        /// <summary>
+        /// Extract local path and query from <paramref name="url"/>.
+        /// If <paramref name="url"/> is an absolute url, 
+        /// <paramref name="localHostName"/> and <paramref name="localPort"/> will be used to check against the host and port in <paramref name="url"/> if any.
+        /// </summary>
+        /// <param name="url">absolute or relative url</param>
+        /// <param name="localHostName"></param>
+        /// <param name="localPort"></param>
+        /// <returns></returns>
+        public virtual string LocalPathAndQuery([NotNull] string url, [CanBeNull] string localHostName = null, [CanBeNull] int? localPort = null)
+        {
+            Check.NotNull(url, nameof(url));
+
+            var uri = ParseWithUriBuilder(url) ?? ParseWithUri(url);
+            if (uri != null && uri.IsWellFormedOriginalString())
+            {
+                if (uri.IsAbsoluteUri)
+                {
+                    var isValidScheme = uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps;
+                    var isSameHost = string.Equals(localHostName, uri.Host, StringComparison.OrdinalIgnoreCase);
+                    var isSamePort = localPort == uri.Port || (localPort == null && uri.IsDefaultPort);
+                    if (isValidScheme && isSameHost && isSamePort)
+                    {
+                        return uri.PathAndQuery;
+                    }
+                }
+                else if (!uri.IsAbsoluteUri)
+                {
+                    return uri.OriginalString;
+                }
+            }
+            return null;
+        }
+
+        protected virtual Uri ParseWithUriBuilder(string url)
+        {
+            try
+            {
+                return new UriBuilder(url).Uri;
+            }
+            catch (UriFormatException)
+            {
+                return null;
+            }
+        }
+
+        protected virtual Uri ParseWithUri(string url)
+        {
+            if (Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out Uri returnUri))
+            {
+                return returnUri;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Abp/Web/Http/IUrlHelper.cs
+++ b/src/Abp/Web/Http/IUrlHelper.cs
@@ -1,0 +1,18 @@
+using JetBrains.Annotations;
+
+namespace Abp.Web.Http
+{
+    public interface IUrlHelper
+    {
+        /// <summary>
+        /// Extract local path and query from <paramref name="url"/>.
+        /// If <paramref name="url"/> is an absolute url, 
+        /// <paramref name="localHostName"/> and <paramref name="localPort"/> will be used to check against the host and port in <paramref name="url"/> if any.
+        /// </summary>
+        /// <param name="url">absolute or relative url</param>
+        /// <param name="localHostName"></param>
+        /// <param name="localPort"></param>
+        /// <returns></returns>
+        string LocalPathAndQuery([NotNull] string url, [CanBeNull] string localHostName = null, [CanBeNull] int? localPort = null);
+    }
+}

--- a/test/Abp.AspNetCore.Tests/Tests/AbpLocalizationController_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/AbpLocalizationController_Tests.cs
@@ -1,0 +1,98 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Abp.AspNetCore.Mvc.Controllers;
+using Shouldly;
+using Xunit;
+
+namespace Abp.AspNetCore.Tests
+{
+    public class AbpLocalizationControllerTests : AppTestBase
+    {
+        [Theory]
+        [InlineData("en")]
+        [InlineData("en-us")]
+        public async Task Should_Set_Culture_Cookie(string cultureName)
+        {
+            // Act
+            var response = await GetResponseAsync(
+                GetUrl<AbpLocalizationController>(
+                    nameof(AbpLocalizationController.ChangeCulture),
+                    new { cultureName }
+                ),
+                HttpStatusCode.Redirect
+            );
+
+            // Assert
+            response.Headers.Location.IsAbsoluteUri.ShouldBeFalse();
+            response.Headers.Location.ToString().ShouldBe("/");
+
+            var exceptedCookieValue = $"c={cultureName}|uic={cultureName}";
+            var cookies = response.Headers.SingleOrDefault(header => header.Key == "Set-Cookie").Value;
+            cookies.Single().ShouldContain($".AspNetCore.Culture={WebUtility.UrlEncode(exceptedCookieValue)}");
+        }
+
+        [Theory]
+        [InlineData("english")]
+        [InlineData("")]
+        public async Task Should_Throw_Invalid_Culture_Name(string cultureName)
+        {
+            // Act
+            var exception = await Should.ThrowAsync<AbpException>(async () => {
+                await GetResponseAsync(
+                    GetUrl<AbpLocalizationController>(
+                        nameof(AbpLocalizationController.ChangeCulture),
+                        new { cultureName }
+                    )
+                );
+            });
+            
+            // Assert
+            exception.Message.ShouldBe($"Unknown language: {cultureName}. It must be a valid culture!");
+        }
+
+        [Theory]
+        [InlineData("/local/site", "/local/site")]
+        [InlineData("/local/site?id=1", "/local/site?id=1")] //aspnetcore can only bind the first query param in an unescaped return url
+        [InlineData("http://localhost/page", "/page")]
+        [InlineData("http%3A%2F%2Flocalhost%2Fpage", "/page")]
+        [InlineData("%2Flocal%2Fsite%3Fid%3D1%26value%3D2", "/local/site?id=1&value=2")]
+        [InlineData("%2F%E7%B5%8C%E5%96%B6%3F%E4%BB%95%E4%BA%8B%E5%A0%B4%3Dbusiness%26ID%3D1", "/経営?仕事場=business&ID=1")]
+        public async Task Should_Redirect_Local_Return_Url(string returnUrl, string expected)
+        {
+            // Act
+            var response = await GetResponseAsync(
+                GetUrl<AbpLocalizationController>(
+                    nameof(AbpLocalizationController.ChangeCulture),
+                    new { cultureName = "en", returnUrl }
+                ),
+                HttpStatusCode.Redirect
+            );
+
+            // Assert
+            response.Headers.Location.IsAbsoluteUri.ShouldBeFalse();
+            response.Headers.Location.ToString().ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("www.example.com", "/")]
+        [InlineData("www.example.com/local/site", "/")]
+        [InlineData("www.example.com%2Flocal%2Fsite%3Fid%3D1", "/")]
+        [InlineData("http%3A%2F%2Fwww.example.com%2F%E7%B5%8C%E5%96%B6%3F%E4%BB%95%E4%BA%8B%E5%A0%B4%3Dbusiness%26ID%3D1", "/")]
+        public async Task Should_Redirect_External_Return_Url(string returnUrl, string expected)
+        {
+            // Act
+            var response = await GetResponseAsync(
+                GetUrl<AbpLocalizationController>(
+                    nameof(AbpLocalizationController.ChangeCulture),
+                    new { cultureName = "en", returnUrl }
+                ),
+                HttpStatusCode.Redirect
+            );
+
+            // Assert
+            response.Headers.Location.IsAbsoluteUri.ShouldBeFalse();
+            response.Headers.Location.ToString().ShouldBe(expected);
+        }
+    }
+}

--- a/test/Abp.Tests/Web/Http/UrlHelper_Tests.cs
+++ b/test/Abp.Tests/Web/Http/UrlHelper_Tests.cs
@@ -1,0 +1,82 @@
+﻿using Abp.Web.Http;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Tests.Web.Http
+{
+    public class UrlHelper_Tests : TestBaseWithLocalIocManager
+    {
+        public UrlHelper_Tests()
+        {
+            LocalIocManager.Register<IUrlHelper, AbpUrlHelper>();
+        }
+
+        [Theory]
+        [InlineData("/relative/path", "/relative/path")]
+        [InlineData("//relative/path", "//relative/path")]
+        [InlineData("/relative/path?id=1&value=2", "/relative/path?id=1&value=2")]
+        [InlineData("%2F%E7%B5%8C%E5%96%B6%3F%E4%BB%95%E4%BA%8B%E5%A0%B4%3Dbusiness%26ID%3D1", "%2F%E7%B5%8C%E5%96%B6%3F%E4%BB%95%E4%BA%8B%E5%A0%B4%3Dbusiness%26ID%3D1")]
+        public void Should_Return_Relative_Url(string url, string expected)
+        {
+            LocalIocManager.Resolve<IUrlHelper>().LocalPathAndQuery(url).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("invalid relative path")]
+        [InlineData("/invalid relative path")]
+        [InlineData("/\\invalid/relative/path")]
+        public void Should_Not_Return_Relative_Url(string url)
+        {
+            LocalIocManager.Resolve<IUrlHelper>().LocalPathAndQuery(url).ShouldBeNull();
+        }
+
+        [Theory]
+        [InlineData("www.example.com", "/")]
+        [InlineData("www.example.com/site", "/site")]
+        [InlineData("www.example.com/site?id=1&value=2", "/site?id=1&value=2")]
+        [InlineData("http://www.example.com", "/")]
+        [InlineData("http://www.example.com/site", "/site")]
+        [InlineData("http://www.example.com/site?id=1&value=2", "/site?id=1&value=2")]
+        [InlineData("http://www.example.com:80", "/")]
+        [InlineData("http://www.example.com:80/site", "/site")]
+        [InlineData("http://www.example.com:80/site?id=1&value=2", "/site?id=1&value=2")]
+        [InlineData("http%3A%2F%2Fwww.example.com%2F%E7%B5%8C%E5%96%B6%3F%E4%BB%95%E4%BA%8B%E5%A0%B4%3Dbusiness%26ID%3D1", "http%3A%2F%2Fwww.example.com%2F%E7%B5%8C%E5%96%B6%3F%E4%BB%95%E4%BA%8B%E5%A0%B4%3Dbusiness%26ID%3D1")]
+        public void Should_Return_Relative_Url_With_Host(string url, string expected)
+        {
+            LocalIocManager.Resolve<IUrlHelper>().LocalPathAndQuery(url, "www.example.com", null).ShouldBe(expected);
+            LocalIocManager.Resolve<IUrlHelper>().LocalPathAndQuery(url, "www.example.com", 80).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("http://www.example.com:8080", "/")]
+        [InlineData("http://www.example.com:8080/site", "/site")]
+        [InlineData("http://www.example.com:8080/site?id=1&value=2", "/site?id=1&value=2")]
+        public void Should_Return_Relative_Url_With_Host_And_Port(string url, string expected)
+        {
+            LocalIocManager.Resolve<IUrlHelper>().LocalPathAndQuery(url, "www.example.com", 8080).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("www.counterexample.com")]
+        [InlineData("www.counterexample.com/site")]
+        [InlineData("http://www.counterexample.com")]
+        [InlineData("http://www.counterexample.com/site")]
+        [InlineData("ftp://www.example.com")]
+        public void Should_Not_Return_Relative_Url_With_Host(string url)
+        {
+            LocalIocManager.Resolve<IUrlHelper>().LocalPathAndQuery(url, "www.example.com", null).ShouldBeNull();
+            LocalIocManager.Resolve<IUrlHelper>().LocalPathAndQuery(url, "www.example.com", 80).ShouldBeNull();
+        }
+
+        [Theory]
+        [InlineData("www.example.com:8080")]
+        [InlineData("www.example.com:8080/site")]
+        [InlineData("http://www.example.com:8080")]
+        [InlineData("http://www.example.com:8080/site")]
+        [InlineData("ftp://www.example.com:21")]
+        public void Should_Not_Return_Relative_Url_With_Host_And_Port(string url)
+        {
+            LocalIocManager.Resolve<IUrlHelper>().LocalPathAndQuery(url, "www.example.com", 8888).ShouldBeNull();
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/aspnetboilerplate/aspnetboilerplate/issues/5563

- Added new `UrlHelper` at `Abp.Web.Http` in core Abp package
  - Uses a combination of [System.Uri](https://docs.microsoft.com/en-us/dotnet/api/system.uri.trycreate?view=netcore-3.1) and  [System.UriBuilder](https://docs.microsoft.com/en-us/dotnet/api/system.uribuilder.-ctor?view=netcore-3.1#System_UriBuilder__ctor_System_String_) to parse the given url and perform comparison on the Uri parts to determine local url/ relative url
- Deprecated old `AbpUrlHelper` in both `Abp.AspNetCore` and `Abp.Web` packages
- In `AbpLocalizationController`
  - Replace `AbpUrlHelper.IsLocalUrl()` with `Abp.Web.Http.UrlHelper.LocalPathAndQuery()`
  - Use `HttpUtility.UrlDecode()` on return url