### PR TITLE
Add commandType parameter to Dapper's Execute methods

### DIFF
--- a/src/Abp.Dapper/Dapper/Repositories/AbpDapperRepositoryBase.cs
+++ b/src/Abp.Dapper/Dapper/Repositories/AbpDapperRepositoryBase.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-
-using Abp.Dependency;
 using Abp.Domain.Entities;
-using Abp.Domain.Uow;
 using Abp.MultiTenancy;
 using Abp.Reflection.Extensions;
 
@@ -59,11 +57,11 @@ namespace Abp.Dapper.Repositories
             return Task.FromResult(Query<TAny>(query, parameters));
         }
 
-        public abstract int Execute(string query, object parameters = null);
+        public abstract int Execute(string query, object parameters = null, CommandType? commandType = null);
 
-        public virtual Task<int> ExecuteAsync(string query, object parameters = null)
+        public virtual Task<int> ExecuteAsync(string query, object parameters = null, CommandType? commandType = null)
         {
-            return Task.FromResult(Execute(query, parameters));
+            return Task.FromResult(Execute(query, parameters, commandType));
         }
 
         public abstract IEnumerable<TEntity> GetAll(Expression<Func<TEntity, bool>> predicate);

--- a/src/Abp.Dapper/Dapper/Repositories/DapperRepositoryBaseOfTEntityAndTPrimaryKey.cs
+++ b/src/Abp.Dapper/Dapper/Repositories/DapperRepositoryBaseOfTEntityAndTPrimaryKey.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-
 using Abp.Dapper.Extensions;
 using Abp.Dapper.Filters.Action;
 using Abp.Dapper.Filters.Query;
@@ -12,9 +12,7 @@ using Abp.Data;
 using Abp.Domain.Entities;
 using Abp.Domain.Uow;
 using Abp.Events.Bus.Entities;
-
 using Dapper;
-
 using DapperExtensions;
 
 namespace Abp.Dapper.Repositories
