### PR TITLE
Implement replacement of AbpPerRequestRedisCache for ICacheManager

### DIFF
--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCacheExtensions.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCacheExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Abp.Dependency;
+using Abp.Runtime.Caching.Configuration;
+
+namespace Abp.Runtime.Caching.Redis;
+
+public static class AbpPerRequestRedisCacheExtensions
+{
+    /// <summary>
+    /// Configures caching to use Redis as cache server.
+    /// </summary>
+    /// <param name="cachingConfiguration">The caching configuration.</param>
+    /// <param name="usePerRequestRedisCache">Replaces ICacheManager with <see cref="Abp.Runtime.Caching.Redis.AbpPerRequestRedisCacheManager"/></param>
+    public static void UseRedis(this ICachingConfiguration cachingConfiguration, bool usePerRequestRedisCache)
+    {
+        cachingConfiguration.UseRedis(options => { }, usePerRequestRedisCache);
+    }
+
+    /// <summary>
+    /// Configures caching to use Redis as cache server.
+    /// </summary>
+    /// <param name="cachingConfiguration">The caching configuration.</param>
+    /// <param name="optionsAction">Action to get/set options</param>
+    /// <param name="usePerRequestRedisCache">Replaces ICacheManager with <see cref="Abp.Runtime.Caching.Redis.AbpPerRequestRedisCacheManager"/></param>
+    public static void UseRedis(this ICachingConfiguration cachingConfiguration, Action<AbpRedisCacheOptions> optionsAction, bool usePerRequestRedisCache)
+    {
+        if (!usePerRequestRedisCache)
+        {
+            cachingConfiguration.UseRedis(optionsAction);
+            return;
+        }
+
+        var iocManager = cachingConfiguration.AbpConfiguration.IocManager;
+        iocManager.RegisterIfNot<ICacheManager, AbpPerRequestRedisCacheManagerForReplacement>();
+
+        optionsAction(iocManager.Resolve<AbpRedisCacheOptions>());
+    }
+}

--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCacheManager.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCacheManager.cs
@@ -33,4 +33,11 @@ namespace Abp.Runtime.Caching.Redis
             }
         }
     }
