### PR TITLE
Allow to send webhook to multiple tenant

### DIFF
--- a/src/Abp.Zero.Common/Webhooks/WebhookSendAttemptStore.cs
+++ b/src/Abp.Zero.Common/Webhooks/WebhookSendAttemptStore.cs
@@ -115,7 +115,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public async Task<bool> HasXConsecutiveFailAsync(int? tenantId, Guid subscriptionId, int failCount)
+        public virtual async Task<bool> HasXConsecutiveFailAsync(int? tenantId, Guid subscriptionId, int failCount)
         {
             using (_unitOfWorkManager.Current.SetTenantId(tenantId))
             {
@@ -134,7 +134,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public bool HasXConsecutiveFail(int? tenantId, Guid subscriptionId, int failCount)
+        public virtual bool HasXConsecutiveFail(int? tenantId, Guid subscriptionId, int failCount)
         {
             using (_unitOfWorkManager.Current.SetTenantId(tenantId))
             {
@@ -152,7 +152,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public async Task<IPagedResult<WebhookSendAttempt>> GetAllSendAttemptsBySubscriptionAsPagedListAsync(int? tenantId, Guid subscriptionId, int maxResultCount, int skipCount)
+        public virtual async Task<IPagedResult<WebhookSendAttempt>> GetAllSendAttemptsBySubscriptionAsPagedListAsync(int? tenantId, Guid subscriptionId, int maxResultCount, int skipCount)
         {
             using (_unitOfWorkManager.Current.SetTenantId(tenantId))
             {
@@ -178,7 +178,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public IPagedResult<WebhookSendAttempt> GetAllSendAttemptsBySubscriptionAsPagedList(int? tenantId, Guid subscriptionId, int maxResultCount, int skipCount)
+        public virtual IPagedResult<WebhookSendAttempt> GetAllSendAttemptsBySubscriptionAsPagedList(int? tenantId, Guid subscriptionId, int maxResultCount, int skipCount)
         {
             using (_unitOfWorkManager.Current.SetTenantId(tenantId))
             {
@@ -204,7 +204,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public async Task<List<WebhookSendAttempt>> GetAllSendAttemptsByWebhookEventIdAsync(int? tenantId, Guid webhookEventId)
+        public virtual async Task<List<WebhookSendAttempt>> GetAllSendAttemptsByWebhookEventIdAsync(int? tenantId, Guid webhookEventId)
         {
             using (_unitOfWorkManager.Current.SetTenantId(tenantId))
             {
@@ -216,7 +216,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public List<WebhookSendAttempt> GetAllSendAttemptsByWebhookEventId(int? tenantId, Guid webhookEventId)
+        public virtual List<WebhookSendAttempt> GetAllSendAttemptsByWebhookEventId(int? tenantId, Guid webhookEventId)
         {
             using (_unitOfWorkManager.Current.SetTenantId(tenantId))
             {

--- a/src/Abp.Zero.Common/Webhooks/WebhookSubscriptionsStore.cs
+++ b/src/Abp.Zero.Common/Webhooks/WebhookSubscriptionsStore.cs
@@ -19,69 +19,105 @@ namespace Abp.Webhooks
 
         public WebhookSubscriptionsStore(
             IRepository<WebhookSubscriptionInfo, Guid> webhookSubscriptionRepository
-            )
+        )
         {
             _webhookSubscriptionRepository = webhookSubscriptionRepository;
 
             AsyncQueryableExecuter = NullAsyncQueryableExecuter.Instance;
         }
-        
+
         public virtual Task<WebhookSubscriptionInfo> GetAsync(Guid id)
         {
             return _webhookSubscriptionRepository.GetAsync(id);
         }
-        
+
         public virtual WebhookSubscriptionInfo Get(Guid id)
         {
             return _webhookSubscriptionRepository.Get(id);
         }
-        
+
         public virtual async Task InsertAsync(WebhookSubscriptionInfo webhookInfo)
         {
             await _webhookSubscriptionRepository.InsertAsync(webhookInfo);
         }
-        
+
         public virtual void Insert(WebhookSubscriptionInfo webhookInfo)
         {
             _webhookSubscriptionRepository.Insert(webhookInfo);
         }
-        
+
         public virtual async Task UpdateAsync(WebhookSubscriptionInfo webhookSubscription)
         {
             await _webhookSubscriptionRepository.UpdateAsync(webhookSubscription);
         }
-        
+
         public virtual void Update(WebhookSubscriptionInfo webhookSubscription)
         {
             _webhookSubscriptionRepository.Update(webhookSubscription);
         }
-        
+
         public virtual async Task DeleteAsync(Guid id)
         {
             await _webhookSubscriptionRepository.DeleteAsync(id);
         }
-        
+
         public virtual void Delete(Guid id)
         {
             _webhookSubscriptionRepository.Delete(id);
         }
-        
-        public virtual async Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsAsync(int? tenantId, string webhookDefinitionName)
+
+        public virtual Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsAsync(int? tenantId)
+        {
+            return _webhookSubscriptionRepository.GetAllListAsync(subscriptionInfo => subscriptionInfo.TenantId == tenantId);
+        }
+
+        public virtual List<WebhookSubscriptionInfo> GetAllSubscriptions(int? tenantId)
+        {
+            return _webhookSubscriptionRepository.GetAllList(subscriptionInfo => subscriptionInfo.TenantId == tenantId);
+        }
+
+        public virtual async Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsAsync(int? tenantId, string webhookName)
         {
             return await _webhookSubscriptionRepository.GetAllListAsync(subscriptionInfo =>
                 subscriptionInfo.TenantId == tenantId &&
                 subscriptionInfo.IsActive &&
-                subscriptionInfo.Webhooks.Contains("\"" + webhookDefinitionName + "\""));
+                subscriptionInfo.Webhooks.Contains("\"" + webhookName + "\""));
         }
-        
-        public virtual List<WebhookSubscriptionInfo> GetAllSubscriptions(int? tenantId, string webhookDefinitionName)
+
+        public virtual List<WebhookSubscriptionInfo> GetAllSubscriptions(int? tenantId, string webhookName)
         {
             return _webhookSubscriptionRepository.GetAllList(subscriptionInfo =>
-               subscriptionInfo.TenantId == tenantId &&
-               subscriptionInfo.IsActive &&
-               subscriptionInfo.Webhooks.Contains("\"" + webhookDefinitionName + "\""));
+                subscriptionInfo.TenantId == tenantId &&
+                subscriptionInfo.IsActive &&
+                subscriptionInfo.Webhooks.Contains("\"" + webhookName + "\""));
         }
-        
+
+        public virtual Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsOfTenantsAsync(int?[] tenantIds)
+        {
+            return _webhookSubscriptionRepository.GetAllListAsync(subscriptionInfo => tenantIds.Contains(subscriptionInfo.TenantId));
+        }
+
+        public virtual List<WebhookSubscriptionInfo> GetAllSubscriptionsOfTenants(int?[] tenantIds)
+        {
+            return _webhookSubscriptionRepository.GetAllList(subscriptionInfo => tenantIds.Contains(subscriptionInfo.TenantId));
+        }
+
+        public virtual async Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsOfTenantsAsync(int?[] tenantIds, string webhookName)
+        {
+            return await _webhookSubscriptionRepository.GetAllListAsync(subscriptionInfo =>
+                subscriptionInfo.IsActive &&
+                tenantIds.Contains(subscriptionInfo.TenantId) &&
+                subscriptionInfo.Webhooks.Contains("\"" + webhookName + "\""));
+        }
+
+        public virtual List<WebhookSubscriptionInfo> GetAllSubscriptionsOfTenants(int?[] tenantIds, string webhookName)
+        {
+            return _webhookSubscriptionRepository.GetAllList(subscriptionInfo =>
+                subscriptionInfo.IsActive &&
+                tenantIds.Contains(subscriptionInfo.TenantId) &&
+                subscriptionInfo.Webhooks.Contains("\"" + webhookName + "\""));
+        }
+
         public virtual Task<bool> IsSubscribedAsync(int? tenantId, string webhookName)
         {
             return AsyncQueryableExecuter.AnyAsync(_webhookSubscriptionRepository.GetAll()
@@ -91,7 +127,7 @@ namespace Abp.Webhooks
                     subscriptionInfo.Webhooks.Contains("\"" + webhookName + "\"")
                 ));
         }
-        
+
         public virtual bool IsSubscribed(int? tenantId, string webhookName)
         {
             return _webhookSubscriptionRepository.GetAll()
@@ -100,16 +136,6 @@ namespace Abp.Webhooks
                     subscriptionInfo.IsActive &&
                     subscriptionInfo.Webhooks.Contains("\"" + webhookName + "\"")
                 );
-        }
-        
-        public virtual Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsAsync(int? tenantId)
-        {
-            return _webhookSubscriptionRepository.GetAllListAsync(subscriptionInfo => subscriptionInfo.TenantId == tenantId);
-        }
-        
-        public virtual List<WebhookSubscriptionInfo> GetAllSubscriptions(int? tenantId)
-        {
-            return _webhookSubscriptionRepository.GetAllList(subscriptionInfo => subscriptionInfo.TenantId == tenantId);
         }
     }
 }

--- a/src/Abp/Webhooks/IWebhookPublisher.cs
+++ b/src/Abp/Webhooks/IWebhookPublisher.cs
@@ -62,5 +62,37 @@ namespace Abp.Webhooks
         /// </para>
         /// </param>
         void Publish(string webhookName, object data, int? tenantId, bool sendExactSameData = false);
+
+        /// <summary>
+        /// Sends webhooks to given tenant's subscriptions
+        /// </summary>
+        /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
+        /// <param name="data">data to send</param>
+        /// <param name="tenantIds">
+        /// Target tenant id(s)
+        /// </param>
+        /// <param name="sendExactSameData">
+        /// True: It sends the exact same data as the parameter to clients.
+        /// <para>
+        /// False: It sends data in <see cref="WebhookPayload"/>. It is recommended way.
+        /// </para>
+        /// </param>
+        Task PublishAsync(int?[] tenantIds, string webhookName, object data, bool sendExactSameData = false);
+
+        /// <summary>
+        /// Sends webhooks to given tenant's subscriptions
+        /// </summary>
+        /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
+        /// <param name="data">data to send</param>
+        /// <param name="tenantIds">
+        /// Target tenant id(s)
+        /// </param>
+        /// <param name="sendExactSameData">
+        /// True: It sends the exact same data as the parameter to clients.
+        /// <para>
+        /// False: It sends data in <see cref="WebhookPayload"/>. It is recommended way.
+        /// </para>
+        /// </param>
+        void Publish(int?[] tenantIds, string webhookName, object data, bool sendExactSameData = false);
     }
 }

--- a/src/Abp/Webhooks/IWebhookSubscriptionManager.cs
+++ b/src/Abp/Webhooks/IWebhookSubscriptionManager.cs
@@ -21,14 +21,16 @@ namespace Abp.Webhooks
         /// <summary>
         /// Returns all subscriptions of tenant
         /// </summary>
-        /// <returns></returns>
+        /// <param name="tenantId">
+        /// Target tenant id.
+        /// </param>
         Task<List<WebhookSubscription>> GetAllSubscriptionsAsync(int? tenantId);
 
         /// <summary>
         /// Returns all subscriptions of tenant
         /// </summary>
         /// <param name="tenantId">
-        /// Target tenant id(s).
+        /// Target tenant id.
         /// </param>
         List<WebhookSubscription> GetAllSubscriptions(int? tenantId);
 
@@ -37,7 +39,7 @@ namespace Abp.Webhooks
         /// </summary>
         /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
         /// <param name="tenantId">
-        /// Target tenant id(s).
+        /// Target tenant id.
         /// </param>
         Task<List<WebhookSubscription>> GetAllSubscriptionsIfFeaturesGrantedAsync(int? tenantId, string webhookName);
 
@@ -45,10 +47,42 @@ namespace Abp.Webhooks
         /// Returns all subscriptions for given webhook.
         /// </summary>
         /// <param name="tenantId">
-        /// Target tenant id(s).
+        /// Target tenant id.
         /// </param>
         /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
         List<WebhookSubscription> GetAllSubscriptionsIfFeaturesGranted(int? tenantId, string webhookName);
+
+        /// <summary>
+        /// Returns all subscriptions of tenant
+        /// </summary>
+        /// <returns></returns>
+        Task<List<WebhookSubscription>> GetAllSubscriptionsOfTenantsAsync(int?[] tenantIds);
+
+        /// <summary>
+        /// Returns all subscriptions of tenant
+        /// </summary>
+        /// <param name="tenantIds">
+        /// Target tenant id(s).
+        /// </param>
+        List<WebhookSubscription> GetAllSubscriptionsOfTenants(int?[] tenantIds);
+
+        /// <summary>
+        /// Returns all subscriptions for given webhook.
+        /// </summary>
+        /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
+        /// <param name="tenantIds">
+        /// Target tenant id(s).
+        /// </param>
+        Task<List<WebhookSubscription>> GetAllSubscriptionsOfTenantsIfFeaturesGrantedAsync(int?[] tenantIds, string webhookName);
+
+        /// <summary>
+        /// Returns all subscriptions for given webhook.
+        /// </summary>
+        /// <param name="tenantIds">
+        /// Target tenant id(s).
+        /// </param>
+        /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
+        List<WebhookSubscription> GetAllSubscriptionsOfTenantsIfFeaturesGranted(int?[] tenantIds, string webhookName);
 
         /// <summary>
         /// Checks if tenant subscribed for a webhook. (Checks if webhook features are granted)

--- a/src/Abp/Webhooks/IWebhookSubscriptionsStore.cs
+++ b/src/Abp/Webhooks/IWebhookSubscriptionsStore.cs
@@ -65,7 +65,7 @@ namespace Abp.Webhooks
         /// Returns all subscriptions of given tenant including deactivated 
         /// </summary>
         /// <param name="tenantId">
-        /// Target tenant id(s).
+        /// Target tenant id.
         /// </param>
         Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsAsync(int? tenantId);
 
@@ -73,7 +73,7 @@ namespace Abp.Webhooks
         /// Returns all subscriptions of given tenant including deactivated 
         /// </summary>
         /// <param name="tenantId">
-        /// Target tenant id(s).
+        /// Target tenant id.
         /// </param>
         List<WebhookSubscriptionInfo> GetAllSubscriptions(int? tenantId);
 
@@ -81,7 +81,7 @@ namespace Abp.Webhooks
         /// Returns webhook subscriptions which subscribe to given webhook on tenant(s)
         /// </summary>
         /// <param name="tenantId">
-        /// Target tenant id(s).
+        /// Target tenant id.
         /// </param>
         /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
         /// <returns></returns>
@@ -91,11 +91,48 @@ namespace Abp.Webhooks
         /// Returns webhook subscriptions which subscribe to given webhook on tenant(s)
         /// </summary>
         /// <param name="tenantId">
-        /// Target tenant id(s).
+        /// Target tenant id.
         /// </param>
         /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
         /// <returns></returns>
         List<WebhookSubscriptionInfo> GetAllSubscriptions(int? tenantId, string webhookName);
+        
+        /// <summary>
+        /// Returns all subscriptions of given tenant including deactivated 
+        /// </summary>
+        /// <param name="tenantIds">
+        /// Target tenant id(s).
+        /// </param>
+        Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsOfTenantsAsync(int?[] tenantIds);
+
+        /// <summary>
+        /// Returns all subscriptions of given tenant including deactivated 
+        /// </summary>
+        /// <param name="tenantIds">
+        /// Target tenant id(s).
+        /// </param>
+        List<WebhookSubscriptionInfo> GetAllSubscriptionsOfTenants(int?[] tenantIds);
+
+        /// <summary>
+        /// Returns webhook subscriptions which subscribe to given webhook on tenant(s)
+        /// </summary>
+        /// <param name="tenantIds">
+        /// Target tenant id(s).
+        /// </param>
+        /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
+        /// <returns></returns>
+        Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsOfTenantsAsync(int?[] tenantIds, string webhookName);
+
+        /// <summary>
+        /// Returns webhook subscriptions which subscribe to given webhook on tenant(s)
+        /// </summary>
+        /// <param name="tenantIds">
+        /// Target tenant id(s).
+        /// </param>
+        /// <param name="webhookName"><see cref="WebhookDefinition.Name"/></param>
+        /// <returns></returns>
+        List<WebhookSubscriptionInfo> GetAllSubscriptionsOfTenants(int?[] tenantIds, string webhookName);
+        
 
         /// <summary>
         /// Checks if tenant subscribed for a webhook

--- a/src/Abp/Webhooks/NullWebhookSubscriptionsStore.cs
+++ b/src/Abp/Webhooks/NullWebhookSubscriptionsStore.cs
@@ -69,6 +69,26 @@ namespace Abp.Webhooks
             return new List<WebhookSubscriptionInfo>();
         }
 
+        public Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsOfTenantsAsync(int?[] tenantIds)
+        {
+            return Task.FromResult(new List<WebhookSubscriptionInfo>());
+        }
+
+        public List<WebhookSubscriptionInfo> GetAllSubscriptionsOfTenants(int?[] tenantIds)
+        {
+            return new List<WebhookSubscriptionInfo>();
+        }
+
+        public Task<List<WebhookSubscriptionInfo>> GetAllSubscriptionsOfTenantsAsync(int?[] tenantIds, string webhookName)
+        {
+            return Task.FromResult(new List<WebhookSubscriptionInfo>());
+        }
+
+        public List<WebhookSubscriptionInfo> GetAllSubscriptionsOfTenants(int?[] tenantIds, string webhookName)
+        {
+            return new List<WebhookSubscriptionInfo>();
+        }
+
         public Task<bool> IsSubscribedAsync(int? tenantId, string webhookName)
         {
             return Task.FromResult(false);

--- a/src/Abp/Webhooks/WebhookSubscriptionInfo.cs
+++ b/src/Abp/Webhooks/WebhookSubscriptionInfo.cs
@@ -9,7 +9,7 @@ namespace Abp.Webhooks
 {
     [Table("AbpWebhookSubscriptions")]
     [MultiTenancySide(MultiTenancySides.Host)]
-    public class WebhookSubscriptionInfo : CreationAuditedEntity<Guid>, IPassivable, IMayHaveTenant
+    public class WebhookSubscriptionInfo : CreationAuditedEntity<Guid>, IPassivable
     {
         /// <summary>
         /// Subscribed Tenant's id .

--- a/src/Abp/Webhooks/WebhookSubscriptionManager.cs
+++ b/src/Abp/Webhooks/WebhookSubscriptionManager.cs
@@ -31,29 +31,29 @@ namespace Abp.Webhooks
             WebhookSubscriptionsStore = NullWebhookSubscriptionsStore.Instance;
         }
 
-        public async Task<WebhookSubscription> GetAsync(Guid id)
+        public virtual async Task<WebhookSubscription> GetAsync(Guid id)
         {
             return (await WebhookSubscriptionsStore.GetAsync(id)).ToWebhookSubscription();
         }
 
-        public WebhookSubscription Get(Guid id)
+        public virtual WebhookSubscription Get(Guid id)
         {
             return WebhookSubscriptionsStore.Get(id).ToWebhookSubscription();
         }
 
-        public async Task<List<WebhookSubscription>> GetAllSubscriptionsAsync(int? tenantId)
+        public virtual async Task<List<WebhookSubscription>> GetAllSubscriptionsAsync(int? tenantId)
         {
             return (await WebhookSubscriptionsStore.GetAllSubscriptionsAsync(tenantId))
                 .Select(subscriptionInfo => subscriptionInfo.ToWebhookSubscription()).ToList();
         }
 
-        public List<WebhookSubscription> GetAllSubscriptions(int? tenantId)
+        public virtual List<WebhookSubscription> GetAllSubscriptions(int? tenantId)
         {
             return WebhookSubscriptionsStore.GetAllSubscriptions(tenantId)
                 .Select(subscriptionInfo => subscriptionInfo.ToWebhookSubscription()).ToList();
         }
 
-        public async Task<List<WebhookSubscription>> GetAllSubscriptionsIfFeaturesGrantedAsync(int? tenantId, string webhookName)
+        public virtual async Task<List<WebhookSubscription>> GetAllSubscriptionsIfFeaturesGrantedAsync(int? tenantId, string webhookName)
         {
             if (!await _webhookDefinitionManager.IsAvailableAsync(tenantId, webhookName))
             {
@@ -64,7 +64,7 @@ namespace Abp.Webhooks
                 .Select(subscriptionInfo => subscriptionInfo.ToWebhookSubscription()).ToList();
         }
 
-        public List<WebhookSubscription> GetAllSubscriptionsIfFeaturesGranted(int? tenantId, string webhookName)
+        public virtual List<WebhookSubscription> GetAllSubscriptionsIfFeaturesGranted(int? tenantId, string webhookName)
         {
             if (!_webhookDefinitionManager.IsAvailable(tenantId, webhookName))
             {
@@ -75,7 +75,49 @@ namespace Abp.Webhooks
                 .Select(subscriptionInfo => subscriptionInfo.ToWebhookSubscription()).ToList();
         }
 
-        public async Task<bool> IsSubscribedAsync(int? tenantId, string webhookName)
+        public virtual async Task<List<WebhookSubscription>> GetAllSubscriptionsOfTenantsAsync(int?[] tenantIds)
+        {
+            return (await WebhookSubscriptionsStore.GetAllSubscriptionsOfTenantsAsync(tenantIds))
+                .Select(subscriptionInfo => subscriptionInfo.ToWebhookSubscription()).ToList();
+        }
+
+        public virtual List<WebhookSubscription> GetAllSubscriptionsOfTenants(int?[] tenantIds)
+        {
+            return WebhookSubscriptionsStore.GetAllSubscriptionsOfTenants(tenantIds)
+                .Select(subscriptionInfo => subscriptionInfo.ToWebhookSubscription()).ToList();
+        }
+
+        public virtual async Task<List<WebhookSubscription>> GetAllSubscriptionsOfTenantsIfFeaturesGrantedAsync(int?[] tenantIds, string webhookName)
+        {
+            var featureGrantedTenants = new List<int?>();
+            foreach (var tenantId in tenantIds)
+            {
+                if (await _webhookDefinitionManager.IsAvailableAsync(tenantId, webhookName))
+                {
+                    featureGrantedTenants.Add(tenantId);
+                }
+            }
+
+            return (await WebhookSubscriptionsStore.GetAllSubscriptionsOfTenantsAsync(featureGrantedTenants.ToArray(), webhookName))
+                .Select(subscriptionInfo => subscriptionInfo.ToWebhookSubscription()).ToList();
+        }
+
+        public virtual List<WebhookSubscription> GetAllSubscriptionsOfTenantsIfFeaturesGranted(int?[] tenantIds, string webhookName)
+        {
+            var featureGrantedTenants = new List<int?>();
+            foreach (var tenantId in tenantIds)
+            {
+                if (_webhookDefinitionManager.IsAvailable(tenantId, webhookName))
+                {
+                    featureGrantedTenants.Add(tenantId);
+                }
+            }
+
+            return WebhookSubscriptionsStore.GetAllSubscriptionsOfTenants(featureGrantedTenants.ToArray(), webhookName)
+                .Select(subscriptionInfo => subscriptionInfo.ToWebhookSubscription()).ToList();
+        }
+
+        public virtual async Task<bool> IsSubscribedAsync(int? tenantId, string webhookName)
         {
             if (!await _webhookDefinitionManager.IsAvailableAsync(tenantId, webhookName))
             {
@@ -85,7 +127,7 @@ namespace Abp.Webhooks
             return await WebhookSubscriptionsStore.IsSubscribedAsync(tenantId, webhookName);
         }
 
-        public bool IsSubscribed(int? tenantId, string webhookName)
+        public virtual bool IsSubscribed(int? tenantId, string webhookName)
         {
             if (!_webhookDefinitionManager.IsAvailable(tenantId, webhookName))
             {
@@ -96,7 +138,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public async Task AddOrUpdateSubscriptionAsync(WebhookSubscription webhookSubscription)
+        public virtual async Task AddOrUpdateSubscriptionAsync(WebhookSubscription webhookSubscription)
         {
             await CheckIfPermissionsGrantedAsync(webhookSubscription);
 
@@ -117,7 +159,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public void AddOrUpdateSubscription(WebhookSubscription webhookSubscription)
+        public virtual void AddOrUpdateSubscription(WebhookSubscription webhookSubscription)
         {
             CheckIfPermissionsGranted(webhookSubscription);
 
@@ -138,33 +180,33 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public async Task ActivateWebhookSubscriptionAsync(Guid id, bool active)
+        public virtual async Task ActivateWebhookSubscriptionAsync(Guid id, bool active)
         {
             var webhookSubscription = await WebhookSubscriptionsStore.GetAsync(id);
             webhookSubscription.IsActive = active;
         }
 
         [UnitOfWork]
-        public void ActivateWebhookSubscription(Guid id, bool active)
+        public virtual void ActivateWebhookSubscription(Guid id, bool active)
         {
             var webhookSubscription = WebhookSubscriptionsStore.Get(id);
             webhookSubscription.IsActive = active;
         }
 
         [UnitOfWork]
-        public Task DeleteSubscriptionAsync(Guid id)
+        public virtual Task DeleteSubscriptionAsync(Guid id)
         {
             return WebhookSubscriptionsStore.DeleteAsync(id);
         }
 
         [UnitOfWork]
-        public void DeleteSubscription(Guid id)
+        public virtual void DeleteSubscription(Guid id)
         {
             WebhookSubscriptionsStore.Delete(id);
         }
 
         [UnitOfWork]
-        public async Task AddWebhookAsync(WebhookSubscriptionInfo subscription, string webhookName)
+        public virtual async Task AddWebhookAsync(WebhookSubscriptionInfo subscription, string webhookName)
         {
             await CheckPermissionsAsync(subscription.TenantId, webhookName);
 
@@ -172,7 +214,7 @@ namespace Abp.Webhooks
         }
 
         [UnitOfWork]
-        public void AddWebhook(WebhookSubscriptionInfo subscription, string webhookName)
+        public virtual void AddWebhook(WebhookSubscriptionInfo subscription, string webhookName)
         {
             CheckPermissions(subscription.TenantId, webhookName);
 
@@ -181,7 +223,7 @@ namespace Abp.Webhooks
 
         #region PermissionCheck
 
-        private async Task CheckIfPermissionsGrantedAsync(WebhookSubscription webhookSubscription)
+        protected virtual async Task CheckIfPermissionsGrantedAsync(WebhookSubscription webhookSubscription)
         {
             if (webhookSubscription.Webhooks.IsNullOrEmpty())
             {
@@ -194,7 +236,7 @@ namespace Abp.Webhooks
             }
         }
 
-        private async Task CheckPermissionsAsync(int? tenantId, string webhookName)
+        protected virtual async Task CheckPermissionsAsync(int? tenantId, string webhookName)
         {
             if (!await _webhookDefinitionManager.IsAvailableAsync(tenantId, webhookName))
             {
@@ -202,7 +244,7 @@ namespace Abp.Webhooks
             }
         }
 
-        private void CheckIfPermissionsGranted(WebhookSubscription webhookSubscription)
+        protected virtual void CheckIfPermissionsGranted(WebhookSubscription webhookSubscription)
         {
             if (webhookSubscription.Webhooks.IsNullOrEmpty())
             {
@@ -215,7 +257,7 @@ namespace Abp.Webhooks
             }
         }
 
-        private void CheckPermissions(int? tenantId, string webhookName)
+        protected virtual void CheckPermissions(int? tenantId, string webhookName)
         {
             if (!_webhookDefinitionManager.IsAvailable(tenantId, webhookName))
             {

--- a/test/Abp.Zero.SampleApp.Tests/WebHooks/WebhookSubscriptionManager_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/WebHooks/WebhookSubscriptionManager_Tests.cs
@@ -527,8 +527,6 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             {
                 var allSubscriptions = await webhookSubscriptionManager.GetAllSubscriptionsAsync(null);
                 allSubscriptions.Count.ShouldBe(0);
-                
-                await Should.ThrowAsync<EntityNotFoundException>(async ()=> await webhookSubscriptionManager.GetAsync(newSubscription.Id));
             });
         }
 
@@ -1062,8 +1060,6 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             {
                 var allSubscriptions = webhookSubscriptionManager.GetAllSubscriptions(null);
                 allSubscriptions.Count.ShouldBe(0);
-
-                Should.Throw<EntityNotFoundException>(() => webhookSubscriptionManager.Get(newSubscription.Id));
             });
         }
 

--- a/test/Abp.Zero.SampleApp.Tests/Webhooks/WebhookPublisher_Tests.cs
+++ b/test/Abp.Zero.SampleApp.Tests/Webhooks/WebhookPublisher_Tests.cs
@@ -46,10 +46,10 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             var subscription = await CreateTenantAndSubscribeToWebhookAsync(webhookDefinition, tenantFeatures);
 
             AbpSession.TenantId = subscription.TenantId;
-            
+
             var webhooksConfiguration = Resolve<IWebhooksConfiguration>();
 
-            var data = new { Name = "Musa", Surname = "Demir" };
+            var data = new {Name = "Musa", Surname = "Demir"};
 
             Predicate<WebhookSenderArgs> predicate = w =>
             {
@@ -77,7 +77,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
         public async Task Should_Not_Send_Webhook_If_There_Is_No_Subscription_Async()
         {
             await CreateTenantAndSubscribeToWebhookAsync(AppWebhookDefinitionNames.Users.Created,
-               AppFeatures.WebhookFeature, "true");
+                AppFeatures.WebhookFeature, "true");
 
             AbpSession.TenantId = GetDefaultTenant().Id;
 
@@ -131,7 +131,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
 
             await AddOrReplaceFeatureToTenantAsync(subscription.TenantId.Value, AppFeatures.WebhookFeature, "false");
 
-            await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, new { Name = "Musa", Surname = "Demir" }, subscription.TenantId);
+            await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, new {Name = "Musa", Surname = "Demir"}, subscription.TenantId);
 
             //should not try to send
             await _backgroundJobManagerSubstitute.DidNotReceive().EnqueueAsync<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
@@ -147,7 +147,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
 
             await AddOrReplaceFeatureToTenantAsync(AbpSession.TenantId.Value, AppFeatures.WebhookFeature, "false");
 
-            await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, new { Name = "Musa", Surname = "Demir" });
+            await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, new {Name = "Musa", Surname = "Demir"});
 
             //should not try to send
             await _backgroundJobManagerSubstitute.DidNotReceive().EnqueueAsync<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
@@ -231,7 +231,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             //remove one feature
             await AddOrReplaceFeatureToTenantAsync(subscription.TenantId.Value, AppFeatures.WebhookFeature, "false");
 
-            await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, new { Name = "Musa", Surname = "Demir" }, subscription.TenantId);
+            await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, new {Name = "Musa", Surname = "Demir"}, subscription.TenantId);
 
             //should not try to send
             await _backgroundJobManagerSubstitute.DidNotReceive().EnqueueAsync<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
@@ -252,7 +252,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             await AddOrReplaceFeatureToTenantAsync(subscription.TenantId.Value, AppFeatures.WebhookFeature, "false");
 
             AbpSession.TenantId = subscription.TenantId;
-            await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, new { Name = "Musa", Surname = "Demir" });
+            await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, new {Name = "Musa", Surname = "Demir"});
 
             //should not try to send
             await _backgroundJobManagerSubstitute.DidNotReceive().EnqueueAsync<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
@@ -266,10 +266,10 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
                 TenantId = null,
                 Secret = "secret",
                 WebhookUri = "www.mywebhook.com",
-                Webhooks = new List<string>() { AppWebhookDefinitionNames.Users.Created },
+                Webhooks = new List<string>() {AppWebhookDefinitionNames.Users.Created},
                 Headers = new Dictionary<string, string>
                 {
-                    { "Key","Value"}
+                    {"Key", "Value"}
                 }
             };
 
@@ -278,7 +278,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
 
             await webhookSubscriptionManager.AddOrUpdateSubscriptionAsync(subscription);
 
-            var data = new { Name = "Musa", Surname = "Demir" };
+            var data = new {Name = "Musa", Surname = "Demir"};
 
             Predicate<WebhookSenderArgs> predicate = w =>
             {
@@ -337,13 +337,13 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
                     webhookSenderJob.Execute(args[0] as WebhookSenderArgs);
 
                     var sub = webhookSubscriptionManager.Get(subscription.Id);
-                    sub.IsActive.ShouldBeFalse();//after it get error MaxConsecutiveFailCountBeforeDeactivateSubscription times(in our case it is 1) subscription becomes deactivate
+                    sub.IsActive.ShouldBeFalse(); //after it get error MaxConsecutiveFailCountBeforeDeactivateSubscription times(in our case it is 1) subscription becomes deactivate
                 });
 
             await webhookSubscriptionManager.AddOrUpdateSubscriptionAsync(subscription);
 
             var storedSubscription = webhookSubscriptionManager.Get(subscription.Id);
-            storedSubscription.IsActive.ShouldBeTrue();//subscription is active 
+            storedSubscription.IsActive.ShouldBeTrue(); //subscription is active 
 
             await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Test, data, subscription.TenantId);
 
