### PR TITLE
Issue #5876 Migration failing

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/Zero/EntityFrameworkCore/AbpZeroDbModelBuilderExtensions.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/Zero/EntityFrameworkCore/AbpZeroDbModelBuilderExtensions.cs
@@ -46,12 +46,16 @@ namespace Abp.Zero.EntityFrameworkCore
             SetTableName<EntityChangeSet>(modelBuilder, prefix + "EntityChangeSets", schemaName);
             SetTableName<EntityPropertyChange>(modelBuilder, prefix + "EntityPropertyChanges", schemaName);
             SetTableName<FeatureSetting>(modelBuilder, prefix + "Features", schemaName);
+            SetTableName<EditionFeatureSetting>(modelBuilder, prefix + "Features", schemaName);
+            SetTableName<TenantFeatureSetting>(modelBuilder, prefix + "Features", schemaName);
             SetTableName<ApplicationLanguage>(modelBuilder, prefix + "Languages", schemaName);
             SetTableName<ApplicationLanguageText>(modelBuilder, prefix + "LanguageTexts", schemaName);
             SetTableName<NotificationInfo>(modelBuilder, prefix + "Notifications", schemaName);
             SetTableName<NotificationSubscriptionInfo>(modelBuilder, prefix + "NotificationSubscriptions", schemaName);
             SetTableName<OrganizationUnit>(modelBuilder, prefix + "OrganizationUnits", schemaName);
             SetTableName<PermissionSetting>(modelBuilder, prefix + "Permissions", schemaName);
+            SetTableName<RolePermissionSetting>(modelBuilder, prefix + "Permissions", schemaName);
+            SetTableName<UserPermissionSetting>(modelBuilder, prefix + "Permissions", schemaName);
             SetTableName<TRole>(modelBuilder, prefix + "Roles", schemaName);
             SetTableName<Setting>(modelBuilder, prefix + "Settings", schemaName);
             SetTableName<TTenant>(modelBuilder, prefix + "Tenants", schemaName);


### PR DESCRIPTION
After update to .Net 5 Migration is failing

Both 'TenantFeatureSetting' and 'EditionFeatureSetting' are mapped to the table 'AbpFeatures'. All the entity types in a hierarchy that don't have a discriminator must be mapped to different tables

This is happening when we are using the custom table names.

Upon checking the code for "ChangeAbpTablePrefix" found that only the base table name is changing there that's why this error is occurring.

So these changes need to be done to that function

SetTableName(modelBuilder, prefix + "Features", schemaName);

SetTableName(modelBuilder, prefix + "Features", schemaName);

Same for the PermissionSetting
SetTableName(modelBuilder, prefix + "Permissions", schemaName);

SetTableName(modelBuilder, prefix + "Permissions", schemaName);