### PR TITLE
Create a new unit of work for TransactionScopeOption.Suppress.

### DIFF
--- a/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
+++ b/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
@@ -291,7 +291,7 @@ namespace Abp.Authorization
 
         protected virtual async Task<bool> TryLockOutAsync(int? tenantId, long userId)
         {
-            using (var uow = UnitOfWorkManager.Begin(TransactionScopeOption.Suppress))
+            using (var uow = UnitOfWorkManager.Begin(TransactionScopeOption.RequiresNew))
             {
                 using (UnitOfWorkManager.Current.SetTenantId(tenantId))
                 {

--- a/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
+++ b/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
@@ -291,7 +291,7 @@ namespace Abp.Authorization
 
         protected virtual async Task<bool> TryLockOutAsync(int? tenantId, long userId)
         {
-            using (var uow = UnitOfWorkManager.Begin(TransactionScopeOption.RequiresNew))
+            using (var uow = UnitOfWorkManager.Begin(TransactionScopeOption.Suppress))
             {
                 using (UnitOfWorkManager.Current.SetTenantId(tenantId))
                 {

--- a/src/Abp/Domain/Uow/InnerSuppressUnitOfWorkCompleteHandle.cs
+++ b/src/Abp/Domain/Uow/InnerSuppressUnitOfWorkCompleteHandle.cs
@@ -2,7 +2,7 @@
 
 namespace Abp.Domain.Uow
 {
-    internal class InnerSuppressUnitOfWorkCompleteHandle : IUnitOfWorkCompleteHandle
+    internal class InnerSuppressUnitOfWorkCompleteHandle : InnerUnitOfWorkCompleteHandle
     {
         private readonly IUnitOfWork _parentUnitOfWork;
 
@@ -11,19 +11,16 @@ namespace Abp.Domain.Uow
             _parentUnitOfWork = parentUnitOfWork;
         }
 
-        public void Complete()
+        public override void Complete()
         {
             _parentUnitOfWork.SaveChanges();
+            base.Complete();
         }
 
-        public async Task CompleteAsync()
+        public override async Task CompleteAsync()
         {
             await _parentUnitOfWork.SaveChangesAsync();
-        }
-
-        public void Dispose()
-        {
-
+            await base.CompleteAsync();
         }
     }
 }

--- a/src/Abp/Domain/Uow/InnerSuppressUnitOfWorkCompleteHandle.cs
+++ b/src/Abp/Domain/Uow/InnerSuppressUnitOfWorkCompleteHandle.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+
+namespace Abp.Domain.Uow
+{
+    internal class InnerSuppressUnitOfWorkCompleteHandle : IUnitOfWorkCompleteHandle
+    {
+        private readonly IUnitOfWork _parentUnitOfWork;
+
+        public InnerSuppressUnitOfWorkCompleteHandle(IUnitOfWork parentUnitOfWork)
+        {
+            _parentUnitOfWork = parentUnitOfWork;
+        }
+
+        public void Complete()
+        {
+            _parentUnitOfWork.SaveChanges();
+        }
+
+        public async Task CompleteAsync()
+        {
+            await _parentUnitOfWork.SaveChangesAsync();
+        }
+
+        public void Dispose()
+        {
+
+        }
+    }
+}

--- a/src/Abp/Domain/Uow/InnerUnitOfWorkCompleteHandle.cs
+++ b/src/Abp/Domain/Uow/InnerUnitOfWorkCompleteHandle.cs
@@ -17,12 +17,12 @@ namespace Abp.Domain.Uow
         private volatile bool _isCompleteCalled;
         private volatile bool _isDisposed;
 
-        public void Complete()
+        public virtual void Complete()
         {
             _isCompleteCalled = true;
         }
 
-        public Task CompleteAsync()
+        public virtual Task CompleteAsync()
         {
             _isCompleteCalled = true;
             return Task.FromResult(0);

--- a/src/Abp/Domain/Uow/InnerUnitOfWorkCompleteHandle.cs
+++ b/src/Abp/Domain/Uow/InnerUnitOfWorkCompleteHandle.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Abp.Domain.Uow
 {
     /// <summary>
-    /// This handle is used for innet unit of work scopes.
+    /// This handle is used for inner unit of work scopes.
     /// A inner unit of work scope actually uses outer unit of work scope
     /// and has no effect on <see cref="IUnitOfWorkCompleteHandle.Complete"/> call.
     /// But if it's not called, an exception is thrown at end of the UOW to rollback the UOW.
@@ -47,7 +47,7 @@ namespace Abp.Domain.Uow
                 throw new AbpException(DidNotCallCompleteMethodExceptionMessage);
             }
         }
-        
+
         private static bool HasException()
         {
             try

--- a/src/Abp/Domain/Uow/UnitOfWorkManager.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkManager.cs
@@ -45,9 +45,13 @@ namespace Abp.Domain.Uow
             var outerUow = _currentUnitOfWorkProvider.Current;
 
             if (options.Scope == TransactionScopeOption.Required &&
-                outerUow != null &&
-                outerUow.Options?.Scope != TransactionScopeOption.Suppress)
+                outerUow != null)
             {
+                if (outerUow.Options?.Scope == TransactionScopeOption.Suppress)
+                {
+                    return new InnerSuppressUnitOfWorkCompleteHandle(outerUow);
+                }
+
                 return new InnerUnitOfWorkCompleteHandle();
             }
 

--- a/src/Abp/Domain/Uow/UnitOfWorkManager.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkManager.cs
@@ -44,15 +44,11 @@ namespace Abp.Domain.Uow
 
             var outerUow = _currentUnitOfWorkProvider.Current;
 
-            if (options.Scope == TransactionScopeOption.Required &&
-                outerUow != null)
+            if (options.Scope == TransactionScopeOption.Required && outerUow != null)
             {
-                if (outerUow.Options?.Scope == TransactionScopeOption.Suppress)
-                {
-                    return new InnerSuppressUnitOfWorkCompleteHandle(outerUow);
-                }
-
-                return new InnerUnitOfWorkCompleteHandle();
+                return outerUow.Options?.Scope == TransactionScopeOption.Suppress
+                    ? new InnerSuppressUnitOfWorkCompleteHandle(outerUow)
+                    : new InnerUnitOfWorkCompleteHandle();
             }
 
             var uow = _iocResolver.Resolve<IUnitOfWork>();

--- a/src/Abp/Domain/Uow/UnitOfWorkManager.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkManager.cs
@@ -44,7 +44,9 @@ namespace Abp.Domain.Uow
 
             var outerUow = _currentUnitOfWorkProvider.Current;
 
-            if (options.Scope == TransactionScopeOption.Required && outerUow != null)
+            if (options.Scope == TransactionScopeOption.Required &&
+                outerUow != null &&
+                outerUow.Options?.Scope != TransactionScopeOption.Suppress)
             {
                 return new InnerUnitOfWorkCompleteHandle();
             }

--- a/src/Abp/Domain/Uow/UnitOfWorkOptions.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkOptions.cs
@@ -40,7 +40,7 @@ namespace Abp.Domain.Uow
         public TransactionScopeAsyncFlowOption? AsyncFlowOption { get; set; }
 
         /// <summary>
-        /// Can be used to enable/disable some filters. 
+        /// Can be used to enable/disable some filters.
         /// </summary>
         public List<DataFilterConfiguration> FilterOverrides { get; }
 

--- a/src/Abp/Events/Bus/Entities/EntityChangeEventHelper.cs
+++ b/src/Abp/Events/Bus/Entities/EntityChangeEventHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Transactions;
 using Abp.Dependency;
 using Abp.Domain.Uow;
 
@@ -118,7 +119,7 @@ namespace Abp.Events.Bus.Entities
             var entityType = entity.GetType();
             var eventType = genericEventType.MakeGenericType(entityType);
 
-            if (triggerInCurrentUnitOfWork || _unitOfWorkManager.Current == null)
+            if (triggerInCurrentUnitOfWork || _unitOfWorkManager.Current == null || _unitOfWorkManager.Current?.Options?.Scope == TransactionScopeOption.Suppress)
             {
                 EventBus.Trigger(eventType, (IEventData)Activator.CreateInstance(eventType, new[] { entity }));
                 return;

--- a/src/Abp/Events/Bus/Entities/EntityChangeEventHelper.cs
+++ b/src/Abp/Events/Bus/Entities/EntityChangeEventHelper.cs
@@ -119,7 +119,9 @@ namespace Abp.Events.Bus.Entities
             var entityType = entity.GetType();
             var eventType = genericEventType.MakeGenericType(entityType);
 
-            if (triggerInCurrentUnitOfWork || _unitOfWorkManager.Current == null || _unitOfWorkManager.Current?.Options?.Scope == TransactionScopeOption.Suppress)
+            if (triggerInCurrentUnitOfWork ||
+                _unitOfWorkManager.Current == null ||
+                _unitOfWorkManager.Current?.Options?.Scope == TransactionScopeOption.Suppress)
             {
                 EventBus.Trigger(eventType, (IEventData)Activator.CreateInstance(eventType, new[] { entity }));
                 return;


### PR DESCRIPTION
Use `InnerSuppressUnitOfWorkCompleteHandle `for `Suppress` option.
```cs
internal class InnerSuppressUnitOfWorkCompleteHandle : InnerUnitOfWorkCompleteHandle
{
	private readonly IUnitOfWork _parentUnitOfWork;

	public InnerSuppressUnitOfWorkCompleteHandle(IUnitOfWork parentUnitOfWork)
	{
		_parentUnitOfWork = parentUnitOfWork;
	}

	public override void Complete()
	{
		_parentUnitOfWork.SaveChanges();
		base.Complete();
	}

	public override async Task CompleteAsync()
	{
		await _parentUnitOfWork.SaveChangesAsync();
		await base.CompleteAsync();
	}
}
```

If we start a new unit of work for `Suppress`, this is unreasonable. it is no different from **RequiresNew**. consider the following code.

```
using (var uow = UnitOfWorkManager.Begin(TransactionScopeOption.Suppress))
{
	_personRepository.Insert(new Person { ContactListId = 1, Name = "halil" });
	_personRepository.Insert(new Person { ContactListId = 2, Name = "halil2" });

	uow.Complete();
}
```

We expect that the **Insert** method does not start a new unit of work and does not participate in any transactions. (All operations within the scope are done without an ambient transaction context.)

