### PR TITLE
Recommend a shared cache on SQLite

### DIFF
--- a/doc/WebSite/EF-Core-Sqlite-Integration.md
+++ b/doc/WebSite/EF-Core-Sqlite-Integration.md
@@ -56,7 +56,7 @@ Change the connection string to your SQLite connection in ***.Web.Mvc/appsetting
 ```js
 {
   "ConnectionStrings": {
-    "Default": "Data Source=SqliteDemoDb.db"
+    "Default": "Data Source=SqliteDemoDb.db;Cache=Shared"
   },
   ...
 }


### PR DESCRIPTION
This reduces locking enabling more concurrent access to the database.