### PR TITLE
AbpPerRequestRedisCache implementation

### DIFF
--- a/Abp.sln
+++ b/Abp.sln
@@ -180,6 +180,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abp.ZeroCore.IdentityServer
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore", "src\Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore\Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore.csproj", "{5779DD70-E43D-4429-8D8D-1DD429392F0D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abp.AspNetCore.PerRequestRedisCache", "src\Abp.AspNetCore.PerRequestRedisCache\Abp.AspNetCore.PerRequestRedisCache.csproj", "{DE3D4F5B-70A2-488B-A478-2C73FFE36D46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -504,6 +506,10 @@ Global
 		{5779DD70-E43D-4429-8D8D-1DD429392F0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5779DD70-E43D-4429-8D8D-1DD429392F0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5779DD70-E43D-4429-8D8D-1DD429392F0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE3D4F5B-70A2-488B-A478-2C73FFE36D46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE3D4F5B-70A2-488B-A478-2C73FFE36D46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE3D4F5B-70A2-488B-A478-2C73FFE36D46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE3D4F5B-70A2-488B-A478-2C73FFE36D46}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -590,6 +596,7 @@ Global
 		{15C9B221-9469-47AC-9D96-117EB00E2CE1} = {DFF0464B-5402-4DD6-86F5-2AEC1163B232}
 		{FA588E3F-FBC1-4B2E-B1FF-0628758422F7} = {DFF0464B-5402-4DD6-86F5-2AEC1163B232}
 		{5779DD70-E43D-4429-8D8D-1DD429392F0D} = {DFF0464B-5402-4DD6-86F5-2AEC1163B232}
+		{DE3D4F5B-70A2-488B-A478-2C73FFE36D46} = {DFF0464B-5402-4DD6-86F5-2AEC1163B232}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A1CB38E-F77D-4A40-B3A9-9A70C3F3BC6D}

--- a/nupkg/pack.ps1
+++ b/nupkg/pack.ps1
@@ -50,7 +50,8 @@ $projects = (
     "Abp.ZeroCore.IdentityServer4",
     "Abp.ZeroCore.IdentityServer4.EntityFrameworkCore",
     "Abp.ZeroCore.IdentityServer4.vNext",
-    "Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore"
+    "Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore",
+    "Abp.AspNetCore.PerRequestRedisCache"
 )
 
 # Rebuild solution

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Abp.AspNetCore.PerRequestRedisCache.csproj
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Abp.AspNetCore.PerRequestRedisCache.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-        <RootNamespace>Abp.RedisCache</RootNamespace>
+        <RootNamespace>Abp</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Abp.AspNetCore.PerRequestRedisCache.csproj
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Abp.AspNetCore.PerRequestRedisCache.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+        <RootNamespace>Abp.RedisCache</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Abp.RedisCache\Abp.RedisCache.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpAspNetCorePerRequestRedisCacheModule.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpAspNetCorePerRequestRedisCacheModule.cs
@@ -1,0 +1,20 @@
+﻿using Abp.Modules;
+using Abp.Reflection.Extensions;
+
+namespace Abp.Runtime.Caching.Redis
+{
+    [DependsOn(typeof(AbpRedisCacheModule))]
+    public class AbpAspNetCorePerRequestRedisCacheModule : AbpModule
+    {
+        public override void PreInitialize()
+        {
+            IocManager.Register<IAbpPerRequestRedisCache, AbpPerRequestRedisCache>();
+            IocManager.Register<IAbpPerRequestRedisCacheManager, AbpPerRequestRedisCacheManager>();
+        }
+
+        public override void Initialize()
+        {
+            IocManager.RegisterAssemblyByConvention(typeof(AbpAspNetCorePerRequestRedisCacheModule).GetAssembly());
+        }
+    }
+}

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs
@@ -1,0 +1,297 @@
+﻿using Abp.Data;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Abp.Runtime.Caching.Redis
+{
+    public class AbpPerRequestRedisCache : AbpRedisCache, IAbpPerRequestRedisCache
+    {
+        private const string AbpPerRequestRedisCachePrefix = "AbpPerRequestRedisCache:";
+
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public AbpPerRequestRedisCache(
+            string name,
+            IAbpRedisCacheDatabaseProvider redisCacheDatabaseProvider,
+            IRedisCacheSerializer redisCacheSerializer,
+            IHttpContextAccessor httpContextAccessor)
+            : base(name, redisCacheDatabaseProvider, redisCacheSerializer)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public override bool TryGetValue(string key, out object value)
+        {
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                string localizedKey = GetPerRequestRedisCacheKey(key);
+
+                if (httpContext.Items.ContainsKey(localizedKey))
+                {
+                    var conditionalValue = (ConditionalValue<object>) httpContext.Items[localizedKey];
+                    value = conditionalValue.HasValue ? conditionalValue.Value : null;
+
+                    return conditionalValue.HasValue;
+                }
+                else
+                {
+                    bool hasValue = base.TryGetValue(key, out value);
+                    httpContext.Items[localizedKey] = new ConditionalValue<object>(hasValue, hasValue ? value : null);
+
+                    return hasValue;
+                }
+            }
+
+            return base.TryGetValue(key, out value);
+        }
+
+        public override ConditionalValue<object>[] TryGetValues(string[] keys)
+        {
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                Dictionary<string, string> localizedKeys = keys.ToDictionary(GetPerRequestRedisCacheKey);
+
+                string[] missingKeys = localizedKeys
+                    .Where(kv => !httpContext.Items.ContainsKey(kv.Key))
+                    .Select(kv => kv.Value)
+                    .ToArray();
+
+                var missingValues = base.TryGetValues(missingKeys);
+
+                for (int i = 0; i < missingKeys.Length; i++)
+                {
+                    httpContext.Items[GetPerRequestRedisCacheKey(missingKeys[i])] = missingValues[i];
+                }
+
+                List<ConditionalValue<object>> result = new List<ConditionalValue<object>>();
+
+                foreach (string localizedKey in localizedKeys.Keys)
+                {
+                    result.Add((ConditionalValue<object>) httpContext.Items[localizedKey]);
+                }
+
+                return result.ToArray();
+            }
+
+            return base.TryGetValues(keys);
+        }
+
+        public override async Task<ConditionalValue<object>> TryGetValueAsync(string key)
+        {
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                string localizedKey = GetPerRequestRedisCacheKey(key);
+
+                if (httpContext.Items.ContainsKey(localizedKey))
+                {
+                    var conditionalValue = (ConditionalValue<object>) httpContext.Items[localizedKey];
+                    return conditionalValue;
+                }
+                else
+                {
+                    var conditionalValue = await base.TryGetValueAsync(key);
+                    httpContext.Items[localizedKey] = conditionalValue;
+
+                    return conditionalValue;
+                }
+            }
+
+            return await base.TryGetValueAsync(key);
+        }
+
+        public override async Task<ConditionalValue<object>[]> TryGetValuesAsync(string[] keys)
+        {
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                Dictionary<string, string> localizedKeys = keys.ToDictionary(GetPerRequestRedisCacheKey);
+
+                string[] missingKeys = localizedKeys
+                    .Where(kv => !httpContext.Items.ContainsKey(kv.Key))
+                    .Select(kv => kv.Value)
+                    .ToArray();
+
+                var missingValues = await base.TryGetValuesAsync(missingKeys);
+
+                for (int i = 0; i < missingKeys.Length; i++)
+                {
+                    httpContext.Items[GetPerRequestRedisCacheKey(missingKeys[i])] = missingValues[i];
+                }
+
+                List<ConditionalValue<object>> result = new List<ConditionalValue<object>>();
+
+                foreach (string localizedKey in localizedKeys.Keys)
+                {
+                    result.Add((ConditionalValue<object>) httpContext.Items[localizedKey]);
+                }
+
+                return result.ToArray();
+            }
+
+            return await base.TryGetValuesAsync(keys);
+        }
+
+        public override void Set(string key, object value, TimeSpan? slidingExpireTime = null, DateTimeOffset? absoluteExpireTime = null)
+        {
+            base.Set(key, value, slidingExpireTime, absoluteExpireTime);
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                httpContext.Items[GetPerRequestRedisCacheKey(key)] = new ConditionalValue<object>(true, value);
+            }
+        }
+
+        public override async Task SetAsync(string key, object value, TimeSpan? slidingExpireTime = null, DateTimeOffset? absoluteExpireTime = null)
+        {
+            await base.SetAsync(key, value, slidingExpireTime, absoluteExpireTime);
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                httpContext.Items[GetPerRequestRedisCacheKey(key)] = new ConditionalValue<object>(true, value);
+            }
+        }
+
+        public override void Set(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, DateTimeOffset? absoluteExpireTime = null)
+        {
+            base.Set(pairs, slidingExpireTime, absoluteExpireTime);
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                for (int i = 0; i < pairs.Length; i++)
+                {
+                    httpContext.Items[GetPerRequestRedisCacheKey(pairs[i].Key)] = new ConditionalValue<object>(true, pairs[i].Value);
+                }
+            }
+        }
+
+        public override async Task SetAsync(KeyValuePair<string, object>[] pairs, TimeSpan? slidingExpireTime = null, DateTimeOffset? absoluteExpireTime = null)
+        {
+            await base.SetAsync(pairs, slidingExpireTime, absoluteExpireTime);
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                for (int i = 0; i < pairs.Length; i++)
+                {
+                    httpContext.Items[GetPerRequestRedisCacheKey(pairs[i].Key)] = new ConditionalValue<object>(true, pairs[i].Value);
+                }
+            }
+        }
+
+        public override void Remove(string key)
+        {
+            base.Remove(key);
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                string localizedKey = GetPerRequestRedisCacheKey(key);
+
+                if (!httpContext.Items.ContainsKey(localizedKey))
+                {
+                    httpContext.Items.Remove(localizedKey);
+                }
+            }
+        }
+
+        public override async Task RemoveAsync(string key)
+        {
+            await base.RemoveAsync(key);
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                string localizedKey = GetPerRequestRedisCacheKey(key);
+
+                if (!httpContext.Items.ContainsKey(localizedKey))
+                {
+                    httpContext.Items.Remove(localizedKey);
+                }
+            }
+        }
+
+        public override void Remove(string[] keys)
+        {
+            base.Remove(keys);
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                foreach (string key in keys)
+                {
+                    string localizedKey = GetPerRequestRedisCacheKey(key);
+
+                    if (!httpContext.Items.ContainsKey(localizedKey))
+                    {
+                        httpContext.Items.Remove(localizedKey);
+                    }
+                }
+            }
+        }
+
+        public override async Task RemoveAsync(string[] keys)
+        {
+            await base.RemoveAsync(keys);
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                foreach (string key in keys)
+                {
+                    string localizedKey = GetPerRequestRedisCacheKey(key);
+
+                    if (!httpContext.Items.ContainsKey(localizedKey))
+                    {
+                        httpContext.Items.Remove(localizedKey);
+                    }
+                }
+            }
+        }
+
+        public override void Clear()
+        {
+            base.Clear();
+
+            HttpContext httpContext = _httpContextAccessor.HttpContext;
+
+            if (httpContext != null)
+            {
+                string localizedKeyPrefix = GetPerRequestRedisCacheKey("");
+
+                foreach (string key in httpContext.Items.Keys.ToList())
+                {
+                    if (key.StartsWith(localizedKeyPrefix))
+                    {
+                        httpContext.Items.Remove(key);
+                    }
+                }
+            }
+        }
+
+        protected virtual string GetPerRequestRedisCacheKey(string key)
+        {
+            return AbpPerRequestRedisCachePrefix + GetLocalizedRedisKey(key).ToString();
+        }
+    }
+}

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCacheManager.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCacheManager.cs
@@ -1,0 +1,36 @@
+﻿using Abp.Dependency;
+using Abp.Runtime.Caching.Configuration;
+
+namespace Abp.Runtime.Caching.Redis
+{
+    /// <summary>
+    /// Used to create <see cref="AbpPerRequestRedisCache"/> instances.
+    /// </summary>
+    public class AbpPerRequestRedisCacheManager : CacheManagerBase<ICache>, IAbpPerRequestRedisCacheManager
+    {
+        private readonly IIocManager _iocManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbpPerRequestRedisCacheManager"/> class.
+        /// </summary>
+        public AbpPerRequestRedisCacheManager(IIocManager iocManager, ICachingConfiguration configuration)
+            : base(configuration)
+        {
+            _iocManager = iocManager;
+            _iocManager.RegisterIfNot<AbpPerRequestRedisCache>(DependencyLifeStyle.Transient);
+        }
+
+        protected override ICache CreateCacheImplementation(string name)
+        {
+            return _iocManager.Resolve<AbpPerRequestRedisCache>(new {name});
+        }
+
+        protected override void DisposeCaches()
+        {
+            foreach (var cache in Caches)
+            {
+                _iocManager.Release(cache.Value);
+            }
+        }
+    }
+}

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/IAbpPerRequestRedisCache.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/IAbpPerRequestRedisCache.cs
@@ -1,0 +1,6 @@
+﻿namespace Abp.Runtime.Caching.Redis
+{
+    public interface IAbpPerRequestRedisCache : ICache
+    {
+    }
+}

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/IAbpPerRequestRedisCacheManager.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/IAbpPerRequestRedisCacheManager.cs
@@ -1,5 +1,15 @@
 ﻿namespace Abp.Runtime.Caching.Redis
 {
+    /// <summary>
+    /// An upper level container for <see cref="ICache"/> objects.
+    /// <para>
+    /// ICache objects requested from <see cref="IAbpPerRequestRedisCacheManager"/> stores redis caches per http context. And it does not try to pull it again from redis during the http context.
+    /// It should not be used if the changes on this data in one instance of the project can causes an error in the other instance of the project.
+    /// It is only recommended to use it in cases that you know cache will never be changed until current http context is done or it is not an important value. (for example some ui view settings etc.)
+    /// Otherwise use <see cref="ICacheManager"/>
+    /// </para>
+    /// A cache manager should work as Singleton and track and manage <see cref="ICache"/> objects.
+    /// </summary>
     public interface IAbpPerRequestRedisCacheManager : ICacheManager
     {
     }

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/IAbpPerRequestRedisCacheManager.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/IAbpPerRequestRedisCacheManager.cs
@@ -1,0 +1,6 @@
+﻿namespace Abp.Runtime.Caching.Redis
+{
+    public interface IAbpPerRequestRedisCacheManager : ICacheManager
+    {
+    }
+}

--- a/test/Abp.ZeroCore.Tests/Abp.ZeroCore.Tests.csproj
+++ b/test/Abp.ZeroCore.Tests/Abp.ZeroCore.Tests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Abp.AspNetCore.PerRequestRedisCache\Abp.AspNetCore.PerRequestRedisCache.csproj" />
     <ProjectReference Include="..\..\src\Abp.EntityFrameworkCore.EFPlus\Abp.EntityFrameworkCore.EFPlus.csproj" />
     <ProjectReference Include="..\..\src\Abp.TestBase\Abp.TestBase.csproj" />
     <ProjectReference Include="..\Abp.ZeroCore.SampleApp\Abp.ZeroCore.SampleApp.csproj" />

--- a/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestModule.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestModule.cs
@@ -6,13 +6,12 @@ using Abp.TestBase;
 using Abp.Zero.Configuration;
 using Abp.Zero.Notifications;
 using Abp.ZeroCore.SampleApp;
-using Castle.MicroKernel.Registration;
 using Abp.Configuration.Startup;
-using Abp.Dependency;
+using Abp.Runtime.Caching.Redis;
 
 namespace Abp.Zero
 {
-    [DependsOn(typeof(AbpZeroCoreSampleAppModule), typeof(AbpTestBaseModule))]
+    [DependsOn(typeof(AbpZeroCoreSampleAppModule), typeof(AbpTestBaseModule), typeof(AbpAspNetCorePerRequestRedisCacheModule))]
     public class AbpZeroTestModule : AbpModule
     {
         public AbpZeroTestModule(AbpZeroCoreSampleAppModule sampleAppModule)

--- a/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestModule.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/AbpZeroTestModule.cs
@@ -7,11 +7,10 @@ using Abp.Zero.Configuration;
 using Abp.Zero.Notifications;
 using Abp.ZeroCore.SampleApp;
 using Abp.Configuration.Startup;
-using Abp.Runtime.Caching.Redis;
 
 namespace Abp.Zero
 {
-    [DependsOn(typeof(AbpZeroCoreSampleAppModule), typeof(AbpTestBaseModule), typeof(AbpAspNetCorePerRequestRedisCacheModule))]
+    [DependsOn(typeof(AbpZeroCoreSampleAppModule), typeof(AbpTestBaseModule))]
     public class AbpZeroTestModule : AbpModule
     {
         public AbpZeroTestModule(AbpZeroCoreSampleAppModule sampleAppModule)

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/AbpPerRequestRedisCacheTestModule.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/AbpPerRequestRedisCacheTestModule.cs
@@ -1,0 +1,20 @@
+﻿using Abp.Modules;
+using Abp.Reflection.Extensions;
+using Abp.Runtime.Caching.Redis;
+
+namespace Abp.Zero.Redis
+{
+    [DependsOn(typeof(AbpAspNetCorePerRequestRedisCacheModule))]
+    public class AbpPerRequestRedisCacheTestModule : AbpModule
+    {
+        public override void PreInitialize()
+        {
+            Configuration.Caching.UseRedis();
+        }
+        
+        public override void Initialize()
+        {
+            IocManager.RegisterAssemblyByConvention(typeof(AbpPerRequestRedisCacheTestModule).GetAssembly());
+        }
+    }
+}

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/AbpPerRequestRedisCache_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/AbpPerRequestRedisCache_Test.cs
@@ -45,9 +45,6 @@ namespace Abp.Zero.Redis
             LocalIocManager.Resolve<ICachingConfiguration>().Configure("MyTestCacheItems", cache => { cache.DefaultSlidingExpireTime = TimeSpan.FromHours(12); });
             LocalIocManager.Resolve<ICachingConfiguration>().Configure("MyPerRequestRedisTestCacheItems", cache => { cache.DefaultSlidingExpireTime = TimeSpan.FromHours(24); });
             
-            //LocalIocManager.Register<AbpRedisCacheManager>();
-            var cacheManager = Resolve<ICacheManager>();
-
             _redisSerializer = LocalIocManager.Resolve<IRedisCacheSerializer>();
 
             _perRequestRedisCache = LocalIocManager.Resolve<IAbpPerRequestRedisCacheManager>().GetCache<string, MyCacheItem>("MyPerRequestRedisTestCacheItems");

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/AbpPerRequestRedisCache_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/AbpPerRequestRedisCache_Test.cs
@@ -1,0 +1,414 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Abp.Configuration.Startup;
+using Abp.Runtime.Caching;
+using Abp.Runtime.Caching.Configuration;
+using Abp.Runtime.Caching.Redis;
+using Abp.TestBase;
+using Castle.MicroKernel.Registration;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Shouldly;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Abp.Zero.Redis
+{
+    public class AbpPerRequestRedisCache_Test : AbpZeroTestBase
+    {
+        private ITypedCache<string, MyCacheItem> _perRequestRedisCache;
+        private ITypedCache<string, MyCacheItem> _normalRedisCache;
+
+        private IDatabase _redisDatabase;
+        private IRedisCacheSerializer _redisSerializer;
+
+        public static HttpContext CurrentHttpContext;
+
+        public AbpPerRequestRedisCache_Test()
+        {
+            var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+            httpContextAccessor.HttpContext.Returns(info => CurrentHttpContext);
+
+            LocalIocManager.IocContainer.Register(Component.For<IHttpContextAccessor>().Instance(httpContextAccessor).LifestyleSingleton());
+
+            _redisDatabase = Substitute.For<IDatabase>();
+            var redisDatabaseProvider = Substitute.For<IAbpRedisCacheDatabaseProvider>();
+
+            redisDatabaseProvider.GetDatabase().Returns(_redisDatabase);
+
+            LocalIocManager.IocContainer.Register(Component.For<IAbpRedisCacheDatabaseProvider>().Instance(redisDatabaseProvider).LifestyleSingleton());
+            LocalIocManager.IocContainer.Register(Component.For<IAbpStartupConfiguration>().Instance(Substitute.For<IAbpStartupConfiguration>()));
+
+            LocalIocManager.Resolve<ICachingConfiguration>().Configure("MyTestCacheItems", cache => { cache.DefaultSlidingExpireTime = TimeSpan.FromHours(12); });
+            LocalIocManager.Resolve<ICachingConfiguration>().Configure("MyPerRequestRedisTestCacheItems", cache => { cache.DefaultSlidingExpireTime = TimeSpan.FromHours(24); });
+            
+            _redisSerializer = LocalIocManager.Resolve<IRedisCacheSerializer>();
+
+            _perRequestRedisCache = LocalIocManager.Resolve<IAbpPerRequestRedisCacheManager>().GetCache<string, MyCacheItem>("MyPerRequestRedisTestCacheItems");
+            _normalRedisCache = LocalIocManager.Resolve<ICacheManager>().GetCache<string, MyCacheItem>("MyTestCacheItems");
+        }
+
+        private HttpContext GetNewContextSubstitute()
+        {
+            var httpContext = Substitute.For<HttpContext>();
+            httpContext.Items = new Dictionary<object, object>();
+            return httpContext;
+        }
+
+        [Fact]
+        public void Cache_Options_Configuration_Test()
+        {
+            _normalRedisCache.DefaultSlidingExpireTime.ShouldBe(TimeSpan.FromHours(12));
+            _perRequestRedisCache.DefaultSlidingExpireTime.ShouldBe(TimeSpan.FromHours(24));
+        }
+
+        [Fact]
+        public void Should_Not_Change_Normal_Redis_Cache()
+        {
+            _redisDatabase.ClearReceivedCalls();
+
+            string cacheKey = "Test";
+            int cacheValue = 1;
+
+            int counter = 0;
+
+            MyCacheItem GetCacheValue()
+            {
+                counter++;
+                return new MyCacheItem {Value = cacheValue};
+            }
+
+            _redisDatabase.StringSet(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<TimeSpan>()).Returns(true);
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+
+            var item = _normalRedisCache.Get(cacheKey, GetCacheValue);
+            _redisDatabase.Received(2).StringGet(Arg.Any<RedisKey>()); //redis cache tries to get value two times if value not exists see AbpCacheBase<TKey, TValue>.Get(TKey key, Func<TKey, TValue> factory)
+            _redisDatabase.Received(1).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            _redisDatabase.StringGet(Arg.Any<RedisKey>()).Returns(cachedObject);
+
+            var item1 = _normalRedisCache.Get(cacheKey, GetCacheValue);
+            _redisDatabase.Received(3).StringGet(Arg.Any<RedisKey>());
+
+            var item2 = _normalRedisCache.Get(cacheKey, GetCacheValue);
+            _redisDatabase.Received(4).StringGet(Arg.Any<RedisKey>());
+
+            //should still be one received calls
+            _redisDatabase.Received(1).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            counter.ShouldBe(1);
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+
+            _normalRedisCache.GetOrDefault(cacheKey).Value.ShouldBe(cacheValue);
+        }
+
+        [Theory]
+        [InlineData("A", 42)]
+        [InlineData("B", 43)]
+        public void Simple_Get_Set_Test(string cacheKey, int cacheValue)
+        {
+            var item = _perRequestRedisCache.Get(cacheKey, () => new MyCacheItem {Value = cacheValue});
+
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+            _redisDatabase.StringGet(Arg.Any<RedisKey>()).Returns(cachedObject);
+            _redisDatabase.Received().StringGet(Arg.Any<RedisKey>());
+
+            _perRequestRedisCache.GetOrDefault(cacheKey).Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public void Should_Request_Once_For_Same_Context()
+        {
+            _redisDatabase.ClearReceivedCalls();
+
+            string cacheKey = "Test";
+            int cacheValue = 1;
+
+            int counter = 0;
+
+            MyCacheItem GetCacheValue()
+            {
+                counter++;
+                return new MyCacheItem {Value = cacheValue};
+            }
+
+            var item = _perRequestRedisCache.Get(cacheKey, GetCacheValue);
+            var item1 = _perRequestRedisCache.Get(cacheKey, GetCacheValue);
+            var item2 = _perRequestRedisCache.Get(cacheKey, GetCacheValue);
+
+            counter.ShouldBe(1);
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+
+            _redisDatabase.Received(1).StringGet(Arg.Any<RedisKey>());
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+            _redisDatabase.Received(1).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            _perRequestRedisCache.GetOrDefault(cacheKey).Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public void Should_Request_Again_For_Different_Contexts()
+        {
+            _redisDatabase.ClearReceivedCalls();
+
+            string cacheKey = "Test";
+            int cacheValue = 1;
+
+            int counter = 0;
+
+            MyCacheItem GetCacheValue()
+            {
+                counter++;
+                return new MyCacheItem {Value = cacheValue};
+            }
+
+            _redisDatabase.StringSet(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<TimeSpan>()).Returns(true);
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+
+            CurrentHttpContext = GetNewContextSubstitute();
+
+            var item = _perRequestRedisCache.Get(cacheKey, GetCacheValue);
+            _redisDatabase.Received(1).StringGet(Arg.Any<RedisKey>());
+            _redisDatabase.Received(1).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            _redisDatabase.StringGet(Arg.Any<RedisKey>()).Returns(cachedObject);
+
+            CurrentHttpContext = GetNewContextSubstitute();
+            var item1 = _perRequestRedisCache.Get(cacheKey, GetCacheValue);
+            _redisDatabase.Received(2).StringGet(Arg.Any<RedisKey>());
+
+            CurrentHttpContext = GetNewContextSubstitute();
+            var item2 = _perRequestRedisCache.Get(cacheKey, GetCacheValue);
+            _redisDatabase.Received(3).StringGet(Arg.Any<RedisKey>());
+
+            //should still be one received calls
+            _redisDatabase.Received(1).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            counter.ShouldBe(1);
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public void Should_Work_With_Null_Contexts()
+        {
+            CurrentHttpContext = null;
+            _redisDatabase.ClearReceivedCalls();
+
+            string cacheKey = "Test";
+            int cacheValue = 1;
+
+            int counter = 0;
+
+            MyCacheItem GetCacheValue()
+            {
+                counter++;
+                return new MyCacheItem {Value = cacheValue};
+            }
+
+            _redisDatabase.StringSet(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<TimeSpan>()).Returns(true);
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+
+            var item = _perRequestRedisCache.Get(cacheKey, GetCacheValue);
+            _redisDatabase.Received(2).StringGet(Arg.Any<RedisKey>());
+            _redisDatabase.Received(1).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            _redisDatabase.StringGet(Arg.Any<RedisKey>()).Returns(cachedObject);
+
+            var item1 = _perRequestRedisCache.Get(cacheKey, GetCacheValue);
+            _redisDatabase.Received(3).StringGet(Arg.Any<RedisKey>()); //since CurrentHttpContext is null it should go to the redisdb again
+
+            var item2 = _perRequestRedisCache.Get(cacheKey, GetCacheValue); //since CurrentHttpContext is null it should go to the redisdb again
+            _redisDatabase.Received(4).StringGet(Arg.Any<RedisKey>());
+
+            //should still be one received calls
+            _redisDatabase.Received(1).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            counter.ShouldBe(1);
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+        }
+
+        #region Async
+
+        [Theory]
+        [InlineData("A", 42)]
+        [InlineData("B", 43)]
+        public async Task Simple_Get_Set_Test_Async(string cacheKey, int cacheValue)
+        {
+            var item = await _perRequestRedisCache.GetAsync(cacheKey, () => Task.FromResult(new MyCacheItem {Value = cacheValue}));
+
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+            _redisDatabase.StringGetAsync(Arg.Any<RedisKey>()).Returns(Task.FromResult(cachedObject));
+            await _redisDatabase.Received().StringGetAsync(Arg.Any<RedisKey>());
+
+            (await _perRequestRedisCache.GetOrDefaultAsync(cacheKey)).Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public async Task Should_Request_Once_For_Same_Context_Async()
+        {
+            _redisDatabase.ClearReceivedCalls();
+
+            string cacheKey = "Test";
+            int cacheValue = 1;
+
+            int counter = 0;
+
+            Task<MyCacheItem> GetCacheValue()
+            {
+                counter++;
+                return Task.FromResult(new MyCacheItem {Value = cacheValue});
+            }
+
+            var item = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue);
+            var item1 = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue);
+            var item2 = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue);
+
+            counter.ShouldBe(1);
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+
+            await _redisDatabase.Received(1).StringGetAsync(Arg.Any<RedisKey>());
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+            await _redisDatabase.Received(1).StringSetAsync(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            (await _perRequestRedisCache.GetOrDefaultAsync(cacheKey)).Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public async Task Should_Request_Again_For_Different_Contexts_Async()
+        {
+            _redisDatabase.ClearReceivedCalls();
+
+            string cacheKey = "Test";
+            int cacheValue = 1;
+
+            int counter = 0;
+
+            Task<MyCacheItem> GetCacheValue()
+            {
+                counter++;
+                return Task.FromResult(new MyCacheItem {Value = cacheValue});
+            }
+
+            _redisDatabase.StringSetAsync(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<TimeSpan>()).Returns(true);
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+
+            CurrentHttpContext = GetNewContextSubstitute();
+
+            var item = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue);
+            await _redisDatabase.Received(1).StringGetAsync(Arg.Any<RedisKey>());
+            await _redisDatabase.Received(1).StringSetAsync(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            _redisDatabase.StringGetAsync(Arg.Any<RedisKey>()).Returns(Task.FromResult(cachedObject));
+
+            CurrentHttpContext = GetNewContextSubstitute();
+            var item1 = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue);
+            await _redisDatabase.Received(2).StringGetAsync(Arg.Any<RedisKey>());
+
+            CurrentHttpContext = GetNewContextSubstitute();
+            var item2 = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue);
+            await _redisDatabase.Received(3).StringGetAsync(Arg.Any<RedisKey>());
+
+            //should still be one received calls
+            await _redisDatabase.Received(1).StringSetAsync(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            counter.ShouldBe(1);
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public async Task Should_Work_With_Null_Contexts_Async()
+        {
+            CurrentHttpContext = null;
+            _redisDatabase.ClearReceivedCalls();
+
+            string cacheKey = "Test";
+            int cacheValue = 1;
+
+            int counter = 0;
+
+            Task<MyCacheItem> GetCacheValue()
+            {
+                counter++;
+                return Task.FromResult(new MyCacheItem {Value = cacheValue});
+            }
+
+            _redisDatabase.StringSetAsync(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<TimeSpan>()).Returns(true);
+
+            var cachedObject = _redisSerializer.Serialize(new MyCacheItem {Value = cacheValue}, typeof(MyCacheItem));
+
+            var item = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue);
+            await _redisDatabase.Received(2).StringGetAsync(Arg.Any<RedisKey>());
+            await _redisDatabase.Received(1).StringSetAsync(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            _redisDatabase.StringGetAsync(Arg.Any<RedisKey>()).Returns(Task.FromResult(cachedObject));
+
+            var item1 = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue);
+            await _redisDatabase.Received(3).StringGetAsync(Arg.Any<RedisKey>()); //since CurrentHttpContext is null it should go to the redisdb again
+
+            var item2 = await _perRequestRedisCache.GetAsync(cacheKey, GetCacheValue); //since CurrentHttpContext is null it should go to the redisdb again
+            await _redisDatabase.Received(4).StringGetAsync(Arg.Any<RedisKey>());
+
+            //should still be one received calls
+            await _redisDatabase.Received(1).StringSetAsync(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            counter.ShouldBe(1);
+            item.ShouldNotBe(null);
+            item.Value.ShouldBe(cacheValue);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+        }
+
+        #endregion
+
+        [Serializable]
+        public class MyCacheItem
+        {
+            public int Value { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
It implements `IAbpPerRequestRedisCache` which stores redis caches per request. It is recomended to use it in cases that you know cache will never be changed until current context is done or it is not an important value. (for example some ui view settings etc.)

Let me give an example. Your application runs on 5 instances. You pulled the data from the redis at the beginning of a request. Then, at the end of the request, you pulled the same data from the redis. Since the active httpcontext does not changed, `IAbpPerRequestRedisCache` will bring you the data it already has without pulling it from redis. Since your application runs on 5 instances, your cache value might be changed in other instances. It increases the performance because it reduces the number of redis request, but it may cause data inconsistency. 

It should not be used if the changes on this data in one instance of the project can causes an error in the other instance of the project.
_______________
Its usage is exactly the same as the current cache implementation. Just use `IAbpPerRequestRedisCacheManager` instead of `ICacheManager`. The rest of the implementation is identical.

```csharp

ICache cache = Resolve<ICacheManager>().GetCache("MyCache");
ICache perRequestCache = Resolve<IAbpPerRequestRedisCacheManager>().GetCache("MyCache");


ITypedCache<string, MyCacheItem> cache = Resolve<ICacheManager>().GetCache<string, MyCacheItem>("MyTypedCache");
ITypedCache<string, MyCacheItem> perRequestCache = Resolve<IAbpPerRequestRedisCacheManager>().GetCache<string, MyCacheItem>("MyTypedCache");
```
_______________
close #5821