### PR TITLE
Handle directory starting with a digit.

### DIFF
--- a/src/Abp/Resources/Embedded/EmbeddedResourcePathHelper.cs
+++ b/src/Abp/Resources/Embedded/EmbeddedResourcePathHelper.cs
@@ -23,6 +23,20 @@ namespace Abp.Resources.Embedded
                 {
                     var currentChar = subPath[i];
 
+                    if (char.IsDigit(currentChar))
+                    {
+                        if (i >= 0)
+                        {
+                            var previousChar = subPath[i - 1];
+                            if (previousChar == '/' || previousChar == '-' || previousChar == '.')
+                            {
+                                builder.Append('_');
+                                builder.Append(currentChar);
+                                continue;
+                            }
+                        }
+                    }
+
                     if (currentChar == '/')
                     {
                         if (i != 0) // omit a starting slash (/), encode any others as a dot

--- a/test/Abp.Tests/Abp.Tests.csproj
+++ b/test/Abp.Tests/Abp.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Embedded\MyResources\js-dash\MyScriptFile.js" />
+    <EmbeddedResource Include="Resources\Embedded\MyResources\0.9\MyScriptFile.0.9.js" />
     <EmbeddedResource Include="Resources\Embedded\MyResources\js_underscore\MyScriptFile.js" />
   </ItemGroup>
 

--- a/test/Abp.Tests/Resources/Embedded/EmbeddedResourceTests.cs
+++ b/test/Abp.Tests/Resources/Embedded/EmbeddedResourceTests.cs
@@ -113,6 +113,21 @@ namespace Abp.Tests.Resources.Embedded
         }
 
         [Fact]
+        public void Should_Get_Embedded_Resource_With_Begin_Digit_In_Folder()
+        {
+            var filepath = "/MyApp/MyResources/0.9/MyScriptFile.0.9.js";
+            var resource = _embeddedResourceManager.GetResource(filepath);
+            var filename = System.IO.Path.GetFileName(filepath);
+            var extension = System.IO.Path.GetExtension(filepath);
+
+            resource.ShouldNotBeNull();
+            Assert.True(resource.Assembly == GetType().GetAssembly());
+            Assert.True(resource.Content.Length > 0);
+            Assert.EndsWith(filename, resource.FileName);
+            Assert.True(resource.FileExtension == extension.Substring(1)); // without dot
+        }
+
+        [Fact]
         public void Should_Get_Embedded_Resources()
         {
             var filepath = "/MyApp/MyResources/js/";

--- a/test/Abp.Tests/Resources/Embedded/MyResources/0.9/MyScriptFile.0.9.js
+++ b/test/Abp.Tests/Resources/Embedded/MyResources/0.9/MyScriptFile.0.9.js
@@ -1,0 +1,2 @@
+﻿/* This file is just a sample to use in tests */
+alert('hello world!');


### PR DESCRIPTION
Resolve #5889

The rules for names are complicated, and we can only cover the common ones.

https://github.com/dotnet/msbuild/blob/master/src/Tasks/CreateCSharpManifestResourceName.cs