### PR TITLE
Add Microsoft.NET.Test.Sdk to fix missing test DLL

### DIFF
--- a/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/AbpAspNetCoreDemo.IntegrationTests.csproj
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/AbpAspNetCoreDemo.IntegrationTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     <PackageReference Include="Shouldly" Version="3.0.2" />


### PR DESCRIPTION
Caused by https://github.com/aspnetboilerplate/aspnetboilerplate/commit/cc0e5f6c635ca541c56f23f5a7986d48fbb8f120#diff-0a1a13c0a13aec84a68abcb3314930f296bcb0392ba6edbbc048644ba0534fb5L10-R11:

```diff
- <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+ <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
```

https://www.nuget.org/packages/xunit.runner.visualstudio/2.4.1 depended on Microsoft.NET.Test.Sdk (>= 15.0.0).
https://www.nuget.org/packages/xunit.runner.visualstudio/2.4.2 has no dependencies, so we need to add explicitly.