@@ -23,7 +21,7 @@ namespace Abp.Dapper.Repositories
         where TEntity : class, IEntity<TPrimaryKey>
     {
         private readonly IActiveTransactionProvider _activeTransactionProvider;
-        
+
         public DapperRepositoryBase(IActiveTransactionProvider activeTransactionProvider)
         {
             _activeTransactionProvider = activeTransactionProvider;
@@ -41,14 +39,15 @@ namespace Abp.Dapper.Repositories
 
         public virtual DbConnection GetConnection()
         {
-            var connection = _activeTransactionProvider.GetActiveConnection(ActiveTransactionProviderArgs.Empty); 
-            return (DbConnection)connection;
+            var connection = _activeTransactionProvider.GetActiveConnection(ActiveTransactionProviderArgs.Empty);
+            return (DbConnection) connection;
         }
-        
+
         public virtual async Task<DbConnection> GetConnectionAsync()
         {
-            var connection = await _activeTransactionProvider.GetActiveConnectionAsync(ActiveTransactionProviderArgs.Empty); 
-            return (DbConnection)connection;
+            var connection =
+                await _activeTransactionProvider.GetActiveConnectionAsync(ActiveTransactionProviderArgs.Empty);
+            return (DbConnection) connection;
         }
 
         /// <summary>
@@ -60,14 +59,15 @@ namespace Abp.Dapper.Repositories
         /// </value>
         public virtual async Task<DbTransaction> GetActiveTransactionAsync()
         {
-            var connection = await _activeTransactionProvider.GetActiveTransactionAsync(ActiveTransactionProviderArgs.Empty);
-            return (DbTransaction)connection;
+            var connection =
+                await _activeTransactionProvider.GetActiveTransactionAsync(ActiveTransactionProviderArgs.Empty);
+            return (DbTransaction) connection;
         }
-        
+
         public virtual DbTransaction GetActiveTransaction()
         {
             var connection = _activeTransactionProvider.GetActiveTransaction(ActiveTransactionProviderArgs.Empty);
-            return (DbTransaction)connection;
+            return (DbTransaction) connection;
         }
 
         public virtual int? Timeout => null;
@@ -80,7 +80,8 @@ namespace Abp.Dapper.Repositories
         public override TEntity Single(Expression<Func<TEntity, bool>> predicate)
         {
             IPredicate pg = DapperQueryFilterExecuter.ExecuteFilter<TEntity, TPrimaryKey>(predicate);
-            return GetConnection().GetList<TEntity>(pg, transaction: GetActiveTransaction(), commandTimeout: Timeout).Single();
+            return GetConnection().GetList<TEntity>(pg, transaction: GetActiveTransaction(), commandTimeout: Timeout)
+                .Single();
         }
 
         public override TEntity FirstOrDefault(TPrimaryKey id)
@@ -91,13 +92,17 @@ namespace Abp.Dapper.Repositories
         public override TEntity FirstOrDefault(Expression<Func<TEntity, bool>> predicate)
         {
             IPredicate pg = DapperQueryFilterExecuter.ExecuteFilter<TEntity, TPrimaryKey>(predicate);
-            return GetConnection().GetList<TEntity>(pg, transaction: GetActiveTransaction(), commandTimeout: Timeout).FirstOrDefault();
+            return GetConnection().GetList<TEntity>(pg, transaction: GetActiveTransaction(), commandTimeout: Timeout)
+                .FirstOrDefault();
         }
 
         public override TEntity Get(TPrimaryKey id)
         {
             TEntity item = FirstOrDefault(id);
-            if (item == null) { throw new EntityNotFoundException(typeof(TEntity), id); }
+            if (item == null)
+            {
+                throw new EntityNotFoundException(typeof(TEntity), id);
+            }
 
             return item;
         }
@@ -105,7 +110,8 @@ namespace Abp.Dapper.Repositories
         public override IEnumerable<TEntity> GetAll()
         {
             PredicateGroup predicateGroup = DapperQueryFilterExecuter.ExecuteFilter<TEntity, TPrimaryKey>();
-            return GetConnection().GetList<TEntity>(predicateGroup, transaction: GetActiveTransaction(), commandTimeout: Timeout);
+            return GetConnection().GetList<TEntity>(predicateGroup, transaction: GetActiveTransaction(),
+                commandTimeout: Timeout);
         }
 
         public override IEnumerable<TEntity> Query(string query, object parameters = null)
@@ -132,28 +138,29 @@ namespace Abp.Dapper.Repositories
             return await connection.QueryAsync<TAny>(query, parameters, activeTransaction, Timeout);
         }
 
-        public override int Execute(string query, object parameters = null)
+        public override int Execute(string query, object parameters = null, CommandType? commandType = null)
         {
-            return GetConnection().Execute(query, parameters, GetActiveTransaction(), Timeout);
+            return GetConnection().Execute(query, parameters, GetActiveTransaction(), Timeout, commandType);
         }
 
-        public override async Task<int> ExecuteAsync(string query, object parameters = null)
+        public override async Task<int> ExecuteAsync(string query, object parameters = null, CommandType? commandType = null)
         {
             var connection = await GetConnectionAsync();
             var activeTransaction = await GetActiveTransactionAsync();
-            return await connection.ExecuteAsync(query, parameters, activeTransaction, Timeout);
+            return await connection.ExecuteAsync(query, parameters, activeTransaction, Timeout, commandType);
         }
 
-        public override IEnumerable<TEntity> GetAllPaged(Expression<Func<TEntity, bool>> predicate, int pageNumber, int itemsPerPage, string sortingProperty, bool ascending = true)
+        public override IEnumerable<TEntity> GetAllPaged(Expression<Func<TEntity, bool>> predicate, int pageNumber,
+            int itemsPerPage, string sortingProperty, bool ascending = true)
         {
             IPredicate filteredPredicate = DapperQueryFilterExecuter.ExecuteFilter<TEntity, TPrimaryKey>(predicate);
 
             return GetConnection().GetPage<TEntity>(
                 filteredPredicate,
-                new List<ISort> { new Sort { Ascending = ascending, PropertyName = sortingProperty } },
+                new List<ISort> {new Sort {Ascending = ascending, PropertyName = sortingProperty}},
                 pageNumber,
                 itemsPerPage,
-                GetActiveTransaction(), 
+                GetActiveTransaction(),
                 Timeout);
         }
 
@@ -163,15 +170,16 @@ namespace Abp.Dapper.Repositories
             return GetConnection().Count<TEntity>(filteredPredicate, GetActiveTransaction(), Timeout);
         }
 
