### PR TITLE
implement WrapResultFilter

### DIFF
--- a/doc/WebSite/AspNet-Core.md
+++ b/doc/WebSite/AspNet-Core.md
@@ -30,7 +30,7 @@ Startup class:
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
             //...
-
+    
             //Configure Abp and Dependency Injection. Should be called last.
             return services.AddAbp<MyProjectWebModule>(options =>
             {
@@ -40,12 +40,12 @@ Startup class:
                 );
             });
         }
-
+    
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             //Initializes ABP framework and all modules. Should be called first.
             app.UseAbp();
-
+    
             //...
         }
     }
@@ -185,7 +185,7 @@ controller actions. It **handles** and **logs** exceptions and returns a
     method defined in the Microsoft.AspNetCore.Diagnostics package to handle view exceptions.
 -   Exception handling and logging behaviour can be changed using the
     **WrapResult** and **DontWrapResult** attributes for methods and
-    classes.
+    classes. You can also create a custom result wrapping filter, see the WrapResultFilters section below.
 
 #### Result Filter
 
@@ -197,9 +197,19 @@ successfully executed.
     versions). If your action is returning a view or any other type of
     result, it will not be wrapped.
 -   The **WrapResult** and **DontWrapResult** attributes can be used for
-    methods and classes to enable/disable wrapping.
+    methods and classes to enable/disable wrapping. You can also create a custom result wrapping filter, see the WrapResultFilters section below.
 -   You can use a startup configuration to change the default behavior for
     result wrapping.
+
+#### WrapResultFilters
+
+You can also implement a custom ```IWrapResultFilter``` and decide result wrapping conditionally by the current request URL. A custom result wrapping filter must be added to ```WrapResultFilters``` as shown below;
+
+````c#
+Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new MyWrapResultFilter());
+````
+
+This approach can be useful if you don't have access the source code of the Controllers and can't used result wrapping attributes on the Controllers.
 
 ### Model Binders
 

--- a/doc/WebSite/Dynamic-Web-API.md
+++ b/doc/WebSite/Dynamic-Web-API.md
@@ -67,7 +67,7 @@ We can override the configuration after the ForAll method. Example:
     Configuration.Modules.AbpWebApi().DynamicApiControllerBuilder
         .ForAll<IApplicationService>(Assembly.GetAssembly(typeof(SimpleTaskSystemApplicationModule)), "tasksystem")
         .Build();
-
+    
     Configuration.Modules.AbpWebApi().DynamicApiControllerBuilder
         .For<ITaskAppService>("tasksystem/task")
         .ForMethod("CreateTask").DontCreateAction().Build();
@@ -119,10 +119,10 @@ interface:
     {
         [HttpGet]
         GetTasksOutput GetTasks(GetTasksInput input);
-
+    
         [HttpPut]
         void UpdateTask(UpdateTaskInput input);
-
+    
         [HttpPost]
         void CreateTask(CreateTaskInput input);
     }
@@ -264,7 +264,7 @@ be returned minifed, by setting the *minify** flag:
 
     <script src="~/api/AbpServiceProxies/GetAll?minify=true"></script>
     <script src="~/api/AbpServiceProxies/GetAll?type=angular&minify=true"></script>
-	<script src="/api/AbpServiceProxies/Get?name=tasksystem/task&minify=true" type="text/javascript"></script>
+    <script src="/api/AbpServiceProxies/Get?name=tasksystem/task&minify=true" type="text/javascript"></script>
 
 Default minification value is **false**.
 
@@ -301,6 +301,16 @@ also handle exceptions yourself since [exception
 handling](Handling-Exceptions.md) will be disabled (DontWrapResult
 attribute has WrapOnError properties that can be used to enable the handling
 and wrapping for exceptions).
+
+#### WrapResultFilters
+
+You can also implement a custom ```IWrapResultFilter``` and decide result wrapping conditionally by the current request URL. A custom result wrapping filter must be added to ```WrapResultFilters``` as shown below;
+
+````c#
+Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new MyWrapResultFilter());
+````
+
+This approach can be useful if you don't have access the source code of the Controllers and can't used result wrapping attributes on the Controllers.
 
 Note: Dynamic JavaScript proxies can understand if the result is unwrapped
 and will run properly in either case.

--- a/doc/WebSite/MVC-Controllers.md
+++ b/doc/WebSite/MVC-Controllers.md
@@ -19,7 +19,7 @@ This is a simple controller derived from AbpController:
             return View();
         }
     }
