### PR TITLE
Save only non-default culture to user setting

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Localization/AbpUserRequestCultureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Localization/AbpUserRequestCultureProvider.cs
@@ -78,9 +78,9 @@ namespace Abp.AspNetCore.Localization
                 }
             }
 
-            if (!cultureName.IsNullOrEmpty())
+            if (!cultureName.IsNullOrEmpty() && cultureName != await GetDefaultCulture(abpSession, settingManager))
             {
-                //Try to set user's language setting from cookie/header if available.
+                // Try to set user's language setting from cookie/header if available and not default.
                 await settingManager.ChangeSettingForUserAsync(
                     abpSession.ToUserIdentifier(),
                     LocalizationSettingNames.DefaultLanguage,
@@ -99,6 +99,13 @@ namespace Abp.AspNetCore.Localization
             }
 
             return await provider.DetermineProviderCultureResult(httpContext);
+        }
+
+        private Task<string> GetDefaultCulture(IAbpSession abpSession, ISettingManager settingManager)
+        {
+            return abpSession.TenantId.HasValue
+                ? settingManager.GetSettingValueForTenantAsync(LocalizationSettingNames.DefaultLanguage, abpSession.TenantId.Value)
+                : settingManager.GetSettingValueForApplicationAsync(LocalizationSettingNames.DefaultLanguage);
         }
     }
 }


### PR DESCRIPTION
Fixes #5835 

Caused by #4823.
When we stopped saving `'null'` string (as we shouldn't), we started to get culture from cookie and header and try to save it.

`ChangeSettingForUserAsync` calls `InsertOrUpdateOrDeleteSettingValueAsync`, which tries to get the setting (to be updated or deleted) from `SettingStore` (database) instead of the setting value from the cache.
Since we [don't *store on database if the value is the default value*](https://github.com/aspnetboilerplate/aspnetboilerplate/blob/1a9e2a88c0cc7294cd171c8dcc38d2a96851e27b/src/Abp/Configuration/SettingManager.cs#L607), we repeat this (get from database + don't store) every time.

`AbpUserRequestCultureProvider` should check that it is not the default value before calling `ChangeSettingForUserAsync`.

# How to verify this patch before it is merged

1. Copy `AbpUserRequestCultureProvider` with the patch to your project as `MyUserRequestCultureProvider`.
2. In [Startup.cs#L132](https://github.com/aspnetboilerplate/module-zero-core-template/blob/1be7ee114725359002ea4b70377b331a7529cc52/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs#L132), insert an instance of `MyUserRequestCultureProvider` into `RequestCultureProviders`:

```diff
- app.UseAbpRequestLocalization();
+ app.UseAbpRequestLocalization(options =>
+ {
+     var userProvider = new MyUserRequestCultureProvider
+     {
+         CookieProvider = options.RequestCultureProviders.OfType<CookieRequestCultureProvider>().FirstOrDefault(),
+         HeaderProvider = options.RequestCultureProviders.OfType<AbpLocalizationHeaderRequestCultureProvider>().FirstOrDefault()
+     };
+     options.RequestCultureProviders.Insert(1, userProvider);
+ });
```