### PR TITLE
Enable filter MayHaveTenant for querying tenant and edition features

### DIFF
--- a/src/Abp.Zero.Common/Application/Features/AbpFeatureValueStore.cs
+++ b/src/Abp.Zero.Common/Application/Features/AbpFeatureValueStore.cs
@@ -220,6 +220,7 @@ namespace Abp.Application.Features
 
                 using (var uow = _unitOfWorkManager.Begin())
                 {
+                    using (_unitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
                     using (_unitOfWorkManager.Current.SetTenantId(tenantId))
                     {
                         var featureSettings = await _tenantFeatureRepository.GetAllListAsync();
@@ -255,6 +256,7 @@ namespace Abp.Application.Features
 
                 using (var uow = _unitOfWorkManager.Begin())
                 {
+                    using (_unitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
                     using (_unitOfWorkManager.Current.SetTenantId(tenantId))
                     {
                         var featureSettings = _tenantFeatureRepository.GetAllList();

--- a/src/Abp.Zero.Common/Application/Features/AbpFeatureValueStore.cs
+++ b/src/Abp.Zero.Common/Application/Features/AbpFeatureValueStore.cs
@@ -130,6 +130,7 @@ namespace Abp.Application.Features
         [UnitOfWork]
         public virtual async Task SetEditionFeatureValueAsync(int editionId, string featureName, string value)
         {
+            using (_unitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
             using (_unitOfWorkManager.Current.SetTenantId(null))
             {
                 if (await GetEditionValueOrNullAsync(editionId, featureName) == value)
@@ -170,6 +171,7 @@ namespace Abp.Application.Features
         [UnitOfWork]
         public virtual void SetEditionFeatureValue(int editionId, string featureName, string value)
         {
+            using (_unitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
             using (_unitOfWorkManager.Current.SetTenantId(null))
             {
                 if (GetEditionValueOrNull(editionId, featureName) == value)
@@ -299,6 +301,7 @@ namespace Abp.Application.Features
 
             using (var uow = _unitOfWorkManager.Begin())
             {
+                using (_unitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
                 using (_unitOfWorkManager.Current.SetTenantId(null))
                 {
                     var featureSettings = await _editionFeatureRepository.GetAllListAsync(f => f.EditionId == editionId);
@@ -320,6 +323,7 @@ namespace Abp.Application.Features
 
             using (var uow = _unitOfWorkManager.Begin())
             {
+                using (_unitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
                 using (_unitOfWorkManager.Current.SetTenantId(null))
                 {
                     var featureSettings = _editionFeatureRepository.GetAllList(f => f.EditionId == editionId);

--- a/src/Abp.Zero.Common/MultiTenancy/AbpTenantManager.cs
+++ b/src/Abp.Zero.Common/MultiTenancy/AbpTenantManager.cs
@@ -244,6 +244,7 @@ namespace Abp.MultiTenancy
 
             //Get the current feature setting
             TenantFeatureSetting currentSetting;
+            using (UnitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
             using (UnitOfWorkManager.Current.SetTenantId(tenant.Id))
             {
                 currentSetting = await TenantFeatureRepository.FirstOrDefaultAsync(f => f.Name == featureName);
@@ -299,6 +300,7 @@ namespace Abp.MultiTenancy
 
             //Get the current feature setting
             TenantFeatureSetting currentSetting;
+            using (UnitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
             using (UnitOfWorkManager.Current.SetTenantId(tenant.Id))
             {
                 currentSetting = TenantFeatureRepository.FirstOrDefault(f => f.Name == featureName);
@@ -351,6 +353,7 @@ namespace Abp.MultiTenancy
         [UnitOfWork]
         public virtual async Task ResetAllFeaturesAsync(int tenantId)
         {
+            using (UnitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
             using (UnitOfWorkManager.Current.SetTenantId(tenantId))
             {
                 await TenantFeatureRepository.DeleteAsync(f => f.TenantId == tenantId);
@@ -365,6 +368,7 @@ namespace Abp.MultiTenancy
         [UnitOfWork]
         public virtual void ResetAllFeatures(int tenantId)
         {
+            using (UnitOfWorkManager.Current.EnableFilter(AbpDataFilters.MayHaveTenant))
             using (UnitOfWorkManager.Current.SetTenantId(tenantId))
             {
                 TenantFeatureRepository.Delete(f => f.TenantId == tenantId);

--- a/test/Abp.ZeroCore.Tests/Zero/Tenants/FeatureValueStoreTests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Tenants/FeatureValueStoreTests.cs
@@ -1,0 +1,96 @@
+using System.Threading.Tasks;
+using Abp.Domain.Repositories;
+using Abp.Domain.Uow;
+using Abp.MultiTenancy;
+using Abp.Runtime.Caching;
+using Abp.ZeroCore.SampleApp.Application;
+using Abp.ZeroCore.SampleApp.Core;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Zero.Tenants
+{
+    public class FeatureValueStoreTests : AbpZeroTestBase
+    {
+        private readonly ICacheManager _cacheManager;
+        private readonly FeatureValueStore _featureValueStore;
+        private readonly IRepository<TenantFeatureSetting, long> _tenantFeatureRepository;
+        private readonly IRepository<Tenant> _tenantRepository;
+        private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+        public FeatureValueStoreTests()
+        {
+            _cacheManager = Resolve<ICacheManager>();
+            _featureValueStore = Resolve<FeatureValueStore>();
+            _tenantFeatureRepository = Resolve<IRepository<TenantFeatureSetting, long>>();
+            _tenantRepository = Resolve<IRepository<Tenant>>();
+            _unitOfWorkManager = Resolve<IUnitOfWorkManager>();
+        }
+
+        [Fact]
+        public void GetTenantFeatureCacheItem_ShouldEnableFilterMayHaveTenant_Test()
+        {
+            // Arrange
+            var tenant = new Tenant("TestTenant", "TestTenant");
+            _tenantRepository.Insert(tenant);
+
+            var tenant2 = new Tenant("TestTenant2", "TestTenant2");
+            _tenantRepository.Insert(tenant2);
+
+            using (var uow = _unitOfWorkManager.Begin())
+            {
+                _tenantFeatureRepository.Insert(new TenantFeatureSetting(tenant.Id, AppFeatures.SimpleBooleanFeature, "true"));
+               _unitOfWorkManager.Current.SaveChanges();
+
+                // Assert (before disable filter)
+                _featureValueStore.GetValueOrNull(tenant.Id, AppFeatures.SimpleBooleanFeature).ShouldBe("true");
+                _featureValueStore.GetValueOrNull(tenant2.Id, AppFeatures.SimpleBooleanFeature).ShouldBeNull();
+
+                // Act (clear cache and disable filter)
+                _cacheManager.GetTenantFeatureCache().Clear();
+
+                using (_unitOfWorkManager.Current.DisableFilter(AbpDataFilters.MayHaveTenant))
+                {
+                    // Assert (after disable filter)
+                    _featureValueStore.GetValueOrNull(tenant.Id, AppFeatures.SimpleBooleanFeature).ShouldBe("true");
+                    _featureValueStore.GetValueOrNull(tenant2.Id, AppFeatures.SimpleBooleanFeature).ShouldBeNull();
+                }
+
+                uow.Complete();
+            }
+        }
+
+        [Fact]
+        public async Task GetTenantFeatureCacheItemAsync_ShouldEnableFilterMayHaveTenant_Test()
+        {
+            // Arrange
+            var tenant = new Tenant("TestTenant", "TestTenant");
+            await _tenantRepository.InsertAsync(tenant);
+
+            var tenant2 = new Tenant("TestTenant2", "TestTenant2");
+            await _tenantRepository.InsertAsync(tenant2);
+
+            using (var uow = _unitOfWorkManager.Begin())
+            {
+                await _tenantFeatureRepository.InsertAsync(new TenantFeatureSetting(tenant.Id, AppFeatures.SimpleBooleanFeature, "true"));
+                await _unitOfWorkManager.Current.SaveChangesAsync();
+
+                // Assert (before disable filter)
+                (await _featureValueStore.GetValueOrNullAsync(tenant.Id, AppFeatures.SimpleBooleanFeature)).ShouldBe("true");
+                (await _featureValueStore.GetValueOrNullAsync(tenant2.Id, AppFeatures.SimpleBooleanFeature)).ShouldBeNull();
+
+                // Act (clear cache and disable filter)
+                await _cacheManager.GetTenantFeatureCache().ClearAsync();
+
+                using (_unitOfWorkManager.Current.DisableFilter(AbpDataFilters.MayHaveTenant))
+                {
+                    // Assert (after disable filter)
+                    (await _featureValueStore.GetValueOrNullAsync(tenant.Id, AppFeatures.SimpleBooleanFeature)).ShouldBe("true");
+                    (await _featureValueStore.GetValueOrNullAsync(tenant2.Id, AppFeatures.SimpleBooleanFeature)).ShouldBeNull();
+                }
+
+                await uow.CompleteAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Otherwise, if the caller disabled filter `MayHaveTenant`, then `SetTenantId` is ineffective.

Fixes #5588 

Related: #3555, #4542