### PR TITLE
Create AbpODataDtoController for OData with DTO's

### DIFF
--- a/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataDtoController
+++ b/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataDtoController
@@ -19,7 +19,7 @@ namespace Framing_App.OData
 {
     public abstract class AbpODataDtoController<TEntity, TDto> : AbpODataDtoController<TEntity, int, TDto, TDto> 
         where TEntity : class, IEntity<int>
-        where TDto : class
+        where TDto : class, IEntityDto<int>
     {
         protected AbpODataDtoController(IRepository<TEntity> repository, IObjectMapper objectMapper)
             : base(repository, objectMapper)
@@ -31,8 +31,8 @@ namespace Framing_App.OData
 
     public abstract class AbpODataDtoController<TEntity, TOutputDto, TInputDto> : AbpODataDtoController<TEntity, int, TOutputDto, TInputDto> //Code copied and modifed for DTO's, from: https://github.com/aspnetboilerplate/aspnetboilerplate/blob/dev/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataEntityController.cs
         where TEntity : class, IEntity<int>
-        where TOutputDto : class
-        where TInputDto : class
+        where TOutputDto : class, IEntityDto<int>
+        where TInputDto : class, IEntityDto<int>
     {
         protected ODataDTOControllerBase(IRepository<TEntity> repository, IObjectMapper objectMapper)
             : base(repository, objectMapper)
@@ -56,8 +56,8 @@ namespace Framing_App.OData
     public abstract class AbpODataDtoController<TEntity, TPrimaryKey, TOutputDto, TInputDto> : AbpODataController, ITransientDependency
         where TPrimaryKey : IEquatable<TPrimaryKey>
         where TEntity : class, IEntity<TPrimaryKey>
-        where TOutputDto : class
-        where TInputDto : class
+        where TOutputDto : class, IEntityDto<TPrimaryKey>
+        where TInputDto : class, IEntityDto<TPrimaryKey>
     {
         protected IRepository<TEntity, TPrimaryKey> Repository { get; private set; }
         protected IObjectMapper ObjectMapper { get; private set; }

--- a/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataDtoController
+++ b/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataDtoController
@@ -1,0 +1,201 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Abp.AspNetCore.Mvc.Controllers;
+using Abp.AspNetCore.OData.Controllers;
+using Abp.Authorization;
+using Abp.AutoMapper;
+using Abp.Dependency;
+using Abp.Domain.Entities;
+using Abp.Domain.Repositories;
+using Abp.Modules;
+using Abp.ObjectMapping;
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Framing_App.OData
+{
+    public abstract class AbpODataDtoController<TEntity, TDto> : AbpODataDtoController<TEntity, int, TDto, TDto> 
+        where TEntity : class, IEntity<int>
+        where TDto : class
+    {
+        protected AbpODataDtoController(IRepository<TEntity> repository, IObjectMapper objectMapper)
+            : base(repository, objectMapper)
+        {
+
+        }
+    }
+
+
+    public abstract class AbpODataDtoController<TEntity, TOutputDto, TInputDto> : AbpODataDtoController<TEntity, int, TOutputDto, TInputDto> //Code copied and modifed for DTO's, from: https://github.com/aspnetboilerplate/aspnetboilerplate/blob/dev/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataEntityController.cs
+        where TEntity : class, IEntity<int>
+        where TOutputDto : class
+        where TInputDto : class
+    {
+        protected ODataDTOControllerBase(IRepository<TEntity> repository, IObjectMapper objectMapper)
+            : base(repository, objectMapper)
+        {
+
+        }
+    }
+
+
+
+    /// <summary>
+    /// A modifed verison of AbpODataEntityController, but manipulated DTO's, rather than raw Entities.
+    /// This allows for better control and security of data, rather than using OData's EDM convention annotations on the entity models.
+    /// Thus, keeping the EF and OData code sperated and clean.
+    /// This code was coppied directly from (v6.4): https://github.com/aspnetboilerplate/aspnetboilerplate/blob/dev/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataEntityController.cs
+    /// </summary>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <typeparam name="TPrimaryKey"></typeparam>
+    /// <typeparam name="TOutputDto"></typeparam>
+    /// <typeparam name="TInputDto"></typeparam>
+    public abstract class AbpODataDtoController<TEntity, TPrimaryKey, TOutputDto, TInputDto> : AbpODataController, ITransientDependency
+        where TPrimaryKey : IEquatable<TPrimaryKey>
+        where TEntity : class, IEntity<TPrimaryKey>
+        where TOutputDto : class
+        where TInputDto : class
+    {
+        protected IRepository<TEntity, TPrimaryKey> Repository { get; private set; }
+        protected IObjectMapper ObjectMapper { get; private set; }
+        protected ODataDTOControllerBase(IRepository<TEntity, TPrimaryKey> repository, 
+                                                                IObjectMapper objectMapper)
+        {
+            Repository = repository;
+            ObjectMapper = objectMapper;
+        }
+
+        //Might be helpfull for automapper https://docs.automapper.org/en/stable/Queryable-Extensions.html#explicit-expansion
+
+
+        protected virtual string GetPermissionName { get; set; }
+
+        protected virtual string GetAllPermissionName { get; set; }
+
+        protected virtual string CreatePermissionName { get; set; }
+
+        protected virtual string UpdatePermissionName { get; set; }
+
+        protected virtual string DeletePermissionName { get; set; }
+
+        [EnableQuery]
+        public virtual IQueryable<TOutputDto> Get( )
+        {
+            CheckGetAllPermission();
+
+            return ObjectMapper.ProjectTo<TOutputDto>(Repository.GetAll());
+        }
+
+        [EnableQuery]
+        public virtual SingleResult<TOutputDto> Get([FromODataUri] TPrimaryKey key)
+        {
+            CheckGetPermission();
+
+            var entity = Repository.GetAll().Where(e => e.Id.Equals(key));
+
+            return SingleResult.Create(ObjectMapper.ProjectTo<TOutputDto>(entity));
+        }
+
+        public virtual async Task<IActionResult> Post([FromBody] TInputDto InputDto)
+        {
+            CheckCreatePermission();
+
+            if (!ModelState.IsValid) {
+                return BadRequest(ModelState);
+            }
+
+            var createdEntity = await Repository.InsertAsync(ObjectMapper.Map<TEntity>(InputDto));
+            await UnitOfWorkManager.Current.SaveChangesAsync();
+
+            return Created(createdEntity);
+        }
+
+        public virtual async Task<IActionResult> Patch([FromODataUri] TPrimaryKey key, [FromBody] Delta<TInputDto> deltaInputDto)
+        {
+            CheckUpdatePermission();
+
+            if (!ModelState.IsValid) {
+                return BadRequest(ModelState);
+            }
+
+            var Entity = await Repository.GetAsync(key);
+            if (Entity == null) {
+                return NotFound();
+            }
+            var EntityDto = ObjectMapper.Map<TInputDto>(Entity);
+
+            deltaInputDto.Patch(EntityDto);
+            Entity = ObjectMapper.Map<TEntity>(deltaInputDto);//Test if updates database
+
+            return Updated(EntityDto);
+        }
+
+        public virtual async Task<IActionResult> Put([FromODataUri] TPrimaryKey key, [FromBody] TInputDto InputDto)
+        {
+            CheckUpdatePermission();
+
+            if (!ModelState.IsValid) {
+                return BadRequest(ModelState);
+            }
+
+            TEntity NewEntity = ObjectMapper.Map<TEntity>(InputDto);
+
+            if (!key.Equals(NewEntity.Id)) {
+                return BadRequest();
+            }
+
+            var updated = await Repository.UpdateAsync(NewEntity);
+
+            return Updated(updated);
+        }
+
+        public virtual async Task<IActionResult> Delete([FromODataUri] TPrimaryKey key)
+        {
+            CheckDeletePermission();
+
+            var product = await Repository.GetAsync(key);
+            if (product == null) {
+                return NotFound();
+            }
+
+            await Repository.DeleteAsync(key);
+
+            return StatusCode((int)HttpStatusCode.NoContent);
+        }
+
+        protected virtual void CheckPermission(string permissionName)
+        {
+            if (!string.IsNullOrEmpty(permissionName)) {
+                PermissionChecker.Authorize(permissionName);
+            }
+        }
+
+        protected virtual void CheckGetPermission( )
+        {
+            CheckPermission(GetPermissionName);
+        }
+
+        protected virtual void CheckGetAllPermission( )
+        {
+            CheckPermission(GetAllPermissionName);
+        }
+
+        protected virtual void CheckCreatePermission( )
+        {
+            CheckPermission(CreatePermissionName);
+        }
+
+        protected virtual void CheckUpdatePermission( )
+        {
+            CheckPermission(UpdatePermissionName);
+        }
+
+        protected virtual void CheckDeletePermission( )
+        {
+            CheckPermission(DeletePermissionName);
+        }
+    }
+}

--- a/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataDtoController
+++ b/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataDtoController
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Abp.Application.Services.Dto;
 using Abp.AspNetCore.Mvc.Controllers;
 using Abp.AspNetCore.OData.Controllers;
 using Abp.Authorization;
@@ -11,17 +12,25 @@ using Abp.Domain.Entities;
 using Abp.Domain.Repositories;
 using Abp.Modules;
 using Abp.ObjectMapping;
-using Microsoft.AspNet.OData;
-using Microsoft.AspNet.OData.Builder;
+using Framing_App.OData.Interfaces;
+using Microsoft.OData.ModelBuilder;
 using Microsoft.AspNetCore.Mvc;
+//using AutoMapper.AspNet.OData;
+using AutoMapper;
+using AutoMapper.AspNet.OData;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Deltas;
+//using Microsoft.AspNet.OData.Query;
 
 namespace Framing_App.OData
 {
-    public abstract class AbpODataDtoController<TEntity, TDto> : AbpODataDtoController<TEntity, int, TDto, TDto> 
+    public abstract class ODataDTOControllerBase<TEntity, TDto> : ODataDTOControllerBase<TEntity, int, TDto, TDto> 
         where TEntity : class, IEntity<int>
         where TDto : class, IEntityDto<int>
     {
-        protected AbpODataDtoController(IRepository<TEntity> repository, IObjectMapper objectMapper)
+        protected ODataDTOControllerBase(IRepository<TEntity> repository, /*IObjectMapper*/ IMapper objectMapper)
             : base(repository, objectMapper)
         {
 
@@ -29,12 +38,25 @@ namespace Framing_App.OData
     }
 
 
-    public abstract class AbpODataDtoController<TEntity, TOutputDto, TInputDto> : AbpODataDtoController<TEntity, int, TOutputDto, TInputDto> //Code copied and modifed for DTO's, from: https://github.com/aspnetboilerplate/aspnetboilerplate/blob/dev/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataEntityController.cs
+    //public abstract class ODataDTOControllerBase<TEntity, TPrimaryKey, TDto> : ODataDTOControllerBase<TEntity, TPrimaryKey, TDto, TDto>
+    //    where TEntity : class, IEntity<int>
+    //    where TPrimaryKey : IEquatable<TPrimaryKey>
+    //    where TDto : class
+    //{
+    //    protected ODataDTOControllerBase(IRepository<TEntity> repository, IObjectMapper objectMapper)
+    //        : base(repository, objectMapper)
+    //    {
+
+    //    }
+    //}
+
+
+    public abstract class ODataDTOControllerBase<TEntity, TOutputDto, TInputDto> : ODataDTOControllerBase<TEntity, int, TOutputDto, TInputDto> //Code copied and modifed for DTO's, from: https://github.com/aspnetboilerplate/aspnetboilerplate/blob/dev/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataEntityController.cs
         where TEntity : class, IEntity<int>
         where TOutputDto : class, IEntityDto<int>
         where TInputDto : class, IEntityDto<int>
     {
-        protected ODataDTOControllerBase(IRepository<TEntity> repository, IObjectMapper objectMapper)
+        protected ODataDTOControllerBase(IRepository<TEntity> repository, /*IObjectMapper*/ IMapper objectMapper)
             : base(repository, objectMapper)
         {
 
@@ -47,28 +69,37 @@ namespace Framing_App.OData
     /// A modifed verison of AbpODataEntityController, but manipulated DTO's, rather than raw Entities.
     /// This allows for better control and security of data, rather than using OData's EDM convention annotations on the entity models.
     /// Thus, keeping the EF and OData code sperated and clean.
+    /// Uses AutoMapper.AspNet.OData nuget package to enable automapping with DTO's whilst keeping the IQuereyable valid and sql efficient (ProjectTo does not do this)
     /// This code was coppied directly from (v6.4): https://github.com/aspnetboilerplate/aspnetboilerplate/blob/dev/src/Abp.AspNetCore.OData/AspNetCore/OData/Controllers/AbpODataEntityController.cs
     /// </summary>
     /// <typeparam name="TEntity"></typeparam>
     /// <typeparam name="TPrimaryKey"></typeparam>
     /// <typeparam name="TOutputDto"></typeparam>
     /// <typeparam name="TInputDto"></typeparam>
-    public abstract class AbpODataDtoController<TEntity, TPrimaryKey, TOutputDto, TInputDto> : AbpODataController, ITransientDependency
+    public abstract class ODataDTOControllerBase<TEntity, TPrimaryKey, TOutputDto, TInputDto> : AbpODataController, IODataDTOControllerBase, ITransientDependency//Transient dependency realy important
         where TPrimaryKey : IEquatable<TPrimaryKey>
         where TEntity : class, IEntity<TPrimaryKey>
         where TOutputDto : class, IEntityDto<TPrimaryKey>
         where TInputDto : class, IEntityDto<TPrimaryKey>
     {
         protected IRepository<TEntity, TPrimaryKey> Repository { get; private set; }
-        protected IObjectMapper ObjectMapper { get; private set; }
-        protected ODataDTOControllerBase(IRepository<TEntity, TPrimaryKey> repository, 
-                                                                IObjectMapper objectMapper)
+        //protected IObjectMapper ObjectMapper { get; private set; }
+        protected IMapper Mapper { get; private set; }
+        protected ODataDTOControllerBase(IRepository<TEntity, TPrimaryKey> repository,
+                                                                //IObjectMapper objectMapper)
+                                                                IMapper mapper)
         {
             Repository = repository;
-            ObjectMapper = objectMapper;
+            //ObjectMapper = objectMapper;
+            Mapper = mapper;
         }
 
         //Might be helpfull for automapper https://docs.automapper.org/en/stable/Queryable-Extensions.html#explicit-expansion
+
+        public abstract void EDMFluentAPIConfig(ODataConventionModelBuilder builder);
+        public virtual void DTOAutoMapperConfig(AutoMapper.IMapperConfigurationExpression configuration) { /*do nothing, assumed convention + attributes*/ }
+        //public abstract void DTOAutoMapperConfig(AutoMapper.IMapperConfigurationExpression configuration);
+
 
 
         protected virtual string GetPermissionName { get; set; }
@@ -81,23 +112,48 @@ namespace Framing_App.OData
 
         protected virtual string DeletePermissionName { get; set; }
 
-        [EnableQuery]
-        public virtual IQueryable<TOutputDto> Get( )
+        //[EnableQuery]
+        //public async virtual Task<IQueryable<TOutputDto>> Get()
+        //{
+        //    CheckGetAllPermission();
+
+        //    return /*Object*/Mapper.ProjectTo<TOutputDto>(Repository.GetAll());
+        //}
+
+        public async virtual Task<IActionResult> Get(ODataQueryOptions<TOutputDto> options/*, [Bind(Prefix = "$page")] int page = null, */)
         {
             CheckGetAllPermission();
 
-            return ObjectMapper.ProjectTo<TOutputDto>(Repository.GetAll());
+            //if ()//add me to odataquerey options
+
+            return Ok(await Repository.GetAll().GetAsync(Mapper, options, null));
         }
 
-        [EnableQuery]
-        public virtual SingleResult<TOutputDto> Get([FromODataUri] TPrimaryKey key)
+
+
+        //[EnableQuery]
+        //public virtual SingleResult<TOutputDto> Get([FromODataUri] TPrimaryKey key)
+        //{
+        //    CheckGetPermission();
+
+        //    var entity = Repository.GetAll().Where(e => e.Id.Equals(key));
+
+        //    return SingleResult.Create(ObjectMapper.ProjectTo<TOutputDto>(entity));
+        //}
+
+        //[EnableQuery]
+        public async virtual Task<TOutputDto> Get([FromODataUri] TPrimaryKey key, ODataQueryOptions<TOutputDto> options)
         {
             CheckGetPermission();
 
-            var entity = Repository.GetAll().Where(e => e.Id.Equals(key));
+            var entity = (await Repository.GetAll().GetQueryAsync(Mapper, options, null)).Where(e => e.Id.Equals(key));
 
-            return SingleResult.Create(ObjectMapper.ProjectTo<TOutputDto>(entity));
+            return entity.FirstOrDefault();
         }
+
+
+
+
 
         public virtual async Task<IActionResult> Post([FromBody] TInputDto InputDto)
         {
@@ -107,11 +163,15 @@ namespace Framing_App.OData
                 return BadRequest(ModelState);
             }
 
-            var createdEntity = await Repository.InsertAsync(ObjectMapper.Map<TEntity>(InputDto));
+            var createdEntity = await Repository.InsertAsync(/*Object*/Mapper.Map<TEntity>(InputDto));
             await UnitOfWorkManager.Current.SaveChangesAsync();
 
             return Created(createdEntity);
         }
+
+
+
+
 
         public virtual async Task<IActionResult> Patch([FromODataUri] TPrimaryKey key, [FromBody] Delta<TInputDto> deltaInputDto)
         {
@@ -125,13 +185,22 @@ namespace Framing_App.OData
             if (Entity == null) {
                 return NotFound();
             }
-            var EntityDto = ObjectMapper.Map<TInputDto>(Entity);
+            var EntityDto = /*Object*/Mapper.Map<TInputDto>(Entity);
+            //Map entity to a dto
 
             deltaInputDto.Patch(EntityDto);
-            Entity = ObjectMapper.Map<TEntity>(deltaInputDto);//Test if updates database
+            //Apply the patch to the dto
+
+            Entity = /*Object*/Mapper.Map<TEntity>(deltaInputDto);
+            //Map updated dto back to Entity
+
+            await UnitOfWorkManager.Current.SaveChangesAsync();
+            //Ensure update has been sucessfull (Else, exception thrown)
 
             return Updated(EntityDto);
         }
+
+
 
         public virtual async Task<IActionResult> Put([FromODataUri] TPrimaryKey key, [FromBody] TInputDto InputDto)
         {
@@ -141,16 +210,18 @@ namespace Framing_App.OData
                 return BadRequest(ModelState);
             }
 
-            TEntity NewEntity = ObjectMapper.Map<TEntity>(InputDto);
+            TEntity NewEntity = /*Object*/Mapper.Map<TEntity>(InputDto);
 
             if (!key.Equals(NewEntity.Id)) {
                 return BadRequest();
             }
 
-            var updated = await Repository.UpdateAsync(NewEntity);
+            var updatedEntity = await Repository.UpdateAsync(NewEntity);
 
-            return Updated(updated);
+            return Updated(Mapper.Map<TOutputDto>(updatedEntity));
         }
+
+
 
         public virtual async Task<IActionResult> Delete([FromODataUri] TPrimaryKey key)
         {
@@ -166,12 +237,16 @@ namespace Framing_App.OData
             return StatusCode((int)HttpStatusCode.NoContent);
         }
 
+
+
         protected virtual void CheckPermission(string permissionName)
         {
             if (!string.IsNullOrEmpty(permissionName)) {
                 PermissionChecker.Authorize(permissionName);
             }
         }
+
+
 
         protected virtual void CheckGetPermission( )
         {


### PR DESCRIPTION
This is a simple mod, utilising Automapper, to create a contoller base that enables the Use of DTO's with odata, Rather than the raw Entities.
Using a DTO has many advantages, as we know, for code security, but also, it keeps the entitys clean of OData EDM conventions annotations such as [DataMember], [IgnoreDataMember] etc. It allows us to flatten nested joins, created caluclated columns etc.

This implementation allows the user to define all of the EDM Annotations in the DTO rather than the Entity model.
It just requires the regular automapper dto mapping and ODataConventionModelBuilder with: .EntitySet<EntityDTO>(...)...

I think some further OData development like this, could realy make ABP a much more flexable product.