-                
+
 
 #### Localization
 
@@ -32,11 +32,11 @@ AbpController defines **L** method to make
         {
             LocalizationSourceName = "MySourceName";
         }
-
+    
         public ActionResult Index()
         {
             var helloWorldText = L("HelloWorld");
-
+    
             return View();
         }
     }
@@ -74,6 +74,16 @@ and **DontWrapResult** attributes for controllers or actions or from the
 [startup configuration](Startup-Configuration.md) (using
 Configuration.Modules.AbpMvc()...) globally. See the [ajax
 documentation](/Pages/Documents/Javascript-API/AJAX) for more info.
+
+##### WrapResultFilters
+
+You can also implement a custom ```IWrapResultFilter``` and decide result wrapping conditionally by the current request URL. A custom result wrapping filter must be added to ```WrapResultFilters``` as shown below;
+
+````c#
+Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new MyWrapResultFilter());
+````
+
+This approach can be useful if you don't have access the source code of the Controllers and can't used result wrapping attributes on the Controllers.
 
 #### Audit Logging
 

--- a/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Configuration/AbpAspNetCoreConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Abp.Domain.Uow;
 using Abp.Web.Models;
+using Abp.Web.Results.Filters;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
@@ -32,7 +33,8 @@ namespace Abp.AspNetCore.Configuration
 
         public List<Action<IEndpointRouteBuilder>> EndpointConfiguration { get; }
 
-
+        public WrapResultFilterCollection WrapResultFilters { get; }
+        
         public AbpAspNetCoreConfiguration()
         {
             DefaultWrapResultAttribute = new WrapResultAttribute();
@@ -42,6 +44,7 @@ namespace Abp.AspNetCore.Configuration
             ControllerAssemblySettings = new ControllerAssemblySettingList();
             FormBodyBindingIgnoredTypes = new List<Type>();
             EndpointConfiguration = new List<Action<IEndpointRouteBuilder>>();
+            WrapResultFilters = new WrapResultFilterCollection();
             IsValidationEnabledForControllers = true;
             SetNoCacheForAjaxResponses = true;
             IsAuditingEnabled = true;

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionFilter.cs
@@ -49,11 +49,10 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
                 return;
             }
 
-            var wrapResultAttribute =
-                ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
-                    context.ActionDescriptor.GetMethodInfo(),
-                    _configuration.DefaultWrapResultAttribute
-                );
+            var wrapResultAttribute = ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
+                context.ActionDescriptor.GetMethodInfo(),
+                _configuration.DefaultWrapResultAttribute
+            );
 
             if (wrapResultAttribute.LogError)
             {
@@ -71,9 +70,9 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
             }
 
             var displayUrl = context.HttpContext.Request.GetDisplayUrl();
-            if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl, out var wrapOnError))
+            if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl,
+                out var wrapOnError))
             {
-                //there is a configuration for that method use configuration
                 context.HttpContext.Response.StatusCode = GetStatusCode(context, wrapOnError);
 
                 if (!wrapOnError)
@@ -84,7 +83,7 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
                 HandleError(context);
                 return;
             }
-            
+
             context.HttpContext.Response.StatusCode = GetStatusCode(context, wrapResultAttribute.WrapOnError);
 
             if (!wrapResultAttribute.WrapOnError)
@@ -106,7 +105,7 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
 
             EventBus.Trigger(this, new AbpHandledExceptionData(context.Exception));
 
-            context.Exception = null; //Handled!
+            context.Exception = null; // Handled!
         }
 
         protected virtual int GetStatusCode(ExceptionContext context, bool wrapOnError)
@@ -114,23 +113,23 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
             if (context.Exception is AbpAuthorizationException)
             {
                 return context.HttpContext.User.Identity.IsAuthenticated
-                    ? (int)HttpStatusCode.Forbidden
-                    : (int)HttpStatusCode.Unauthorized;
+                    ? (int) HttpStatusCode.Forbidden
+                    : (int) HttpStatusCode.Unauthorized;
             }
 
             if (context.Exception is AbpValidationException)
             {
-                return (int)HttpStatusCode.BadRequest;
+                return (int) HttpStatusCode.BadRequest;
             }
 
             if (context.Exception is EntityNotFoundException)
             {
-                return (int)HttpStatusCode.NotFound;
+                return (int) HttpStatusCode.NotFound;
             }
 
             if (wrapOnError)
             {
-                return (int)HttpStatusCode.InternalServerError;
+                return (int) HttpStatusCode.InternalServerError;
             }
 
             return context.HttpContext.Response.StatusCode;

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionFilter.cs
@@ -10,8 +10,10 @@ using Abp.Events.Bus.Exceptions;
 using Abp.Logging;
 using Abp.Reflection;
 using Abp.Runtime.Validation;
