### PR TITLE
CheckAndSetMayHaveTenantIdProperty

### DIFF
--- a/src/Abp.EntityFramework/EntityFramework/AbpDbContext.cs
+++ b/src/Abp.EntityFramework/EntityFramework/AbpDbContext.cs
@@ -23,6 +23,7 @@ using Abp.EntityFramework.Utils;
 using Abp.Events.Bus;
 using Abp.Events.Bus.Entities;
 using Abp.Extensions;
+using Abp.MultiTenancy;
 using Abp.Runtime.Session;
 using Abp.Timing;
 using Castle.Core.Logging;
@@ -495,9 +496,10 @@ namespace Abp.EntityFramework
                 return;
             }
 
-            //Only works for single tenant applications
-            if (MultiTenancyConfig?.IsEnabled ?? false)
+            //Should set TenantId if multitenancy is disabled
+            if (!MultiTenancyConfig?.IsEnabled ?? true)
             {
+                entity.TenantId = MultiTenancyConsts.DefaultTenantId;
                 return;
             }
 


### PR DESCRIPTION
I implemented a basic fix to #5653 :

so this pull request altered  AbpDbContext.CheckAndSetMayHaveTenantIdProperty  so it will now:

Set TenantId with MultiTenancyConsts.DefaultTenantId if multitenancy is disabled
Set TenantId with 'CurrentTenantId' if multitenancy is enabled

