### PR TITLE
Fixed bugs at AbpPerRequestRedisCache

### DIFF
--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs
@@ -194,7 +194,7 @@ namespace Abp.Runtime.Caching.Redis
             
             var localizedKey = GetPerRequestRedisCacheKey(key);
 
-            if (!httpContext.Items.ContainsKey(localizedKey))
+            if (httpContext.Items.ContainsKey(localizedKey))
             {
                 httpContext.Items.Remove(localizedKey);
             }
@@ -210,7 +210,7 @@ namespace Abp.Runtime.Caching.Redis
             {
                 var localizedKey = GetPerRequestRedisCacheKey(key);
 
-                if (!httpContext.Items.ContainsKey(localizedKey))
+                if (httpContext.Items.ContainsKey(localizedKey))
                 {
                     httpContext.Items.Remove(localizedKey);
                 }
@@ -232,7 +232,7 @@ namespace Abp.Runtime.Caching.Redis
             {
                 var localizedKey = GetPerRequestRedisCacheKey(key);
 
-                if (!httpContext.Items.ContainsKey(localizedKey))
+                if (httpContext.Items.ContainsKey(localizedKey))
                 {
                     httpContext.Items.Remove(localizedKey);
                 }
@@ -251,7 +251,7 @@ namespace Abp.Runtime.Caching.Redis
                 {
                     var localizedKey = GetPerRequestRedisCacheKey(key);
 
-                    if (!httpContext.Items.ContainsKey(localizedKey))
+                    if (httpContext.Items.ContainsKey(localizedKey))
                     {
                         httpContext.Items.Remove(localizedKey);
                     }
@@ -272,7 +272,7 @@ namespace Abp.Runtime.Caching.Redis
             
             var localizedKeyPrefix = GetPerRequestRedisCacheKey("");
 
-            foreach (string key in httpContext.Items.Keys.ToList())
+            foreach (string key in httpContext.Items.Keys.OfType<string>.ToList())
             {
                 if (key.StartsWith(localizedKeyPrefix))
                 {


### PR DESCRIPTION
The **AbpPerRequestRedisCache** was based on code I made myself earlier and shared here: https://github.com/aspnetboilerplate/aspnetboilerplate/issues/5821

We have been using my implementation of the PerRequestRedisCache for over a year, and during that time we located some bugs in the original code that we fixed on our side but never shared here.

This pull request contains all the fixes we implemented on that class.
They are all related to removing keys from the cache or clearing the entire cache. 

Once you review the file changes you will notice they are very obvious mistakes, and the last one is related to this issue: https://github.com/aspnetzero/aspnet-zero-core/issues/3958

Please let me know if you have any comments about this PR