+using Abp.Web.Configuration;
 using Abp.Web.Models;
 using Castle.Core.Logging;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
@@ -25,11 +27,16 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
 
         private readonly IErrorInfoBuilder _errorInfoBuilder;
         private readonly IAbpAspNetCoreConfiguration _configuration;
+        private readonly IAbpWebCommonModuleConfiguration _abpWebCommonModuleConfiguration;
 
-        public AbpExceptionFilter(IErrorInfoBuilder errorInfoBuilder, IAbpAspNetCoreConfiguration configuration)
+        public AbpExceptionFilter(
+            IErrorInfoBuilder errorInfoBuilder,
+            IAbpAspNetCoreConfiguration configuration,
+            IAbpWebCommonModuleConfiguration abpWebCommonModuleConfiguration)
         {
             _errorInfoBuilder = errorInfoBuilder;
             _configuration = configuration;
+            _abpWebCommonModuleConfiguration = abpWebCommonModuleConfiguration;
 
             Logger = NullLogger.Instance;
             EventBus = NullEventBus.Instance;
@@ -63,6 +70,21 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
                 return;
             }
 
+            var displayUrl = context.HttpContext.Request.GetDisplayUrl();
+            if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl, out var wrapOnError))
+            {
+                //there is a configuration for that method use configuration
+                context.HttpContext.Response.StatusCode = GetStatusCode(context, wrapOnError);
+
+                if (!wrapOnError)
+                {
+                    return;
+                }
+
+                HandleError(context);
+                return;
+            }
+            
             context.HttpContext.Response.StatusCode = GetStatusCode(context, wrapResultAttribute.WrapOnError);
 
             if (!wrapResultAttribute.WrapOnError)
@@ -70,6 +92,11 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
                 return;
             }
 
+            HandleError(context);
+        }
+
+        private void HandleError(ExceptionContext context)
+        {
             context.Result = new ObjectResult(
                 new AjaxResponse(
                     _errorInfoBuilder.BuildForException(context.Exception),

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
@@ -48,7 +48,8 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
             return Task.CompletedTask;
         }
 
-        public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context,
+            PageHandlerExecutionDelegate next)
         {
             if (context.HandlerMethod == null)
             {
@@ -63,11 +64,10 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
                 return;
             }
 
-            var wrapResultAttribute =
-                ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
-                    context.HandlerMethod.MethodInfo,
-                    _configuration.DefaultWrapResultAttribute
-                );
+            var wrapResultAttribute = ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
+                context.HandlerMethod.MethodInfo,
+                _configuration.DefaultWrapResultAttribute
+            );
 
             if (wrapResultAttribute.LogError)
             {
@@ -77,17 +77,18 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
             HandleAndWrapException(pageHandlerExecutedContext, wrapResultAttribute);
         }
 
-        protected virtual void HandleAndWrapException(PageHandlerExecutedContext context, WrapResultAttribute wrapResultAttribute)
+        protected virtual void HandleAndWrapException(PageHandlerExecutedContext context,
+            WrapResultAttribute wrapResultAttribute)
         {
             if (!ActionResultHelper.IsObjectResult(context.HandlerMethod.MethodInfo.ReturnType))
             {
                 return;
             }
-            
+
             var displayUrl = context.HttpContext.Request.GetDisplayUrl();
-            if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl, out var wrapOnError))
+            if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl,
+                out var wrapOnError))
             {
-                //there is a configuration for that method use configuration
                 context.HttpContext.Response.StatusCode = GetStatusCode(context, wrapOnError);
 
                 if (!wrapOnError)
@@ -120,7 +121,7 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
 
             EventBus.Trigger(this, new AbpHandledExceptionData(context.Exception));
 
-            context.Exception = null; //Handled!
+            context.Exception = null; // Handled!
         }
 
         protected virtual int GetStatusCode(PageHandlerExecutedContext context, bool wrapOnError)