-        public override IEnumerable<TEntity> GetSet(Expression<Func<TEntity, bool>> predicate, int firstResult, int maxResults, string sortingProperty, bool ascending = true)
+        public override IEnumerable<TEntity> GetSet(Expression<Func<TEntity, bool>> predicate, int firstResult,
+            int maxResults, string sortingProperty, bool ascending = true)
         {
             IPredicate filteredPredicate = DapperQueryFilterExecuter.ExecuteFilter<TEntity, TPrimaryKey>(predicate);
             return GetConnection().GetSet<TEntity>(
                 filteredPredicate,
-                new List<ISort> { new Sort { Ascending = ascending, PropertyName = sortingProperty } },
+                new List<ISort> {new Sort {Ascending = ascending, PropertyName = sortingProperty}},
                 firstResult,
                 maxResults,
-                GetActiveTransaction(),  
+                GetActiveTransaction(),
                 Timeout
             );
         }
@@ -179,19 +187,24 @@ namespace Abp.Dapper.Repositories
         public override IEnumerable<TEntity> GetAll(Expression<Func<TEntity, bool>> predicate)
         {
             IPredicate filteredPredicate = DapperQueryFilterExecuter.ExecuteFilter<TEntity, TPrimaryKey>(predicate);
-            return GetConnection().GetList<TEntity>(filteredPredicate, transaction: GetActiveTransaction(), commandTimeout: Timeout);
+            return GetConnection().GetList<TEntity>(filteredPredicate, transaction: GetActiveTransaction(),
+                commandTimeout: Timeout);
         }
 
-        public override IEnumerable<TEntity> GetAllPaged(Expression<Func<TEntity, bool>> predicate, int pageNumber, int itemsPerPage, bool ascending = true, params Expression<Func<TEntity, object>>[] sortingExpression)
+        public override IEnumerable<TEntity> GetAllPaged(Expression<Func<TEntity, bool>> predicate, int pageNumber,
+            int itemsPerPage, bool ascending = true, params Expression<Func<TEntity, object>>[] sortingExpression)
         {
             IPredicate filteredPredicate = DapperQueryFilterExecuter.ExecuteFilter<TEntity, TPrimaryKey>(predicate);
-            return GetConnection().GetPage<TEntity>(filteredPredicate, sortingExpression.ToSortable(ascending), pageNumber, itemsPerPage, GetActiveTransaction(), Timeout);
+            return GetConnection().GetPage<TEntity>(filteredPredicate, sortingExpression.ToSortable(ascending),
+                pageNumber, itemsPerPage, GetActiveTransaction(), Timeout);
         }
 
-        public override IEnumerable<TEntity> GetSet(Expression<Func<TEntity, bool>> predicate, int firstResult, int maxResults, bool ascending = true, params Expression<Func<TEntity, object>>[] sortingExpression)
+        public override IEnumerable<TEntity> GetSet(Expression<Func<TEntity, bool>> predicate, int firstResult,
+            int maxResults, bool ascending = true, params Expression<Func<TEntity, object>>[] sortingExpression)
         {
             IPredicate filteredPredicate = DapperQueryFilterExecuter.ExecuteFilter<TEntity, TPrimaryKey>(predicate);
-            return GetConnection().GetSet<TEntity>(filteredPredicate, sortingExpression.ToSortable(ascending), firstResult, maxResults, GetActiveTransaction(), Timeout);
+            return GetConnection().GetSet<TEntity>(filteredPredicate, sortingExpression.ToSortable(ascending),
+                firstResult, maxResults, GetActiveTransaction(), Timeout);
         }
 
         public override void Insert(TEntity entity)
