### PR TITLE
Fix abp.localization.values typing

### DIFF
--- a/src/Abp.Web.Resources/Abp/Framework/scripts/abp.d.ts
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/abp.d.ts
@@ -78,7 +78,7 @@
 
         let defaultSourceName: string;
 
-        let values: { [key: string]: string };
+        let values: { [key: string]: { [key: string]: string } };
 
         let abpWeb: (key: string) => string;
 


### PR DESCRIPTION
`AbpUserLocalizationConfigDto.Values`' type is `Dictionary<string, Dictionary<string, string>>`, not `Dictionary<string, string>`.

Resolves #6021 