@@ -128,23 +129,23 @@ namespace Abp.AspNetCore.Mvc.ExceptionHandling
             if (context.Exception is AbpAuthorizationException)
             {
                 return context.HttpContext.User.Identity.IsAuthenticated
-                    ? (int)HttpStatusCode.Forbidden
-                    : (int)HttpStatusCode.Unauthorized;
+                    ? (int) HttpStatusCode.Forbidden
+                    : (int) HttpStatusCode.Unauthorized;
             }
 
             if (context.Exception is AbpValidationException)
             {
-                return (int)HttpStatusCode.BadRequest;
+                return (int) HttpStatusCode.BadRequest;
             }
 
             if (context.Exception is EntityNotFoundException)
             {
-                return (int)HttpStatusCode.NotFound;
+                return (int) HttpStatusCode.NotFound;
             }
 
             if (wrapOnError)
             {
-                return (int)HttpStatusCode.InternalServerError;
+                return (int) HttpStatusCode.InternalServerError;
             }
 
             return context.HttpContext.Response.StatusCode;

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultFilter.cs
@@ -33,16 +33,10 @@ namespace Abp.AspNetCore.Mvc.Results
             }
 
             var methodInfo = context.ActionDescriptor.GetMethodInfo();
-
-            /*
-             * Here is the check order,
-             * 1) Configuration
-             * 2) Attribute
-             */
+            
             var displayUrl = context.HttpContext.Request.GetDisplayUrl();
             if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnSuccess(displayUrl, out var wrapOnSuccess))
             {
-                //there is a configuration for that method use configuration
                 if (!wrapOnSuccess)
                 {
                     return;

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultPageFilter.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Results/AbpResultPageFilter.cs
@@ -1,18 +1,11 @@
-﻿using System.Net;
+﻿using System;
 using System.Threading.Tasks;
 using Abp.AspNetCore.Configuration;
 using Abp.AspNetCore.Mvc.Results.Wrapping;
-using Abp.Authorization;
 using Abp.Dependency;
-using Abp.Domain.Entities;
-using Abp.Events.Bus;
-using Abp.Events.Bus.Exceptions;
-using Abp.Logging;
 using Abp.Reflection;
-using Abp.Runtime.Validation;
-using Abp.Web.Models;
-using Castle.Core.Logging;
-using Microsoft.AspNetCore.Mvc;
+using Abp.Web.Configuration;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Abp.AspNetCore.Mvc.Results
@@ -21,11 +14,15 @@ namespace Abp.AspNetCore.Mvc.Results
     {
         private readonly IAbpAspNetCoreConfiguration _configuration;
         private readonly IAbpActionResultWrapperFactory _actionResultWrapperFactory;
+        private readonly IAbpWebCommonModuleConfiguration _abpWebCommonModuleConfiguration;
 
-        public AbpResultPageFilter(IAbpAspNetCoreConfiguration configuration, IAbpActionResultWrapperFactory actionResultWrapperFactory)
+        public AbpResultPageFilter(IAbpAspNetCoreConfiguration configuration, 
+            IAbpActionResultWrapperFactory actionResultWrapperFactory,
+            IAbpWebCommonModuleConfiguration abpWebCommonModuleConfiguration)
         {
             _configuration = configuration;
             _actionResultWrapperFactory = actionResultWrapperFactory;
+            _abpWebCommonModuleConfiguration = abpWebCommonModuleConfiguration;
         }
 
         public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
@@ -45,6 +42,26 @@ namespace Abp.AspNetCore.Mvc.Results
 
             var methodInfo = context.HandlerMethod.MethodInfo;
 
+            /*
+            * Here is the check order,
+            * 1) Configuration
+            * 2) Attribute
+            */
+
+            var displayUrl = context.HttpContext.Request.GetDisplayUrl();
+            
+            if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnSuccess(displayUrl, out var wrapOnSuccess))
+            {
+                //there is a configuration for that method use configuration
+                if (!wrapOnSuccess)
+                {
+                    return;
+                }
+
+                _actionResultWrapperFactory.CreateFor(pageHandlerExecutedContext).Wrap(pageHandlerExecutedContext);
+                return;
+            }
+            
             var wrapResultAttribute =
                 ReflectionHelper.GetSingleAttributeOfMemberOrDeclaringTypeOrDefault(
                     methodInfo,

--- a/src/Abp.Web.Api/WebApi/Authorization/AbpApiAuthorizeFilter.cs
+++ b/src/Abp.Web.Api/WebApi/Authorization/AbpApiAuthorizeFilter.cs
@@ -107,7 +107,6 @@ namespace Abp.WebApi.Authorization
             var displayUrl = actionContext.Request.RequestUri.AbsolutePath;
             if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl, out var wrapOnError))
             {
-                //there is a configuration for that method use configuration
                 return HandleError(wrapOnError);
             }
             

--- a/src/Abp.Web.Api/WebApi/Controllers/ResultWrapperHandler.cs
+++ b/src/Abp.Web.Api/WebApi/Controllers/ResultWrapperHandler.cs
@@ -54,12 +54,6 @@ namespace Abp.WebApi.Controllers
                 };
             }
             