@@ -351,6 +351,130 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
                 .EnqueueAsync<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate(w)));
 
             webhookSenderSubstitute.Received().SendWebhook(Arg.Any<WebhookSenderArgs>());
+        }
+
+        [Fact]
+        public async Task Should_Send_Webhook_To_Subscribed_Tenants_Async()
+        {
+            var tenant1Subscription = await CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Users.Created,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            );
+
+            var tenant2Subscription = await CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Users.Created,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            );
+
+            var tenant3Subscription = await CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Test,
+                null
+            );
+
+            var webhooksConfiguration = Resolve<IWebhooksConfiguration>();
+
+            var data = new {Name = "Musa", Surname = "Demir"};
+
+            Predicate<WebhookSenderArgs> predicate = w =>
+            {
+                w.Secret.ShouldNotBeNullOrEmpty();
+                w.Secret.ShouldStartWith(WebhookSubscriptionSecretPrefix);
+                w.WebhookName.ShouldContain(AppWebhookDefinitionNames.Users.Created);
+
+                w.Headers.Count.ShouldBe(1);
+                w.Headers.Single().Key.ShouldBe("Key");
+                w.Headers.Single().Value.ShouldBe("Value");
+
+                var acceptedIds = new[] {tenant1Subscription.Id, tenant2Subscription.Id}; //since tenant 3 is not subscribed to that event, tenant3's subscription should not receive that event
+                acceptedIds.ShouldContain(w.WebhookSubscriptionId);
+
+                w.Data.ShouldBe(
+                    webhooksConfiguration.JsonSerializerSettings != null
+                        ? data.ToJsonString(webhooksConfiguration.JsonSerializerSettings)
+                        : data.ToJsonString()
+                );
+                return true;
+            };
+
+            //Even if we try to publish this webhook to tenant 3, it shouldn't get it since it has no subscription to that AppWebhookDefinitionNames.Users.Created
+            await _webhookPublisher.PublishAsync(new[]
+            {
+                tenant1Subscription.TenantId,
+                tenant2Subscription.TenantId,
+                tenant3Subscription.TenantId
+            }, AppWebhookDefinitionNames.Users.Created, data);
+
+            await _backgroundJobManagerSubstitute.Received(2)
+                .EnqueueAsync<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(p => predicate(p)));
+        }
+
+        [Fact]
+        public async Task Should_Send_Webhook_To_Only_Listed_Subscribed_Tenants_Async()
+        {
+            var tenant1Subscription = await CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Users.Created,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            );
+
+            var tenant2Subscription = await CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Users.Created,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            );
+
+            var tenant3Subscription = await CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Test,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            );
+
+            var webhooksConfiguration = Resolve<IWebhooksConfiguration>();
+
+            var data = new {Name = "Musa", Surname = "Demir"};
+
+            Predicate<WebhookSenderArgs> predicate = w =>
+            {
+                w.Secret.ShouldNotBeNullOrEmpty();
+                w.Secret.ShouldStartWith(WebhookSubscriptionSecretPrefix);
+                w.WebhookName.ShouldContain(AppWebhookDefinitionNames.Users.Created);
+
+                w.Headers.Count.ShouldBe(1);
+                w.Headers.Single().Key.ShouldBe("Key");
+                w.Headers.Single().Value.ShouldBe("Value");
+
+                var acceptedIds = new[] {tenant1Subscription.Id, tenant2Subscription.Id}; //since tenant 3 is not listed in publish function, tenant3's subscription should not receive that event
+                acceptedIds.ShouldContain(w.WebhookSubscriptionId);
+
+                w.Data.ShouldBe(
+                    webhooksConfiguration.JsonSerializerSettings != null
+                        ? data.ToJsonString(webhooksConfiguration.JsonSerializerSettings)
+                        : data.ToJsonString()
+                );
+                return true;
+            };
+
+            //only send to tenant1 and tenant2, not tenant3
+            await _webhookPublisher.PublishAsync(new[]
+            {
+                tenant1Subscription.TenantId,
+                tenant2Subscription.TenantId
+            }, AppWebhookDefinitionNames.Users.Created, data);
+
+            await _backgroundJobManagerSubstitute.Received(2)
+                .EnqueueAsync<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(p => predicate(p)));
         }
 
         #endregion
