### PR TITLE
Handle null for Publish to host in NotificationPublisher

### DIFF
--- a/src/Abp/Notifications/NotificationPublisher.cs
+++ b/src/Abp/Notifications/NotificationPublisher.cs
@@ -88,7 +88,7 @@ namespace Abp.Notifications
                 Severity = severity,
                 UserIds = userIds.IsNullOrEmpty() ? null : userIds.Select(uid => uid.ToUserIdentifierString()).JoinAsString(","),
                 ExcludedUserIds = excludedUserIds.IsNullOrEmpty() ? null : excludedUserIds.Select(uid => uid.ToUserIdentifierString()).JoinAsString(","),
-                TenantIds = tenantIds.IsNullOrEmpty() ? null : tenantIds.JoinAsString(","),
+                TenantIds = GetTenantIdsAsStr(tenantIds),
                 Data = data?.ToJsonString(),
                 DataTypeName = data?.GetType().AssemblyQualifiedName
             };
@@ -154,7 +154,7 @@ namespace Abp.Notifications
                 Severity = severity,
                 UserIds = userIds.IsNullOrEmpty() ? null : userIds.Select(uid => uid.ToUserIdentifierString()).JoinAsString(","),
                 ExcludedUserIds = excludedUserIds.IsNullOrEmpty() ? null : excludedUserIds.Select(uid => uid.ToUserIdentifierString()).JoinAsString(","),
-                TenantIds = tenantIds.IsNullOrEmpty() ? null : tenantIds.JoinAsString(","),
+                TenantIds = GetTenantIdsAsStr(tenantIds),
                 Data = data?.ToJsonString(),
                 DataTypeName = data?.GetType().AssemblyQualifiedName
             };
@@ -183,6 +183,23 @@ namespace Abp.Notifications
                        )
                    );
             }
+        }
+
+        /// <summary>
+        /// Gets the string for <see cref="NotificationInfo.TenantIds"/>.
+        /// </summary>
+        /// <param name="tenantIds"></param>
+        /// <seealso cref="DefaultNotificationDistributer.GetTenantIds"/>
+        private static string GetTenantIdsAsStr(int?[] tenantIds)
+        {
+            if (tenantIds.IsNullOrEmpty())
+            {
+                return null;
+            }
+
+            return tenantIds
+                .Select(tenantId => tenantId == null ? "null" : tenantId.ToString())
+                .JoinAsString(",");
         }
     }
 }

--- a/test/Abp.Tests/Notifications/NotificationPublisher_Tests.cs
+++ b/test/Abp.Tests/Notifications/NotificationPublisher_Tests.cs
@@ -48,6 +48,32 @@ namespace Abp.Tests.Notifications
                 );
         }
 
+        [Fact]
+        public async Task Should_PublishAsync_To_Host()
+        {
+            // Act
+            await _publisher.PublishAsync("TestNotification", tenantIds: new int?[] { null });
+
+            // Assert
+            await _store.Received()
+                .InsertNotificationAsync(
+                    Arg.Is<NotificationInfo>(n => n.TenantIds == "null")
+                );
+        }
+
+        [Fact]
+        public void Should_Publish_To_Host()
+        {
+            // Act
+            _publisher.Publish("TestNotification", tenantIds: new int?[] { null });
+
+            // Assert
+            _store.Received()
+                .InsertNotification(
+                    Arg.Is<NotificationInfo>(n => n.TenantIds == "null")
+                );
+        }
+
         private static NotificationData CreateNotificationData()
         {
             var notificationData = new NotificationData();


### PR DESCRIPTION
Fixes #5562 

The existing behavior has been the case since the Notification Infrastructure was introduced in #799, which was released in ABP v0.8.0.0 (Feb 2016).

However, a few other parts of the code, especially `DefaultNotificationDistribution.GetTenantIds`, appear to expect `"null"` string for host. `"0"` is already used for `NotificationInfo.AllTenantIds`.

From https://docs.microsoft.com/en-us/dotnet/api/system.string.join?view=netcore-3.1:

> # String.Join Method
>
> #### Return Value
> ...
> [Empty](https://docs.microsoft.com/en-us/dotnet/api/system.string.empty?view=netcore-3.1) if `values` has zero elements or all the elements of `values` are `null`.