-            /*
-            * Here is the check order
-            * 1) Configuration
-            * 2) Attribute
-            */
-            
             var absolutePath = request.RequestUri.AbsolutePath;
 
             if (_abpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnSuccess(absolutePath, out var wrapOnSuccess))

--- a/src/Abp.Web.Api/WebApi/ExceptionHandling/AbpApiExceptionFilterAttribute.cs
+++ b/src/Abp.Web.Api/WebApi/ExceptionHandling/AbpApiExceptionFilterAttribute.cs
@@ -25,7 +25,6 @@ namespace Abp.WebApi.ExceptionHandling
     /// </summary>
     public class AbpApiExceptionFilterAttribute : ExceptionFilterAttribute, ITransientDependency
     {
-
         /// <summary>
         /// Reference to the <see cref="ILogger"/>.
         /// </summary>
@@ -41,6 +40,7 @@ namespace Abp.WebApi.ExceptionHandling
         protected IAbpWebApiConfiguration Configuration { get; }
 
         protected IAbpWebCommonModuleConfiguration AbpWebCommonModuleConfiguration { get; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AbpApiExceptionFilterAttribute"/> class.
         /// </summary>
@@ -88,24 +88,23 @@ namespace Abp.WebApi.ExceptionHandling
 
                 EventBus.Trigger(this, new AbpHandledExceptionData(context.Exception));
             }
-            
+
             var displayUrl = context.Request.RequestUri.AbsolutePath;
-            if (AbpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl, out var wrapOnError))
+            if (AbpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl,
+                out var wrapOnError))
             {
-                //there is a configuration for that method use configuration
                 if (!wrapOnError)
                 {
                     context.Response.StatusCode = GetStatusCode(context, false);
                     return;
                 }
-                
+
                 HandleError();
                 return;
             }
 
