### PR TITLE
Implement caching mechanism for GetScripts

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Caching/GetScriptsResponsePerUserCacheMiddleware.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Caching/GetScriptsResponsePerUserCacheMiddleware.cs
@@ -6,6 +6,7 @@ namespace Abp.AspNetCore.Mvc.Caching
 {
     public class GetScriptsResponsePerUserCacheMiddleware
     {
+        internal static TimeSpan? MaxAge = TimeSpan.FromMinutes(30);
         private readonly RequestDelegate _next;
 
         public GetScriptsResponsePerUserCacheMiddleware(RequestDelegate next)
@@ -21,7 +22,7 @@ namespace Abp.AspNetCore.Mvc.Caching
                     new Microsoft.Net.Http.Headers.CacheControlHeaderValue()
                     {
                         Public = true,
-                        MaxAge = TimeSpan.FromMinutes(30),
+                        MaxAge = MaxAge,
                     };
             }
 

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Caching/GetScriptsResponsePerUserCacheMiddleware.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Caching/GetScriptsResponsePerUserCacheMiddleware.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Abp.AspNetCore.Mvc.Caching
+{
+    public class GetScriptsResponsePerUserCacheMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public GetScriptsResponsePerUserCacheMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            if (context.Request.Path == "/AbpScripts/GetScripts")
+            {
+                context.Response.GetTypedHeaders().CacheControl =
+                    new Microsoft.Net.Http.Headers.CacheControlHeaderValue()
+                    {
+                        Public = true,
+                        MaxAge = TimeSpan.FromMinutes(30),
+                    };
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Caching/GetScriptsResponsePerUserCacheMiddlewareExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Caching/GetScriptsResponsePerUserCacheMiddlewareExtensions.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace Abp.AspNetCore.Mvc.Caching
+{
+    public static class GetScriptsResponsePerUserCacheMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseGetScriptsResponsePerUserCache(
+            this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<GetScriptsResponsePerUserCacheMiddleware>();
+        }
+    }
+}

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Caching/GetScriptsResponsePerUserCacheMiddlewareExtensions.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Caching/GetScriptsResponsePerUserCacheMiddlewareExtensions.cs
@@ -1,12 +1,23 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System;
+using Microsoft.AspNetCore.Builder;
 
 namespace Abp.AspNetCore.Mvc.Caching
 {
     public static class GetScriptsResponsePerUserCacheMiddlewareExtensions
     {
+        /// <summary>
+        /// Implements GetScriptsResponsePerUserCacheMiddleware middleware with given maxAge
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="maxAge">Default is 30min</param>
         public static IApplicationBuilder UseGetScriptsResponsePerUserCache(
-            this IApplicationBuilder builder)
+            this IApplicationBuilder builder, TimeSpan? maxAge = null)
         {
+            if (maxAge != null)
+            {
+                GetScriptsResponsePerUserCacheMiddleware.MaxAge = maxAge;
+            }
+
             return builder.UseMiddleware<GetScriptsResponsePerUserCacheMiddleware>();
         }
     }

--- a/src/Abp.Zero.Common/Caching/GetScriptsResponsePerUserCache.cs
+++ b/src/Abp.Zero.Common/Caching/GetScriptsResponsePerUserCache.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+using Abp.Application.Services;
+using Abp.Runtime.Caching;
+using Abp.Runtime.Session;
+
+namespace Abp.Caching
+{
+    public class GetScriptsResponsePerUserCache : ApplicationService, IGetScriptsResponsePerUserCache
+    {
+        private const string GetScriptsResponsePerUserCacheKey = "GetScriptsResponsePerUserCache";
+        private readonly ITypedCache<string, string> _cache;
+
+        public GetScriptsResponsePerUserCache(ICacheManager cacheManager)
+        {
+            _cache = cacheManager.GetCache<string, string>(GetScriptsResponsePerUserCacheKey);
+        }
+
+        public async Task<string> GetKey()
+        {
+            if (!AbpSession.UserId.HasValue)
+            {
+                return Guid.NewGuid().ToString("N");
+            }
+
+            return await _cache.GetAsync(GetKeyString(),
+                () => Task.FromResult(Guid.NewGuid().ToString("N")));
+        }
+
+        public async Task RemoveKey()
+        {
+            if (!AbpSession.UserId.HasValue)
+            {
+                return;
+            }
+
+            await _cache.RemoveAsync(GetKeyString());
+        }
+
+        public async Task ClearAll()
+        {
+            await _cache.ClearAsync();
+        }
+
+        private string GetKeyString() => AbpSession.ToUserIdentifier().ToString();
+    }
+}

--- a/src/Abp.Zero.Common/Caching/GetScriptsResponsePerUserCacheInvalidator.cs
+++ b/src/Abp.Zero.Common/Caching/GetScriptsResponsePerUserCacheInvalidator.cs
@@ -1,0 +1,68 @@
+﻿using Abp.Authorization.Users;
+using Abp.Configuration;
+using Abp.Dependency;
+using Abp.Events.Bus.Entities;
+using Abp.Events.Bus.Handlers;
+using Abp.Localization;
+using Abp.Organizations;
+
+namespace Abp.Caching
+{
+    public class GetScriptsResponsePerUserCacheInvalidator :
+        IEventHandler<EntityChangedEventData<UserPermissionSetting>>,
+        IEventHandler<EntityChangedEventData<UserRole>>,
+        IEventHandler<EntityChangedEventData<UserOrganizationUnit>>,
+        IEventHandler<EntityDeletedEventData<AbpUserBase>>,
+        IEventHandler<EntityChangedEventData<OrganizationUnitRole>>,
+        IEventHandler<EntityChangedEventData<LanguageInfo>>,
+        IEventHandler<EntityChangedEventData<SettingInfo>>,
+        ITransientDependency
+    {
+        private readonly IGetScriptsResponsePerUserCache _getScriptsResponsePerUserCache;
+
+        public GetScriptsResponsePerUserCacheInvalidator(IGetScriptsResponsePerUserCache getScriptsResponsePerUserCache)
+        {
+            _getScriptsResponsePerUserCache = getScriptsResponsePerUserCache;
+        }
+
+        public void HandleEvent(EntityChangedEventData<UserPermissionSetting> eventData)
+        {
+            RemoveCache();
+        }
+
+        public void HandleEvent(EntityChangedEventData<UserRole> eventData)
+        {
+            RemoveCache();
+        }
+
+        public void HandleEvent(EntityChangedEventData<UserOrganizationUnit> eventData)
+        {
+            RemoveCache();
+        }
+
+        public void HandleEvent(EntityDeletedEventData<AbpUserBase> eventData)
+        {
+            RemoveCache();
+        }
+
+        public void HandleEvent(EntityChangedEventData<OrganizationUnitRole> eventData)
+        {
+            RemoveCache();
+        }
+
+        public void HandleEvent(EntityChangedEventData<LanguageInfo> eventData)
+        {
+            RemoveCache();
+        }
+
+        public void HandleEvent(EntityChangedEventData<SettingInfo> eventData)
+        {
+            _getScriptsResponsePerUserCache.ClearAll();
+        }
+
+        private void RemoveCache()
+        {
+            _getScriptsResponsePerUserCache.RemoveKey();
+        }
+    }
+}

--- a/src/Abp.Zero.Common/Caching/IGetScriptsResponsePerUserCache.cs
+++ b/src/Abp.Zero.Common/Caching/IGetScriptsResponsePerUserCache.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+
+namespace Abp.Caching
+{
+    public interface IGetScriptsResponsePerUserCache
+    {
+        Task<string> GetKey();
+
+        Task RemoveKey();
+
+        Task ClearAll();
+    }
+}


### PR DESCRIPTION
Related #3673 
It implements caching mechanism for GetScripts endpoint.
Example usage:

_Startup.cs_
```csharp
//...
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
        {
            app.UseGetScriptsResponsePerUserCache();
//...
```

__Layout.cshtml_
```csharp
@using Abp.Caching
@inject IGetScriptsResponsePerUserCache GetScriptsResponsePerUserCache
<!---...--->
<script src="@(ApplicationPath)AbpScripts/GetScripts?v=@(await GetScriptsResponsePerUserCache.GetKey())" type="text/javascript"></script>
<!---...--->
```

Then it will be cached on user's browser and cache will be expire when it is necessary