@@ -361,15 +485,15 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
         public void Should_Not_Send_Webhook_If_There_Is_Subscription_Sync()
         {
             AsyncHelper.RunSync(() => CreateTenantAndSubscribeToWebhookAsync(AppWebhookDefinitionNames.Users.Created,
-               AppFeatures.WebhookFeature, "true"));
+                AppFeatures.WebhookFeature, "true"));
 
             AbpSession.TenantId = GetDefaultTenant().Id;
             _webhookPublisher.Publish(AppWebhookDefinitionNames.Test,
-               new
-               {
-                   Name = "Musa",
-                   Surname = "Demir"
-               });
+                new
+                {
+                    Name = "Musa",
+                    Surname = "Demir"
+                });
 
             _backgroundJobManagerSubstitute.DidNotReceive().Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
         }
@@ -386,7 +510,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             _webhookPublisher.Publish(AppWebhookDefinitionNames.Users.Created, data, subscription.TenantId);
 
             _backgroundJobManagerSubstitute.Received()
-               .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate(w)));
+                .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate(w)));
         }
 
         [Fact]
@@ -414,7 +538,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
 
             AsyncHelper.RunSync(() => AddOrReplaceFeatureToTenantAsync(subscription.TenantId.Value, AppFeatures.WebhookFeature, "false"));
 