@@ -219,6 +232,7 @@ namespace Abp.Dapper.Repositories
             {
                 GetConnection().Delete(entity, GetActiveTransaction(), Timeout);
             }
+
             EntityChangeEventHelper.TriggerEntityDeletedEventOnUowCompleted(entity);
         }
 

--- a/src/Abp.Dapper/Dapper/Repositories/IDapperRepositoryOfTEntityAndTPrimaryKey.cs
+++ b/src/Abp.Dapper/Dapper/Repositories/IDapperRepositoryOfTEntityAndTPrimaryKey.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 
@@ -231,15 +232,17 @@ namespace Abp.Dapper.Repositories
         /// </summary>
         /// <param name="query">The query.</param>
         /// <param name="parameters">The parameters.</param>
+        /// <param name="commandType">Command type.</param>
         /// <returns></returns>
-        int Execute([NotNull] string query, [CanBeNull] object parameters = null);
+        int Execute([NotNull] string query, [CanBeNull] object parameters = null, CommandType? commandType = null);
 
         /// <summary>
         ///     Executes as async the given query text
         /// </summary>
         /// <param name="query"></param>
         /// <param name="parameters"></param>
-        Task<int> ExecuteAsync([NotNull] string query, [CanBeNull] object parameters = null);
+        /// <param name="commandType">Command type.</param>
+        Task<int> ExecuteAsync([NotNull] string query, [CanBeNull] object parameters = null, CommandType? commandType = null);
 
         /// <summary>
         ///     Gets the set.

--- a/test/Abp.EntityFrameworkCore.Dapper.Tests/Tests/Repository_Tests.cs
+++ b/test/Abp.EntityFrameworkCore.Dapper.Tests/Tests/Repository_Tests.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Abp.Dapper.Repositories;
 using Abp.Domain.Repositories;
 using Abp.Domain.Uow;
 using Abp.EntityFrameworkCore.Dapper.Tests.Domain;
-
 using Microsoft.EntityFrameworkCore;
-
 using Shouldly;
-
 using Xunit;
 
 namespace Abp.EntityFrameworkCore.Dapper.Tests.Tests
@@ -212,12 +209,24 @@ namespace Abp.EntityFrameworkCore.Dapper.Tests.Tests
             }
         }
 
-        [Fact]
-        public async Task execute_method_for_void_sqls_should_work()
+        [Theory]
+        [InlineData(null)]
+        [InlineData(CommandType.Text)]
+        public async Task execute_method_for_void_sqls_should_work(CommandType? commandType)
         {
-            int blogId = await _blogDapperRepository.InsertAndGetIdAsync(new Blog("Oguzhan_Blog", "wwww.aspnetboilerplate.com"));
+            int blogId = await _blogDapperRepository.InsertAndGetIdAsync(
+                new Blog("Oguzhan_Blog", "wwww.aspnetboilerplate.com")
+            );
 
-            await _blogDapperRepository.ExecuteAsync("Update Blogs Set Name = @name where Id =@id", new { id = blogId, name = "Oguzhan_New_Blog" });
+            await _blogDapperRepository.ExecuteAsync(
+                "Update Blogs Set Name = @name where Id =@id",
+                new
+                {
+                    id = blogId,
+                    name = "Oguzhan_New_Blog"
+                },
+                commandType
+            );
 
             (await _blogDapperRepository.GetAsync(blogId)).Name.ShouldBe("Oguzhan_New_Blog");
             (await _blogRepository.GetAsync(blogId)).Name.ShouldBe("Oguzhan_New_Blog");


### PR DESCRIPTION
So, stored procedures can be used with Dapper as well. I couldn't test `CommandType.StoredProcedure` becasue we are using SQLite in unit tests and it doesn't support stored procedures.

Resolves #5992