### PR TITLE
New configuration options and AbpMailKitConfiguration via SettingManager

### DIFF
--- a/src/Abp.MailKit/Abp.MailKit.csproj
+++ b/src/Abp.MailKit/Abp.MailKit.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="MailKit" Version="3.0.0-preview1" />
+    <PackageReference Include="MailKit" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Abp.MailKit/AbpMailKitConfiguration.cs
+++ b/src/Abp.MailKit/AbpMailKitConfiguration.cs
@@ -1,9 +1,35 @@
-﻿using MailKit.Security;
+﻿using System;
+using Abp.Configuration;
+using Abp.Net.Mail.Smtp;
+using MailKit.Security;
 
 namespace Abp.MailKit
 {
-    public class AbpMailKitConfiguration : IAbpMailKitConfiguration
+    public class AbpMailKitConfiguration : SmtpEmailSenderConfiguration, IAbpMailKitConfiguration
     {
-        public SecureSocketOptions? SecureSocketOption { get; set; }
+        public SecureSocketOptions? SecureSocketOption
+        { 
+            get
+            {
+                var valueAsString = SettingManager.GetSettingValue(MailKitEmailSettingNames.Smtp.SecureSocketOption);
+                if (string.IsNullOrWhiteSpace(valueAsString)) return null;
+
+                SecureSocketOptions result;
+                return Enum.TryParse(valueAsString, true, out result) ? result : SecureSocketOptions.Auto;
+            } 
+        }
+
+        public bool? DisableCertificateValidation => SettingManager.GetSettingValue<bool>(MailKitEmailSettingNames.Smtp.DisableCertificateValidation);
+
+        public bool? CheckCertificateRevocation => SettingManager.GetSettingValue<bool>(MailKitEmailSettingNames.Smtp.CheckCertificateRevocation);
+
+        /// <summary>
+        /// Creates a new <see cref="AbpMailKitConfiguration"/>.
+        /// </summary>
+        /// <param name="settingManager">Setting manager</param>
+        public AbpMailKitConfiguration(ISettingManager settingManager)
+            : base(settingManager) {
+
+        }
     }
 }