-            _webhookPublisher.Publish(AppWebhookDefinitionNames.Users.Created, new { Name = "Musa", Surname = "Demir" }, subscription.TenantId);
+            _webhookPublisher.Publish(AppWebhookDefinitionNames.Users.Created, new {Name = "Musa", Surname = "Demir"}, subscription.TenantId);
 
             //should not try to send
             _backgroundJobManagerSubstitute.DidNotReceive().Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
@@ -430,7 +554,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
 
             AbpSession.TenantId = subscription.TenantId;
 
-            _webhookPublisher.Publish(AppWebhookDefinitionNames.Users.Created, new { Name = "Musa", Surname = "Demir" });
+            _webhookPublisher.Publish(AppWebhookDefinitionNames.Users.Created, new {Name = "Musa", Surname = "Demir"});
 
             //should not try to send
             _backgroundJobManagerSubstitute.DidNotReceive().Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
@@ -465,7 +589,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             _webhookPublisher.Publish(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, data2, subscription2.TenantId);
 
             _backgroundJobManagerSubstitute.Received()
-               .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate2(w)));
+                .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate2(w)));
         }
 
         [Fact]
@@ -507,16 +631,16 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
         {
             //DefaultThemeChanged webhook requires AppFeatures.WebhookFeature, AppFeatures.ThemeFeature and requires all
             var subscription = AsyncHelper.RunSync(() => CreateTenantAndSubscribeToWebhookAsync(AppWebhookDefinitionNames.Theme.DefaultThemeChanged,
-               new Dictionary<string, string>
-               {
+                new Dictionary<string, string>
+                {
                     {AppFeatures.WebhookFeature, "true"},
                     {AppFeatures.ThemeFeature, "true"}
-               }));
+                }));
 
             //remove one feature
             AsyncHelper.RunSync(() => AddOrReplaceFeatureToTenantAsync(subscription.TenantId.Value, AppFeatures.WebhookFeature, "false"));
 
