### PR TITLE
Fix loss of permissions when Application Pool is recycled

### DIFF
--- a/test/Abp.Tests/Authorization/PermissionDefinitionTests.cs
+++ b/test/Abp.Tests/Authorization/PermissionDefinitionTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Abp.Application.Features;
 using Abp.Authorization;
@@ -27,10 +27,11 @@ namespace Abp.Tests.Authorization
                 Component.For<MyAuthorizationProvider2>().LifestyleTransient(),
                 Component.For<IUnitOfWorkManager, UnitOfWorkManager>().LifestyleTransient(),
                 Component.For<ICurrentUnitOfWorkProvider, AsyncLocalCurrentUnitOfWorkProvider>().LifestyleTransient(),
-                Component.For<IUnitOfWorkDefaultOptions, UnitOfWorkDefaultOptions>().LifestyleTransient()
+                Component.For<IUnitOfWorkDefaultOptions, UnitOfWorkDefaultOptions>().LifestyleTransient(),
+                Component.For<IMultiTenancyConfig, MultiTenancyConfig>().LifestyleTransient()
                 );
 
-            var permissionManager = new PermissionManager(LocalIocManager, authorizationConfiguration, LocalIocManager.Resolve<IUnitOfWorkManager>());
+            var permissionManager = new PermissionManager(LocalIocManager, authorizationConfiguration, LocalIocManager.Resolve<IUnitOfWorkManager>(), LocalIocManager.Resolve<IMultiTenancyConfig>());
             permissionManager.Initialize();
 
             permissionManager.GetAllPermissions().Count.ShouldBe(5);
@@ -63,10 +64,11 @@ namespace Abp.Tests.Authorization
                 Component.For<MyAuthorizationProviderWithCustomProperties>().LifestyleTransient(),
                 Component.For<IUnitOfWorkManager, UnitOfWorkManager>().LifestyleTransient(),
                 Component.For<ICurrentUnitOfWorkProvider, AsyncLocalCurrentUnitOfWorkProvider>().LifestyleTransient(),
-                Component.For<IUnitOfWorkDefaultOptions, UnitOfWorkDefaultOptions>().LifestyleTransient()
+                Component.For<IUnitOfWorkDefaultOptions, UnitOfWorkDefaultOptions>().LifestyleTransient(),
+                Component.For<IMultiTenancyConfig, MultiTenancyConfig>().LifestyleTransient()
             );
 
-            var permissionManager = new PermissionManager(LocalIocManager, authorizationConfiguration, LocalIocManager.Resolve<IUnitOfWorkManager>());
+            var permissionManager = new PermissionManager(LocalIocManager, authorizationConfiguration, LocalIocManager.Resolve<IUnitOfWorkManager>(), LocalIocManager.Resolve<IMultiTenancyConfig>());
             permissionManager.Initialize();
 
             permissionManager.GetAllPermissions().Count.ShouldBe(4);


### PR DESCRIPTION
Fixes https://github.com/aspnetzero/aspnet-zero-core/issues/3638

More recently discussed here:
https://support.aspnetzero.com/QA/Questions/10259

_I am receiving reports from my super users (those who have access to impersonate tenant accounts) that sometimes they lose their access to administrative menu pages, such as the "Tenants" and "Maintenance" menus.
The menus disappears from the navigation tree, and even if the user types the administrative page address directly into the address bar, they are bounced as if they do not have permissions.
I have traced this back to, when the user is impersonating a tenant account, the server application has been recycled. The user then "returns to my account", and they are still logged in, but they have lost their claims to administrative permissions.
There is no way for the user to fix this - no amount of logging in and out, clearing cookies, etc, will fix it. 
The only fix I have found, is to ask the user to log out, then recycle the application pool again - as you can imagine, this just raises the risk of it happening to another user._

I noticed that UserManager.cs does not directly access AbpSession.MultiTenancySide, but instead attempts to get it from the unitOfWork first. Copying this technique to PermissionManager.cs fixes the issue.