### PR TITLE
Update Nuke.Common package for .NET 6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.CommandLine" Version="5.11.0">
+    <PackageReference Include="NuGet.CommandLine" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+    <PackageReference Include="Nuke.Common" Version="6.0.0-beta0012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.0-preview.6.21352.12",
+    "version": "6.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Abp.MailKit/Abp.MailKit.csproj
+++ b/src/Abp.MailKit/Abp.MailKit.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="MailKit" Version="3.0.0-preview1" />
+    <PackageReference Include="MailKit" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/Startup.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/Startup.cs
@@ -84,7 +84,7 @@ namespace AbpAspNetCoreDemo
                     @"..\AbpAspNetCoreDemo.PlugIn\bin\Debug\net6.0\AbpAspNetCoreDemo.PlugIn.dll");
 #else
                 plugDllInPath = Path.Combine(_env.ContentRootPath,
-                    @"..\AbpAspNetCoreDemo.PlugIn\bin\Release\net5.0\AbpAspNetCoreDemo.PlugIn.dll");
+                    @"..\AbpAspNetCoreDemo.PlugIn\bin\Release\net6.0\AbpAspNetCoreDemo.PlugIn.dll");
 #endif
                 if (!File.Exists(plugDllInPath))
                 {


### PR DESCRIPTION
Follows #6265 and #6309

1. Update Nuke.Common from 5.3.0 to 6.0.0-beta0012 to fix AppVeyor checks.
   - Also fix plugin DLL path in Release mode in test/aspnet-core-demo/AbpAspNetCoreDemo/Startup.cs.
2. Update .NET SDK version in .github/workflows/build-and-test.yml to fix GitHub Actions checks.
3. Also update:
   - NuGet.CommandLine from 5.11.0 to 6.0.0
   - MailKit from 3.0.0-preview1 to 3.0.0