-            _webhookPublisher.Publish(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, new { Name = "Musa", Surname = "Demir" }, subscription.TenantId);
+            _webhookPublisher.Publish(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, new {Name = "Musa", Surname = "Demir"}, subscription.TenantId);
 
             //should not try to send
             _backgroundJobManagerSubstitute.DidNotReceive().Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
@@ -537,7 +661,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             //remove one feature
             AsyncHelper.RunSync(() => AddOrReplaceFeatureToTenantAsync(AbpSession.TenantId.Value, AppFeatures.WebhookFeature, "false"));
 
-            _webhookPublisher.Publish(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, new { Name = "Musa", Surname = "Demir" }, AbpSession.TenantId);
+            _webhookPublisher.Publish(AppWebhookDefinitionNames.Theme.DefaultThemeChanged, new {Name = "Musa", Surname = "Demir"}, AbpSession.TenantId);
 
             //should not try to send
             _backgroundJobManagerSubstitute.DidNotReceive().Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Any<WebhookSenderArgs>());
@@ -551,10 +675,10 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
                 TenantId = null,
                 Secret = "secret",
                 WebhookUri = "www.mywebhook.com",
-                Webhooks = new List<string>() { AppWebhookDefinitionNames.Users.Created },
+                Webhooks = new List<string>() {AppWebhookDefinitionNames.Users.Created},
                 Headers = new Dictionary<string, string>
                 {
-                    { "Key","Value"}
+                    {"Key", "Value"}
                 }
             };
 
