### PR TITLE
Support setting header name of culture information

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Localization/AbpLocalizationHeaderRequestCultureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Localization/AbpLocalizationHeaderRequestCultureProvider.cs
@@ -21,6 +21,12 @@ namespace Abp.AspNetCore.Localization
         private static readonly string _culturePrefix = "c=";
         private static readonly string _uiCulturePrefix = "uic=";
 
+        /// <summary>
+        /// The name of the header that contains the user's preferred culture information.
+        /// Defaults to <see cref="CookieRequestCultureProvider.DefaultCookieName"/>.
+        /// </summary>
+        public string HeaderName { get; set; } = CookieRequestCultureProvider.DefaultCookieName;
+
         public AbpLocalizationHeaderRequestCultureProvider()
         {
             Logger = NullLogger.Instance;
@@ -34,7 +40,7 @@ namespace Abp.AspNetCore.Localization
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            var localizationHeader = httpContext.Request.Headers[CookieRequestCultureProvider.DefaultCookieName];
+            var localizationHeader = httpContext.Request.Headers[HeaderName];
 
             if (localizationHeader.Count == 0)
             {


### PR DESCRIPTION
Resolves #2531 

Introduce `AbpLocalizationHeaderRequestCultureProvider.HeaderName`, similar to [`CookieRequestCultureProvider.CookieName`](https://github.com/dotnet/aspnetcore/blob/8a81194f372fa6fe63ded2d932d379955854d080/src/Middleware/Localization/src/CookieRequestCultureProvider.cs#L28).

# Usage

In [Startup.cs#L132](https://github.com/aspnetboilerplate/module-zero-core-template/blob/1be7ee114725359002ea4b70377b331a7529cc52/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs#L132):

```diff
- app.UseAbpRequestLocalization();
+ app.UseAbpRequestLocalization(options =>
+ {
+     var headerProvider = options.RequestCultureProviders.OfType<AbpLocalizationHeaderRequestCultureProvider>().First();
+     headerProvider.HeaderName = "AspNetCore-Culture";
+ });
```

In [app-initializer.ts#L122](https://github.com/aspnetboilerplate/module-zero-core-template/blob/8dc59e36fe8e07e318f55527a35baa40ad07f010/angular/src/app-initializer.ts#L122):

```diff
- '.AspNetCore.Culture': `c=${cookieLangValue}|uic=${cookieLangValue}`,
+ 'AspNetCore-Culture': `c=${cookieLangValue}|uic=${cookieLangValue}`,
```