### PR TITLE
Handle EF property mapped directly to a field for Entity History

### DIFF
--- a/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.ZeroCore.EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -219,7 +219,7 @@ namespace Abp.EntityHistory
                     continue;
                 }
 
-                var shouldSaveProperty = property.IsShadowProperty() // i.e. property.PropertyInfo == null
+                var shouldSaveProperty = property.PropertyInfo == null // Shadow properties or if mapped directly to a field
                     ? !auditedPropertiesOnly
                     : IsAuditedPropertyInfo(property.PropertyInfo) ?? !auditedPropertiesOnly;
 
@@ -269,7 +269,7 @@ namespace Abp.EntityHistory
                 {
                     foreach (var property in foreignKey.Properties)
                     {
-                        var shouldSaveProperty = property.IsShadowProperty()
+                        var shouldSaveProperty = property.PropertyInfo == null // Shadow properties or if mapped directly to a field
                             ? null
                             : IsAuditedPropertyInfo(entityEntryType, property.PropertyInfo);
 
@@ -302,10 +302,10 @@ namespace Abp.EntityHistory
                         var ownerForeignKey = foreignKeys.First(fk => fk.IsOwnership);
                         propertyEntityType = ownerForeignKey.PrincipalEntityType.ClrType;
                     }
-                    var isAuditedProperty = !propertyEntry.Metadata.IsShadowProperty() &&
-                                            IsAuditedPropertyInfo(propertyEntityType,
-                                                propertyEntry.Metadata.PropertyInfo) == true;
-                    var isForeignKeyShadowProperty = propertyEntry.Metadata.IsShadowProperty() && foreignKeys.Any(fk => fk.Properties.Any(p => p.Name == propertyChange.PropertyName));
+                    var property = propertyEntry.Metadata;
+                    var isAuditedProperty = property.PropertyInfo != null &&
+                                            (IsAuditedPropertyInfo(propertyEntityType, property.PropertyInfo) ?? false);
+                    var isForeignKeyShadowProperty = property.IsShadowProperty() && foreignKeys.Any(fk => fk.Properties.Any(p => p.Name == propertyChange.PropertyName));
 
                     propertyChange.SetNewValue(propertyEntry.GetNewValue()?.ToJsonString());
                     if ((!isAuditedProperty && !isForeignKeyShadowProperty) || propertyChange.IsValuesEquals())

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Blog.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/Blog.cs
@@ -9,7 +9,11 @@ namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
     [Audited]
     public class Blog : AggregateRoot, IHasCreationTime
     {
-        [DisableAuditing] public string Name { get; set; }
+        // EF property mapped directly to a field
+        private string _name;
+
+        [DisableAuditing]
+        public string Name { get => _name; set => _name = value; }
 
         public string Url { get; protected set; }
 

--- a/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
+++ b/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
@@ -52,6 +52,10 @@ namespace Abp.ZeroCore.SampleApp.EntityFramework
 
             modelBuilder.ConfigurePersistedGrantEntity();
 
+            // EF property mapped directly to a field
+            modelBuilder.Entity<Blog>()
+                 .Property<string>("_name").HasColumnName("Name");
+
             modelBuilder.Entity<Blog>().OwnsOne(x => x.More);
 
             modelBuilder.Entity<Blog>().OwnsMany(x => x.Promotions, b => 


### PR DESCRIPTION
Fixes #6279 

1. Currently, it causes `NullReferenceException` since `property.PropertyInfo` is `null`  if mapped directly to a field.
https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.metadata.ipropertybase.propertyinfo?view=efcore-3.1#Microsoft_EntityFrameworkCore_Metadata_IPropertyBase_PropertyInfo
This PR handles EF property mapped directly to a field as not an audited property.
Notably, it is not possible to define attributes on a field.

2. This PR also fixes `isAuditedProperty` in `UpdateChangeSet` and properly handles foreign key shadow property.
Related test: `Should_Write_History_For_Audited_Property_Foreign_Key_Shadow`