### PR TITLE
Handle lazy loading proxies for Entity History

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -9,6 +9,7 @@ using Abp.EntityHistory.Extensions;
 using Abp.Events.Bus.Entities;
 using Abp.Extensions;
 using Abp.Json;
+using Abp.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -49,7 +50,7 @@ namespace Abp.EntityHistory
 
             foreach (var entityEntry in entityEntries)
             {
-                var typeOfEntity = entityEntry.Entity.GetType();
+                var typeOfEntity = ProxyHelper.GetUnproxiedType(entityEntry.Entity);
                 var shouldTrackEntity = IsTypeOfTrackedEntity(typeOfEntity);
                 if (shouldTrackEntity.HasValue && !shouldTrackEntity.Value)
                 {
@@ -165,7 +166,7 @@ namespace Abp.EntityHistory
         private EntityChange CreateEntityChange(EntityEntry entityEntry)
         {
             var entityId = GetEntityId(entityEntry);
-            var entityTypeFullName = entityEntry.Entity.GetType().FullName;
+            var entityTypeFullName = ProxyHelper.GetUnproxiedType(entityEntry.Entity).FullName;
             EntityChangeType changeType;
             switch (entityEntry.State)
             {
@@ -210,7 +211,6 @@ namespace Abp.EntityHistory
         {
             var propertyChanges = new List<EntityPropertyChange>();
             var properties = entityEntry.Metadata.GetProperties();
-            var entityEntryType = entityEntry.Entity.GetType();
 
             foreach (var property in properties)
             {
@@ -248,7 +248,7 @@ namespace Abp.EntityHistory
             foreach (var entityChange in changeSet.EntityChanges)
             {
                 var entityEntry = entityChange.EntityEntry.As<EntityEntry>();
-                var entityEntryType = entityEntry.Entity.GetType();
+                var entityEntryType = ProxyHelper.GetUnproxiedType(entityEntry.Entity);
                 var isAuditedEntity = IsTypeOfAuditedEntity(entityEntryType) == true;
 
                 /* Update change time */

--- a/src/Abp/Reflection/ProxyHelper.cs
+++ b/src/Abp/Reflection/ProxyHelper.cs
@@ -1,5 +1,4 @@
-﻿using Abp.Extensions;
-using Castle.DynamicProxy;
+﻿using Castle.DynamicProxy;
 using System;
 
 namespace Abp.Reflection

--- a/src/Abp/Reflection/ProxyHelper.cs
+++ b/src/Abp/Reflection/ProxyHelper.cs
@@ -1,4 +1,6 @@
-﻿using Castle.DynamicProxy;
+﻿using Abp.Extensions;
+using Castle.DynamicProxy;
+using System;
 
 namespace Abp.Reflection
 {
@@ -10,6 +12,14 @@ namespace Abp.Reflection
         public static object UnProxy(object obj)
         {
             return ProxyUtil.GetUnproxiedInstance(obj);
+        }
+
+        /// <summary>
+        /// Returns the type of the dynamic proxy target object if this is a proxied object, otherwise returns the type of the given object.
+        /// </summary>
+        public static Type GetUnproxiedType(object obj)
+        {
+            return ProxyUtil.GetUnproxiedType(obj);
         }
     }
 }


### PR DESCRIPTION
Resolves #5996 

Tested locally by adding `builder.UseLazyLoadingProxies();` in `TestServiceCollectionRegistrar.RegisterSqliteInMemoryDb`:
- affects all tests in `Abp.ZeroCore.Tests` so I didn't push; also we want non-`UseLazyLoadingProxies` to test for regression.
- results in multiple occurrences of fixable error `System.InvalidOperationException : Property 'Blog.Posts' is not virtual. 'UseChangeTrackingProxies' requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. 'UseLazyLoadingProxies' requires only the navigation properties be virtual.`
  - `Blog.Posts`
  - `Comment.Post`
  - `Post.Blog`
  - `Order.Translations`, `Order.Products`