-            var wrapResultAttribute = HttpActionDescriptorHelper
-                                          .GetWrapResultAttributeOrNull(context.ActionContext.ActionDescriptor) ??
-                                      Configuration.DefaultWrapResultAttribute;
+            var wrapResultAttribute = HttpActionDescriptorHelper.GetWrapResultAttributeOrNull(context.ActionContext.ActionDescriptor) ??
+                Configuration.DefaultWrapResultAttribute;
 
             if (wrapResultAttribute.LogError)
             {

--- a/src/Abp.Web.Api/WebApi/ExceptionHandling/AbpApiExceptionFilterAttribute.cs
+++ b/src/Abp.Web.Api/WebApi/ExceptionHandling/AbpApiExceptionFilterAttribute.cs
@@ -12,6 +12,7 @@ using Abp.Extensions;
 using Abp.Logging;
 using Abp.Runtime.Session;
 using Abp.Runtime.Validation;
+using Abp.Web.Configuration;
 using Abp.Web.Models;
 using Abp.WebApi.Configuration;
 using Abp.WebApi.Controllers;
@@ -24,6 +25,7 @@ namespace Abp.WebApi.ExceptionHandling
     /// </summary>
     public class AbpApiExceptionFilterAttribute : ExceptionFilterAttribute, ITransientDependency
     {
+
         /// <summary>
         /// Reference to the <see cref="ILogger"/>.
         /// </summary>
@@ -38,11 +40,15 @@ namespace Abp.WebApi.ExceptionHandling
 
         protected IAbpWebApiConfiguration Configuration { get; }
 
+        protected IAbpWebCommonModuleConfiguration AbpWebCommonModuleConfiguration { get; }
         /// <summary>
         /// Initializes a new instance of the <see cref="AbpApiExceptionFilterAttribute"/> class.
         /// </summary>
-        public AbpApiExceptionFilterAttribute(IAbpWebApiConfiguration configuration)
+        public AbpApiExceptionFilterAttribute(
+            IAbpWebApiConfiguration configuration,
+            IAbpWebCommonModuleConfiguration abpWebCommonModuleConfiguration)
         {
+            this.AbpWebCommonModuleConfiguration = abpWebCommonModuleConfiguration;
             Configuration = configuration;
             Logger = NullLogger.Instance;
             EventBus = NullEventBus.Instance;
@@ -55,9 +61,51 @@ namespace Abp.WebApi.ExceptionHandling
         /// <param name="context">The context for the action.</param>
         public override void OnException(HttpActionExecutedContext context)
         {
+            void HandleError()
+            {
+                if (context.Exception is HttpException)
+                {
+                    var httpException = context.Exception as HttpException;
+                    var httpStatusCode = (HttpStatusCode) httpException.GetHttpCode();
+
+                    context.Response = context.Request.CreateResponse(
+                        httpStatusCode,
+                        new AjaxResponse(
+                            new ErrorInfo(httpException.Message),
+                            httpStatusCode == HttpStatusCode.Unauthorized || httpStatusCode == HttpStatusCode.Forbidden
+                        )
+                    );
+                }
+                else
+                {
+                    context.Response = context.Request.CreateResponse(
+                        GetStatusCode(context, true),
+                        new AjaxResponse(
+                            SingletonDependency<IErrorInfoBuilder>.Instance.BuildForException(context.Exception),
+                            context.Exception is Abp.Authorization.AbpAuthorizationException)
+                    );
+                }
+
+                EventBus.Trigger(this, new AbpHandledExceptionData(context.Exception));
+            }
+            
+            var displayUrl = context.Request.RequestUri.AbsolutePath;
+            if (AbpWebCommonModuleConfiguration.WrapResultFilters.HasFilterForWrapOnError(displayUrl, out var wrapOnError))
+            {
+                //there is a configuration for that method use configuration
+                if (!wrapOnError)
+                {
+                    context.Response.StatusCode = GetStatusCode(context, false);
+                    return;
+                }
+                
+                HandleError();
+                return;
+            }
+
             var wrapResultAttribute = HttpActionDescriptorHelper
-                .GetWrapResultAttributeOrNull(context.ActionContext.ActionDescriptor) ??
-                Configuration.DefaultWrapResultAttribute;
+                                          .GetWrapResultAttributeOrNull(context.ActionContext.ActionDescriptor) ??
+                                      Configuration.DefaultWrapResultAttribute;
 
             if (wrapResultAttribute.LogError)
             {
@@ -75,30 +123,7 @@ namespace Abp.WebApi.ExceptionHandling
                 return;
             }
 
-            if (context.Exception is HttpException)
-            {
-                var httpException = context.Exception as HttpException;
-                var httpStatusCode = (HttpStatusCode) httpException.GetHttpCode();
-
-                context.Response = context.Request.CreateResponse(
-                    httpStatusCode,
-                    new AjaxResponse(
-                        new ErrorInfo(httpException.Message),
-                        httpStatusCode == HttpStatusCode.Unauthorized || httpStatusCode == HttpStatusCode.Forbidden
-                    )
-                );
-            }
-            else
-            {
-                context.Response = context.Request.CreateResponse(
-                    GetStatusCode(context, wrapResultAttribute.WrapOnError),
-                    new AjaxResponse(
-                        SingletonDependency<IErrorInfoBuilder>.Instance.BuildForException(context.Exception),
-                        context.Exception is Abp.Authorization.AbpAuthorizationException)
-                );
-            }
-
-            EventBus.Trigger(this, new AbpHandledExceptionData(context.Exception));
+            HandleError();
         }
 
         protected virtual HttpStatusCode GetStatusCode(HttpActionExecutedContext context, bool wrapOnError)

--- a/src/Abp.Web.Common/Web/Configuration/AbpWebCommonModuleConfiguration.cs
+++ b/src/Abp.Web.Common/Web/Configuration/AbpWebCommonModuleConfiguration.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
-using Abp.Web.Api.ProxyScripting.Configuration;
+﻿using Abp.Web.Api.ProxyScripting.Configuration;
 using Abp.Web.MultiTenancy;
+using Abp.Web.Results.Filters;
 using Abp.Web.Security.AntiForgery;
 
 namespace Abp.Web.Configuration
@@ -17,16 +17,19 @@ namespace Abp.Web.Configuration
 
         public IWebMultiTenancyConfiguration MultiTenancy { get; }
 
+        public WrapResultFilterCollection WrapResultFilters { get; }
+
         public AbpWebCommonModuleConfiguration(
-            IApiProxyScriptingConfiguration apiProxyScripting, 
+            IApiProxyScriptingConfiguration apiProxyScripting,
             IAbpAntiForgeryConfiguration abpAntiForgery,
-            IWebEmbeddedResourcesConfiguration embeddedResources, 
+            IWebEmbeddedResourcesConfiguration embeddedResources,
             IWebMultiTenancyConfiguration multiTenancy)
         {
             ApiProxyScripting = apiProxyScripting;
             AntiForgery = abpAntiForgery;
             EmbeddedResources = embeddedResources;
             MultiTenancy = multiTenancy;
+            WrapResultFilters = new WrapResultFilterCollection();
         }
     }
 }

--- a/src/Abp.Web.Common/Web/Configuration/IAbpWebCommonModuleConfiguration.cs
+++ b/src/Abp.Web.Common/Web/Configuration/IAbpWebCommonModuleConfiguration.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
-using Abp.Web.Api.ProxyScripting.Configuration;
+﻿using Abp.Web.Api.ProxyScripting.Configuration;
 using Abp.Web.MultiTenancy;
+using Abp.Web.Results.Filters;
 using Abp.Web.Security.AntiForgery;
 
 namespace Abp.Web.Configuration
@@ -32,5 +32,10 @@ namespace Abp.Web.Configuration
         IWebEmbeddedResourcesConfiguration EmbeddedResources { get; }
 
         IWebMultiTenancyConfiguration MultiTenancy { get; }
+        
+        /// <summary>
+        /// Used to configure wrap results
+        /// </summary>
+        WrapResultFilterCollection WrapResultFilters { get; }
     }
 }