--- a/src/Abp.MailKit/AbpMailKitModule.cs
+++ b/src/Abp.MailKit/AbpMailKitModule.cs
@@ -11,6 +11,9 @@ namespace Abp.MailKit
     {
         public override void PreInitialize()
         {
+            Configuration.Settings.Providers.Remove<EmailSettingProvider>();
+            Configuration.Settings.Providers.Add<MailKitEmailSettingProvider>();
+
             IocManager.Register<IAbpMailKitConfiguration, AbpMailKitConfiguration>();
             Configuration.ReplaceService<IEmailSender, MailKitEmailSender>(DependencyLifeStyle.Transient);
         }

--- a/src/Abp.MailKit/IAbpMailKitConfiguration.cs
+++ b/src/Abp.MailKit/IAbpMailKitConfiguration.cs
@@ -1,9 +1,30 @@
-﻿using MailKit.Security;
+﻿using Abp.Net.Mail.Smtp;
+using MailKit.Security;
 
 namespace Abp.MailKit
 {
-    public interface IAbpMailKitConfiguration
-    {
-        SecureSocketOptions? SecureSocketOption { get; set; }
+
+    /// <summary>
+    /// Extends configurations to used by Mailkit-based SmtpClient object.
+    /// </summary>
+    public interface IAbpMailKitConfiguration : ISmtpEmailSenderConfiguration {
+
+        /// <summary>
+        /// If set, force the use of a specific socket option, else it is automatic
+        /// </summary>
+        SecureSocketOptions? SecureSocketOption { get; }
+
+        /// <summary>
+        ///     If set to true, force MailKit to accept certificates self-signed, expired, etc.
+        ///     Default behaviour is: leave Mailkit to verify certificates
+        /// </summary>
+        bool? DisableCertificateValidation { get; }
+
+        /// <summary>
+        ///     If set to true, connections via SSL/TLS checks certificate revocation.
+        ///     Normally, the value of this property should be set to true (the default) for security reasons
+        ///     Default behaviour: if null, use the Mailkit default (check is active)
+        /// </summary>
+        bool? CheckCertificateRevocation { get; }
     }
 }

--- a/src/Abp.MailKit/MailKitEmailSender.cs
+++ b/src/Abp.MailKit/MailKitEmailSender.cs
@@ -11,7 +11,7 @@ namespace Abp.MailKit
         private readonly IMailKitSmtpBuilder _smtpBuilder;
 
         public MailKitEmailSender(
-            IEmailSenderConfiguration smtpEmailSenderConfiguration,
+            IAbpMailKitConfiguration smtpEmailSenderConfiguration,
             IMailKitSmtpBuilder smtpBuilder)
             : base(
                   smtpEmailSenderConfiguration)

--- a/src/Abp.MailKit/MailKitEmailSettingNames.cs
+++ b/src/Abp.MailKit/MailKitEmailSettingNames.cs
@@ -1,0 +1,30 @@
+﻿namespace Abp.MailKit
+{
+    /// <summary>
+    /// Declares names of the settings defined by <see cref="MailKitEmailSettingProvider"/>.
+    /// </summary>
+    public static class MailKitEmailSettingNames
+    {
+        /// <summary>
+        /// SMTP related email settings.
+        /// </summary>
+        public static class Smtp
+        {
+            /// <summary>
+            /// AbAbp.Net.Mail.Smtp.MailKit.SecureSocketOption
+            /// </summary>
+            public const string SecureSocketOption = "Abp.Net.Mail.Smtp.MailKit.SecureSocketOption";
+
+            /// <summary>
+            /// AbAbp.Net.Mail.Smtp.MailKit.CheckCertificateRevocation
+            /// </summary>
+            public const string CheckCertificateRevocation = "Abp.Net.Mail.Smtp.MailKit.CheckCertificateRevocation";
+
+            /// <summary>
+            /// Abp.Net.Mail.Smtp.MailKit.DisableCertificateValidation
+            /// </summary>
+            public const string DisableCertificateValidation = "Abp.Net.Mail.Smtp.MailKit.DisableCertificateValidation";
+
+        }
+    }
+}

--- a/src/Abp.MailKit/MailKitEmailSettingProvider.cs
+++ b/src/Abp.MailKit/MailKitEmailSettingProvider.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Abp.Configuration;
+using Abp.Localization;
+using Abp.Net.Mail;
+
+namespace Abp.MailKit
+{
+    /// <summary>
+    /// Defines settings to send emails.
+    /// <see cref="MailKitEmailSettingNames"/> for all available configurations.
+    /// </summary>
+    public class MailKitEmailSettingProvider : EmailSettingProvider
+    {
+        public override IEnumerable<SettingDefinition> GetSettingDefinitions(SettingDefinitionProviderContext context)
+        {
+            var settings = new List<SettingDefinition>(base.GetSettingDefinitions(context));
+            settings.AddRange(
+                new[]
+                   {
+                       new SettingDefinition(MailKitEmailSettingNames.Smtp.SecureSocketOption, null, L("SecureSocketOption"), scopes: SettingScopes.Application | SettingScopes.Tenant),
+                       new SettingDefinition(MailKitEmailSettingNames.Smtp.CheckCertificateRevocation, null, L("CheckCertificateRevocation"), scopes: SettingScopes.Application | SettingScopes.Tenant),
+                       new SettingDefinition(MailKitEmailSettingNames.Smtp.DisableCertificateValidation, null, L("DisableCertificateValidation"), scopes: SettingScopes.Application | SettingScopes.Tenant),
+                   }
+                );
+
+            return settings;
+        }
+
+    }
+}

--- a/src/Abp/Net/Mail/EmailSettingProvider.cs
+++ b/src/Abp/Net/Mail/EmailSettingProvider.cs
@@ -8,7 +8,7 @@ namespace Abp.Net.Mail
     /// Defines settings to send emails.
     /// <see cref="EmailSettingNames"/> for all available configurations.
     /// </summary>
-    internal class EmailSettingProvider : SettingProvider
+    public class EmailSettingProvider : SettingProvider
     {
         public override IEnumerable<SettingDefinition> GetSettingDefinitions(SettingDefinitionProviderContext context)
         {
@@ -26,7 +26,7 @@ namespace Abp.Net.Mail
                    };
         }
 
-        private static LocalizableString L(string name)
+        protected static LocalizableString L(string name)
         {
             return new LocalizableString(name, AbpConsts.LocalizationSourceName);
         }

--- a/test/Abp.MailKit.Tests/MailKitEmailSender_Tests.cs
+++ b/test/Abp.MailKit.Tests/MailKitEmailSender_Tests.cs
@@ -1,13 +1,13 @@
-﻿using System.Threading.Tasks;
-using Abp.Net.Mail.Smtp;
+﻿using System.Net.Mail;
+using System.Threading.Tasks;
 using NSubstitute;
-using System.Net.Mail;
+using Xunit;
 
 namespace Abp.MailKit.Tests
 {
     public class MailKitEmailSender_Tests
     {
-        //[Fact]
+        //[Fact]  //Need to set configuration before executing this test
         public void ShouldSend()
         {
             var mailSender = CreateMailKitEmailSender();
@@ -15,7 +15,7 @@ namespace Abp.MailKit.Tests
             mailSender.Send("from_mail_address", "to_mail_address", "subject", "body", true);
         }
 
-        //[Fact]
+        //[Fact]  //Need to set configuration before executing this test
         public async Task ShouldSendAsync()
         {
             var mailSender = CreateMailKitEmailSender();
@@ -23,7 +23,7 @@ namespace Abp.MailKit.Tests
             await mailSender.SendAsync("from_mail_address", "to_mail_address", "subject", "body", true);
         }
 
-        //[Fact]
+        //[Fact]  //Need to set configuration before executing this test
         public async Task ShouldSendMailMessageAsync()
         {
             var mailSender = CreateMailKitEmailSender();
@@ -33,7 +33,7 @@ namespace Abp.MailKit.Tests
             await mailSender.SendAsync(mailMessage);
         }
 
-        //[Fact]
+        //[Fact]  //Need to set configuration before executing this test
         public void ShouldSendMailMessage()
         {
             var mailSender = CreateMailKitEmailSender();
@@ -43,17 +43,35 @@ namespace Abp.MailKit.Tests
             mailSender.Send(mailMessage);
         }
 
+        //[Fact]  //Need to set configuration before executing this test
+        public void ShouldSendWithDefaultFrom()
+        {
+            var mailSender = CreateMailKitEmailSender();
+
+            mailSender.Send("to_mail_address", "subject", "body", true);
+        }
+
         private static MailKitEmailSender CreateMailKitEmailSender()
         {
-            var mailConfig = Substitute.For<ISmtpEmailSenderConfiguration>();
+            var mailConfig = Substitute.For<IAbpMailKitConfiguration>();
+
+            mailConfig.DefaultFromAddress.Returns("...");
+            mailConfig.DefaultFromDisplayName.Returns("...");
 
             mailConfig.Host.Returns("stmp_server_name");
-            mailConfig.UserName.Returns("mail_server_user_name");
-            mailConfig.Password.Returns("mail_server_password");
             mailConfig.Port.Returns(587);
             mailConfig.EnableSsl.Returns(false);
 
-            var mailSender = new MailKitEmailSender(mailConfig, new DefaultMailKitSmtpBuilder(mailConfig, new AbpMailKitConfiguration()));
+            //configuration.Domain.Returns("...");
+            mailConfig.UserName.Returns("mail_server_user_name");
+            mailConfig.Password.Returns("mail_server_password.");
+
+            // MailKit specifics
+            //mailConfig.SecureSocketOption.Returns((MailKit.Security.SecureSocketOptions?)null);
+            mailConfig.CheckCertificateRevocation.Returns((bool?)null);
+            mailConfig.DisableCertificateValidation.Returns((bool?)null);
+
+            var mailSender = new MailKitEmailSender(mailConfig, new DefaultMailKitSmtpBuilder(mailConfig));
             return mailSender;
         }
     }


### PR DESCRIPTION
With this change AbpMailKitConfiguration extends SmtpEmailSenderConfiguration so that SmtpEmailSenderConfiguration is no more required to use Abp.Mailkit.

Setting are available via setting manager with new keys available in class MailKitEmailSettingNames

Changes are compatible with Abp v. 6.x