@@ -563,7 +687,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
 
             webhookSubscriptionManager.AddOrUpdateSubscription(subscription);
 
-            var data = new { Name = "Musa", Surname = "Demir" };
+            var data = new {Name = "Musa", Surname = "Demir"};
 
             Predicate<WebhookSenderArgs> predicate = w =>
             {
@@ -587,7 +711,7 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
             _webhookPublisher.Publish(AppWebhookDefinitionNames.Users.Created, data, null);
 
             _backgroundJobManagerSubstitute.Received()
-               .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate(w)));
+                .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate(w)));
         }
 
         [Fact]
@@ -622,20 +746,144 @@ namespace Abp.Zero.SampleApp.Tests.Webhooks
                     webhookSenderJob.Execute(args[0] as WebhookSenderArgs);
 
                     var sub = webhookSubscriptionManager.Get(subscription.Id);
-                    sub.IsActive.ShouldBeFalse();//after it get error MaxConsecutiveFailCountBeforeDeactivateSubscription times(in our case it is 1) subscription becomes deactivate
+                    sub.IsActive.ShouldBeFalse(); //after it get error MaxConsecutiveFailCountBeforeDeactivateSubscription times(in our case it is 1) subscription becomes deactivate
                 });
 
             webhookSubscriptionManager.AddOrUpdateSubscription(subscription);
 
             var storedSubscription = webhookSubscriptionManager.Get(subscription.Id);