--- a/src/Abp.Web.Common/Web/Results/Filters/IWrapResultFilter.cs
+++ b/src/Abp.Web.Common/Web/Results/Filters/IWrapResultFilter.cs
@@ -1,0 +1,21 @@
+﻿namespace Abp.Web.Results.Filters
+{
+    public interface IWrapResultFilter
+    {
+        /// <summary>
+        /// Returns whether to apply the filter. Stores filter result on <paramref name="wrapOnSuccess"/>.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="wrapOnSuccess"></param>
+        /// <returns></returns>
+        bool HasFilterForWrapOnSuccess(string url, out bool wrapOnSuccess);
+        
+        /// <summary>
+        /// Returns whether to apply the filter. Stores filter result on <paramref name="wrapOnError"/>.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="wrapOnError"></param>
+        /// <returns></returns>
+        bool HasFilterForWrapOnError(string url, out bool wrapOnError);
+    }
+}

--- a/src/Abp.Web.Common/Web/Results/Filters/WrapResultFilterCollection.cs
+++ b/src/Abp.Web.Common/Web/Results/Filters/WrapResultFilterCollection.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.ObjectModel;
+
+namespace Abp.Web.Results.Filters
+{
+    public class WrapResultFilterCollection: Collection<IWrapResultFilter>
+    {
+        /// <summary>
+        /// Returns whether to apply the filter. Stores filter result on <paramref name="wrapOnSuccess"/>. Checks the filters in the list sequentially.
+        /// <para>for example, the first element in the list has priority over the second element.</para>
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="wrapOnSuccess"></param>
+        /// <returns></returns>
+        public bool HasFilterForWrapOnSuccess(string url, out bool wrapOnSuccess)
+        {
+            for (var index = 0; index < Items.Count; index++)
+            {
+                if (Items[index].HasFilterForWrapOnSuccess(url, out wrapOnSuccess))
+                {
+                    return true;
+                }
+            }
+
+            wrapOnSuccess = false;
+            return false;
+        }
+        
+        /// <summary>
+        /// Returns whether to apply the filter. Stores filter result on <paramref name="wrapOnError"/>. Checks the filters in the list sequentially.
+        /// <para>for example, the first element in the list has priority over the second element.</para>
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="wrapOnError"></param>
+        /// <returns></returns>
+        public bool HasFilterForWrapOnError(string url, out bool wrapOnError)
+        {
+            for (var index = 0; index < Items.Count; index++)
+            {
+                if (Items[index].HasFilterForWrapOnError(url, out wrapOnError))
+                {
+                    return true;
+                }
+            }
+
+            wrapOnError = false;
+            return false;
+        }
+    }
+}

--- a/test/Abp.AspNetCore.Tests/App/AppModule.cs
+++ b/test/Abp.AspNetCore.Tests/App/AppModule.cs
@@ -1,4 +1,5 @@
 ﻿using Abp.AspNetCore.App.MultiTenancy;
+using Abp.AspNetCore.App.ResultWrapping;
 using Abp.AspNetCore.TestBase;
 using Abp.Configuration.Startup;
 using Abp.Modules;