+
+    internal class AbpPerRequestRedisCacheManagerForReplacement : AbpPerRequestRedisCacheManager
+    {
+        public AbpPerRequestRedisCacheManagerForReplacement(IIocManager iocManager, ICachingConfiguration configuration) : base(iocManager, configuration)
+        {
+        }
+    }
 }

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCacheReplacementModule.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCacheReplacementModule.cs
@@ -1,0 +1,21 @@
+﻿using Abp.Modules;
+using Abp.Reflection.Extensions;
+using Abp.Runtime.Caching.Redis;
+
+namespace Abp.Zero.Redis.PerRequestRedisCache
+{
+    [DependsOn(typeof(AbpAspNetCorePerRequestRedisCacheModule))]
+    public class AbpPerRequestRedisCacheReplacementModule : AbpModule
+    {
+        public override void PreInitialize()
+        {
+            Configuration.Caching.UseRedis(usePerRequestRedisCache: true);
+        }
+
+        public override void Initialize()
+        {
+            IocManager.RegisterAssemblyByConvention(
+                typeof(AbpPerRequestRedisCacheReplacementModule).GetAssembly());
+        }
+    }
+}

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCacheReplacement_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCacheReplacement_Tests.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Threading.Tasks;
+using Abp.Runtime.Caching;
+using NSubstitute;
+using Shouldly;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Abp.Zero.Redis.PerRequestRedisCache
+{
+    public class
+        AbpPerRequestRedisCacheReplacement_Tests : PerRequestRedisCacheTestsBase<
+            AbpPerRequestRedisCacheReplacementModule>
+    {
+        private ITypedCache<string, TestCacheItem> _typedCache;
+
+        public AbpPerRequestRedisCacheReplacement_Tests()
+        {
+            _typedCache = LocalIocManager.Resolve<ICacheManager>().GetCache<string, TestCacheItem>("TestCacheItems");
+        }
+
+        [Fact]
+        public void Should_Request_Once_For_Same_Context()
+        {
+            ChangeHttpContext();
+
+            string cacheKey = Guid.NewGuid().ToString();
+            int counter = 0;
+            int cacheValue = 1;
+
+            TestCacheItem GetCacheValue()
+            {
+                counter++;
+                return new TestCacheItem { Value = cacheValue };
+            }
+
+            var item1 = _typedCache.Get(cacheKey, GetCacheValue);
+            var item2 = _typedCache.Get(cacheKey, GetCacheValue);
+            RedisDatabase.Received(1).StringGet(Arg.Any<RedisKey>());
+
+            var cachedObject =
+                RedisSerializer.Serialize(new TestCacheItem { Value = cacheValue }, typeof(TestCacheItem));
+            RedisDatabase.Received(1).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(),
+                Arg.Any<CommandFlags>());
+
+            _typedCache.GetOrDefault(cacheKey).Value.ShouldBe(cacheValue);
+
+            counter.ShouldBe(1);
+
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public void Should_Request_Again_For_Same_Context()
+        {
+            ChangeHttpContext();
+
+            string cacheKey = Guid.NewGuid().ToString();
+            int counter = 0;
+            int cacheValue = 1;
+
+            TestCacheItem GetCacheValue()
+            {
+                counter++;
+                return new TestCacheItem { Value = cacheValue };
+            }
+
+            var item1 = _typedCache.Get(cacheKey, GetCacheValue);
+
+            ChangeHttpContext();
+            var item2 = _typedCache.Get(cacheKey, GetCacheValue);
+
+            RedisDatabase.Received(2).StringGet(Arg.Any<RedisKey>());
+
+            var cachedObject =
+                RedisSerializer.Serialize(new TestCacheItem { Value = cacheValue }, typeof(TestCacheItem));
+            RedisDatabase.Received(2).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(),
+                Arg.Any<CommandFlags>());
+
+            _typedCache.GetOrDefault(cacheKey).Value.ShouldBe(cacheValue);
+
+            counter.ShouldBe(2);
+
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public void Should_Not_Request_Again_For_Same_Context()
+        {
+            var context1 = GetNewContextSubstitute();
+            var context2 = GetNewContextSubstitute();
+
+            string cacheKey = Guid.NewGuid().ToString();
+            int counter = 0;
+            int cacheValue = 1;
+
+            TestCacheItem GetCacheValue()
+            {
+                counter++;
+                return new TestCacheItem { Value = cacheValue };
+            }
+
+            CurrentHttpContext = context1;
+            var item1 = _typedCache.Get(cacheKey, GetCacheValue); //First request
+
+            CurrentHttpContext = context2;
+            var item2 = _typedCache.Get(cacheKey, GetCacheValue); //Second request
+
+            CurrentHttpContext = context1;
+            var item3 = _typedCache.Get(cacheKey, GetCacheValue); //First request again
+
+            CurrentHttpContext = context2;
+            var item4 = _typedCache.Get(cacheKey, GetCacheValue); //Second request again
+
+            RedisDatabase.Received(2).StringGet(Arg.Any<RedisKey>());
+
+            var cachedObject =
+                RedisSerializer.Serialize(new TestCacheItem { Value = cacheValue }, typeof(TestCacheItem));
+            RedisDatabase.Received(2).StringSet(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(), Arg.Any<When>(),
+                Arg.Any<CommandFlags>());
+
+            _typedCache.GetOrDefault(cacheKey).Value.ShouldBe(cacheValue);
+
+            counter.ShouldBe(2);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+
+            item3.ShouldNotBe(null);
+            item3.Value.ShouldBe(cacheValue);
+
+            item4.ShouldNotBe(null);
+            item4.Value.ShouldBe(cacheValue);
+        }
+
+        #region Async Methods
+
+        [Fact]
+        public async Task Should_Request_Once_For_Same_Context_Async()
+        {
+            ChangeHttpContext();
+
+            string cacheKey = Guid.NewGuid().ToString();
+            int counter = 0;
+            int cacheValue = 1;
+
+            Task<TestCacheItem> GetCacheValue()
+            {
+                counter++;
+                return Task.FromResult(new TestCacheItem { Value = cacheValue });
+            }
+
+            var item1 = await _typedCache.GetAsync(cacheKey, GetCacheValue);
+            var item2 = await _typedCache.GetAsync(cacheKey, GetCacheValue);
+            await RedisDatabase.Received(1).StringGetAsync(Arg.Any<RedisKey>());
+
+            var cachedObject =
+                RedisSerializer.Serialize(new TestCacheItem { Value = cacheValue }, typeof(TestCacheItem));
+            await RedisDatabase.Received(1).StringSetAsync(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(),
+                Arg.Any<When>(), Arg.Any<CommandFlags>());
+
+            (await _typedCache.GetOrDefaultAsync(cacheKey)).Value.ShouldBe(cacheValue);
+
+            counter.ShouldBe(1);
+
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public async Task Should_Request_Again_For_Same_Context_Async()
+        {
+            ChangeHttpContext();
+
+            string cacheKey = Guid.NewGuid().ToString();
+            int counter = 0;
+            int cacheValue = 1;
+
+            Task<TestCacheItem> GetCacheValue()
+            {
+                counter++;
+                return Task.FromResult(new TestCacheItem { Value = cacheValue });
+            }
+
+            var item1 = await _typedCache.GetAsync(cacheKey, GetCacheValue);
+
+            ChangeHttpContext();
+            var item2 = await _typedCache.GetAsync(cacheKey, GetCacheValue);
+
+            await RedisDatabase.Received(2).StringGetAsync(Arg.Any<RedisKey>());
+
+            var cachedObject =
+                RedisSerializer.Serialize(new TestCacheItem { Value = cacheValue }, typeof(TestCacheItem));
+            await RedisDatabase.Received(2).StringSetAsync(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(),
+                Arg.Any<When>(),
+                Arg.Any<CommandFlags>());
+
+            (await _typedCache.GetOrDefaultAsync(cacheKey)).Value.ShouldBe(cacheValue);
+
+            counter.ShouldBe(2);
+
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+        }
+
+        [Fact]
+        public async Task Should_Not_Request_Again_For_Same_Context_Async()
+        {
+            var context1 = GetNewContextSubstitute();
+            var context2 = GetNewContextSubstitute();
+
+            string cacheKey = Guid.NewGuid().ToString();
+            int counter = 0;
+            int cacheValue = 1;
+
+            Task<TestCacheItem> GetCacheValue()
+            {
+                counter++;
+                return Task.FromResult(new TestCacheItem { Value = cacheValue });
+            }
+
+            CurrentHttpContext = context1;
+            var item1 = await _typedCache.GetAsync(cacheKey, GetCacheValue); //First request
+
+            CurrentHttpContext = context2;
+            var item2 = await _typedCache.GetAsync(cacheKey, GetCacheValue); //Second request
+
+            CurrentHttpContext = context1;
+            var item3 = await _typedCache.GetAsync(cacheKey, GetCacheValue); //First request again
+
+            CurrentHttpContext = context2;
+            var item4 = await _typedCache.GetAsync(cacheKey, GetCacheValue); //Second request again
+
+            await RedisDatabase.Received(2).StringGetAsync(Arg.Any<RedisKey>());
+
+            var cachedObject =
+                RedisSerializer.Serialize(new TestCacheItem { Value = cacheValue }, typeof(TestCacheItem));
+
+            await RedisDatabase.Received(2).StringSetAsync(Arg.Any<RedisKey>(), cachedObject, Arg.Any<TimeSpan>(),
+                Arg.Any<When>(),
+                Arg.Any<CommandFlags>());
+
+            (await _typedCache.GetOrDefaultAsync(cacheKey)).Value.ShouldBe(cacheValue);
+
+            counter.ShouldBe(2);
+            item1.ShouldNotBe(null);
+            item1.Value.ShouldBe(cacheValue);
+
+            item2.ShouldNotBe(null);
+            item2.Value.ShouldBe(cacheValue);
+
+            item3.ShouldNotBe(null);
+            item3.Value.ShouldBe(cacheValue);
+
+            item4.ShouldNotBe(null);
+            item4.Value.ShouldBe(cacheValue);
+        }
+
+        #endregion
+
+        [Serializable]
+        public class TestCacheItem
+        {
+            public int Value { get; set; }
+        }
+    }
+}

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCacheTestModule.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCacheTestModule.cs
@@ -2,7 +2,7 @@
 using Abp.Reflection.Extensions;
 using Abp.Runtime.Caching.Redis;
 
-namespace Abp.Zero.Redis
+namespace Abp.Zero.Redis.PerRequestRedisCache
 {
     [DependsOn(typeof(AbpAspNetCorePerRequestRedisCacheModule))]
     public class AbpPerRequestRedisCacheTestModule : AbpModule

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/PerRequestRedisCacheTestsBase.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/PerRequestRedisCacheTestsBase.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using Abp.Modules;
+using Abp.Runtime.Caching.Redis;
+using Abp.TestBase;
+using Castle.MicroKernel.Registration;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using StackExchange.Redis;
+
+namespace Abp.Zero.Redis.PerRequestRedisCache
+{
+    public abstract class PerRequestRedisCacheTestsBase<TStartupModule>: AbpIntegratedTestBase<TStartupModule> 
+    where TStartupModule : AbpModule
+    {
+        protected IDatabase RedisDatabase;
+        protected IRedisCacheSerializer RedisSerializer;
+        protected HttpContext CurrentHttpContext;
+
+        protected override void PreInitialize()
+        {
+            CurrentHttpContext = GetNewContextSubstitute();
+
+            RedisDatabase = Substitute.For<IDatabase>();
+            
+            var redisDatabaseProvider = Substitute.For<IAbpRedisCacheDatabaseProvider>();
+            redisDatabaseProvider.GetDatabase().Returns(RedisDatabase);
+            
+            LocalIocManager.IocContainer.Register(Component.For<IAbpRedisCacheDatabaseProvider>().Instance(redisDatabaseProvider).LifestyleSingleton().IsDefault());
+        }
+
+        protected PerRequestRedisCacheTestsBase()
+        {
+            var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+            httpContextAccessor.HttpContext.Returns(info => CurrentHttpContext);
+
+            LocalIocManager.IocContainer.Register(Component.For<IHttpContextAccessor>().Instance(httpContextAccessor).LifestyleSingleton().IsDefault());
+            
+            RedisSerializer = LocalIocManager.Resolve<IRedisCacheSerializer>();
+        }
+        
+        protected HttpContext GetNewContextSubstitute()
+        {
+            var httpContext = Substitute.For<HttpContext>();
+            httpContext.Items = new Dictionary<object, object>();
+            return httpContext;
+        }
+
+        protected void ChangeHttpContext()
+        {
+            CurrentHttpContext = GetNewContextSubstitute();
+        }
+    }
+}


### PR DESCRIPTION
Allow users to use [PerRequestRedisCache](https://github.com/aspnetboilerplate/aspnetboilerplate/blob/dev/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs) in most cache used places to improve redis performance. With that implementation multiple redis request in one http request will be prevent in that places. 

That pr implements replacement of `AbpPerRequestRedisCache` for `ICacheManager`

Usage:
* Import `Abp.AspNetCore.PerRequestRedisCache` package
* Go to your module's preinitialize and add following code parts
```csharp
public override void PreInitialize()
{
     //...
     Configuration.Caching.UseRedis(usePerRequestRedisCache: true);
}
```
![Screenshot_14](https://user-images.githubusercontent.com/48536631/143138188-77f9bd1a-de88-4ec5-80de-970c841344a6.png)


See https://github.com/aspnetboilerplate/aspnetboilerplate/issues/6275 for more information about `PerRequestRedisCache`

close #6260