-            storedSubscription.IsActive.ShouldBeTrue();//subscription is active 
+            storedSubscription.IsActive.ShouldBeTrue(); //subscription is active 
 
             _webhookPublisher.Publish(AppWebhookDefinitionNames.Test, data, subscription.TenantId);
 
             _backgroundJobManagerSubstitute.Received()
-               .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate(w)));
+                .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(w => predicate(w)));
 
             webhookSenderSubstitute.Received().SendWebhook(Arg.Any<WebhookSenderArgs>());
+        }
+
+        [Fact]
+        public void Should_Send_Webhook_To_Subscribed_Tenants()
+        {
+            var tenant1Subscription = AsyncHelper.RunSync(() => CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Users.Created,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            ));
+
+            var tenant2Subscription = AsyncHelper.RunSync(() => CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Users.Created,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            ));
+
+            var tenant3Subscription = AsyncHelper.RunSync(() => CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Test,
+                null
+            ));
+
+            var webhooksConfiguration = Resolve<IWebhooksConfiguration>();
+
+            var data = new {Name = "Musa", Surname = "Demir"};
+
+            Predicate<WebhookSenderArgs> predicate = w =>
+            {
+                w.Secret.ShouldNotBeNullOrEmpty();
+                w.Secret.ShouldStartWith(WebhookSubscriptionSecretPrefix);
+                w.WebhookName.ShouldContain(AppWebhookDefinitionNames.Users.Created);
+
+                w.Headers.Count.ShouldBe(1);
+                w.Headers.Single().Key.ShouldBe("Key");
+                w.Headers.Single().Value.ShouldBe("Value");
+
+                var acceptedIds = new[] {tenant1Subscription.Id, tenant2Subscription.Id}; //since tenant 3 is not subscribed to that event, tenant3's subscription should not receive that event
+                acceptedIds.ShouldContain(w.WebhookSubscriptionId);
+
+                w.Data.ShouldBe(
+                    webhooksConfiguration.JsonSerializerSettings != null
+                        ? data.ToJsonString(webhooksConfiguration.JsonSerializerSettings)
+                        : data.ToJsonString()
+                );
+                return true;
+            };
+
+            //Even if we try to publish this webhook to tenant 3, it shouldn't get it since it has no subscription to that AppWebhookDefinitionNames.Users.Created
+            _webhookPublisher.Publish(new[]
+            {
+                tenant1Subscription.TenantId,
+                tenant2Subscription.TenantId,
+                tenant3Subscription.TenantId
+            }, AppWebhookDefinitionNames.Users.Created, data);
+
+            _backgroundJobManagerSubstitute.Received(2)
+                .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(p => predicate(p)));
+        }
+
+        [Fact]
+        public void Should_Send_Webhook_To_Only_Listed_Subscribed_Tenants()
+        {
+            var tenant1Subscription = AsyncHelper.RunSync(() => CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Users.Created,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            ));
+
+            var tenant2Subscription = AsyncHelper.RunSync(() => CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Users.Created,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            ));
+
+            var tenant3Subscription = AsyncHelper.RunSync(() => CreateTenantAndSubscribeToWebhookAsync(
+                AppWebhookDefinitionNames.Test,
+                new Dictionary<string, string>
+                {
+                    {AppFeatures.WebhookFeature, "true"}
+                }
+            ));
+
+            var webhooksConfiguration = Resolve<IWebhooksConfiguration>();
+
+            var data = new {Name = "Musa", Surname = "Demir"};
+
+            Predicate<WebhookSenderArgs> predicate = w =>
+            {
+                w.Secret.ShouldNotBeNullOrEmpty();
+                w.Secret.ShouldStartWith(WebhookSubscriptionSecretPrefix);
+                w.WebhookName.ShouldContain(AppWebhookDefinitionNames.Users.Created);
+
+                w.Headers.Count.ShouldBe(1);
+                w.Headers.Single().Key.ShouldBe("Key");
+                w.Headers.Single().Value.ShouldBe("Value");
+
+                var acceptedIds = new[] {tenant1Subscription.Id, tenant2Subscription.Id}; //since tenant 3 is not listed in publish function, tenant3's subscription should not receive that event
+                acceptedIds.ShouldContain(w.WebhookSubscriptionId);
+
+                w.Data.ShouldBe(
+                    webhooksConfiguration.JsonSerializerSettings != null
+                        ? data.ToJsonString(webhooksConfiguration.JsonSerializerSettings)
+                        : data.ToJsonString()
+                );
+                return true;
+            };
+
+            //only send to tenant1 and tenant2, not tenant3
+            _webhookPublisher.Publish(new[]
+            {
+                tenant1Subscription.TenantId,
+                tenant2Subscription.TenantId
+            }, AppWebhookDefinitionNames.Users.Created, data);
+
+            _backgroundJobManagerSubstitute.Received(2)
+                .Enqueue<WebhookSenderJob, WebhookSenderArgs>(Arg.Is<WebhookSenderArgs>(p => predicate(p)));
         }
 
         #endregion


### PR DESCRIPTION
close https://github.com/aspnetboilerplate/aspnetboilerplate/issues/6013

Now you can publish webhook to multiple tenants

```csharp
IWebhookPublisher _webhookPublisher;
//...

var data = new {text= "text"};

_webhookPublisher.Publish(new[]
{
    tenant1Id,
    tenant2Id
}, "WebhookName", data);
```