@@ -38,6 +39,8 @@ namespace Abp.AspNetCore.App
                 endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
                 endpoints.MapRazorPages();
             });
+            
+            Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new CustomWrapResultFilter());
         }
 
         public override void Initialize()

--- a/test/Abp.AspNetCore.Tests/App/Controllers/WrapResultTestController.cs
+++ b/test/Abp.AspNetCore.Tests/App/Controllers/WrapResultTestController.cs
@@ -1,4 +1,5 @@
 ﻿using Abp.AspNetCore.Mvc.Controllers;
+using Abp.UI;
 using Abp.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -27,6 +28,20 @@ namespace Abp.AspNetCore.App.Controllers
         public int GetXml()
         {
             return 42;
+        }
+
+        [HttpGet]
+        [Route("WrapResultTest/GetDontWrapByUrl")]
+        public int GetDontWrapByUrl()
+        {
+            return 42;
+        }
+        
+        [HttpGet]
+        [Route("WrapResultTest/GetDontWrapByUrlWithException")]
+        public int GetDontWrapByUrlWithException()
+        {
+            throw new UserFriendlyException("Test error");
         }
     }
 }

--- a/test/Abp.AspNetCore.Tests/App/ResultWrapping/CustomWrapResultFilter.cs
+++ b/test/Abp.AspNetCore.Tests/App/ResultWrapping/CustomWrapResultFilter.cs
@@ -1,0 +1,19 @@
+﻿using Abp.Web.Results.Filters;
+
+namespace Abp.AspNetCore.App.ResultWrapping
+{
+    public class CustomWrapResultFilter : IWrapResultFilter
+    {
+        public bool HasFilterForWrapOnSuccess(string url, out bool wrapOnSuccess)
+        {
+            wrapOnSuccess = false;
+            return url.EndsWith("WrapResultTest/GetDontWrapByUrl");
+        }
+
+        public bool HasFilterForWrapOnError(string url, out bool wrapOnError)
+        {
+            wrapOnError = false;
+            return url.EndsWith("WrapResultTest/GetDontWrapByUrlWithException");
+        }
+    }
+}

--- a/test/Abp.AspNetCore.Tests/Tests/WrapResultTestController_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/WrapResultTestController_Tests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Abp.AspNetCore.App.Controllers;
+using Abp.UI;
 using Shouldly;
 using Xunit;
 
@@ -36,6 +38,31 @@ namespace Abp.AspNetCore.Tests
 
             // Assert
             response.ShouldBe("42");
+        }
+        
+        [Fact]
+        public async Task WrapResultTestControllerTests_GetDontWrapByUrl_Test()
+        {
+            // Act
+            var response = await GetResponseAsStringAsync(
+                GetUrl<WrapResultTestController>(
+                    nameof(WrapResultTestController.GetDontWrapByUrl)
+                )
+            );
+
+            // Assert
+            response.ShouldBe("42");
+        }
+        
+        [Fact]
+        public async Task WrapResultTestControllerTests_GetDontWrapByUrlException_Test()
+        {
+            // Act
+            var response = await GetResponseAsStringAsync(
+                GetUrl<WrapResultTestController>(
+                    nameof(WrapResultTestController.GetDontWrapByUrlWithException)
+                )
+            ).ShouldThrowAsync<UserFriendlyException>();
         }
 
         [Fact]


### PR DESCRIPTION
It implements WrapResultFilter which can be used for overriding wrapresult for controllers.(Might be usefell for controllers which we can not use attribute on or loaded from another assembly)
Example Usage:

Create a custom wrap result filter
```csharp
public class MyWrapResultFilter : IWrapResultFilter
{
    public bool HasFilterForWrapOnSuccess(string url, out bool wrapOnSuccess)
    {
        if (url == "xxx")
        {
            wrapOnSuccess = true;
            return true;
        }

        if (url == "xxxyyy")
        {
            wrapOnSuccess = false;
            return true;
        }

        wrapOnSuccess = default;
        return false;
    }

    public bool HasFilterForWrapOnError(string url, out bool wrapOnError)
    {
        if (url == "xxx")
        {
            wrapOnError = true;
            return true;
        }

        if (url == "xxxyyy")
        {
            wrapOnError = false;
            return true;
        }
        
        wrapOnError = default;
        return false;
    }
}
```

Add that filter to wrap result filters on your module
```csharp
public override void PreInitialize()
{
      Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new MyWrapResultFilter());
}
```

closes #6190 