### PR TITLE
add option to add header in webhook publish methods

### DIFF
--- a/doc/WebSite/Webhook-System.md
+++ b/doc/WebSite/Webhook-System.md
@@ -244,7 +244,7 @@ If you want to send webhook(s) to a specific tenant you can set tenant id as see
  await _webHookPublisher.PublishAsync(AppWebHookNames.TenantDeleted, tenantDeletedInput,null);//sends webhook(s) to subscriptions of host
 ```
 
-As we mentioned before, users can define headers for their webhook subscription. But sometimes you may want to send webhooks with same headers. Or you may need to replace user's header or add couple of headers etc.  To do that you can use header parameter in Publish methods.
+As we mentioned before, users can define headers for their webhook subscription. But sometimes you may want to send webhooks with same headers. Or you may need to replace user's header or add a couple of headers etc.  To do that you can use header parameter in Publish methods.
 
 ```csharp
 await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, data, 

--- a/doc/WebSite/Webhook-System.md
+++ b/doc/WebSite/Webhook-System.md
@@ -244,6 +244,25 @@ If you want to send webhook(s) to a specific tenant you can set tenant id as see
  await _webHookPublisher.PublishAsync(AppWebHookNames.TenantDeleted, tenantDeletedInput,null);//sends webhook(s) to subscriptions of host
 ```
 
+As we mentioned before, users can define headers for their webhook subscription. But sometimes you may want to send webhooks with same headers. Or you may need to replace user's header etc. To do that you can use header parameter in Publish methods.
+
+```csharp
+await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, data, 
+  headers: new WebhookHeader()
+  {
+      UseOnlyGivenHeaders = false,
+      Headers = new Dictionary<string, string>()
+      {
+          {"Key1", "Value1"},
+          {"Key3", "Value3"}
+      }
+  };
+);
+```
+
+ Note: 
+ * If subscription already has given header, publisher uses the one you give. 
+ * If the **UseOnlyGivenHeaders** parameter is **true**, webhook will only contain given headers. If it is **false** given headers will be added to predefined headers in subscription (default is **false**).
 
 
 ### Configuration

--- a/doc/WebSite/Webhook-System.md
+++ b/doc/WebSite/Webhook-System.md
@@ -244,7 +244,7 @@ If you want to send webhook(s) to a specific tenant you can set tenant id as see
  await _webHookPublisher.PublishAsync(AppWebHookNames.TenantDeleted, tenantDeletedInput,null);//sends webhook(s) to subscriptions of host
 ```
 
-As we mentioned before, users can define headers for their webhook subscription. But sometimes you may want to send webhooks with same headers. Or you may need to replace user's header etc. To do that you can use header parameter in Publish methods.
+As we mentioned before, users can define headers for their webhook subscription. But sometimes you may want to send webhooks with same headers. Or you may need to replace user's header or add couple of headers etc.  To do that you can use header parameter in Publish methods.
 
 ```csharp
 await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, data, 

--- a/doc/WebSite/Webhook-System.md
+++ b/doc/WebSite/Webhook-System.md
@@ -244,7 +244,7 @@ If you want to send webhook(s) to a specific tenant you can set tenant id as see
  await _webHookPublisher.PublishAsync(AppWebHookNames.TenantDeleted, tenantDeletedInput,null);//sends webhook(s) to subscriptions of host
 ```
 
-As we mentioned before, users can define headers for their webhook subscription. But sometimes you may want to send webhooks with same headers. Or you may need to replace user's header or add a couple of headers etc.  To do that you can use header parameter in Publish methods.
+As we mentioned before, users can define headers for their webhook subscription. But sometimes you may want to send webhooks with same headers or you may need to replace user's header or add a couple of headers etc.  To do that you can use header parameter in Publish methods.
 
 ```csharp
 await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, data, 

--- a/src/Abp/Webhooks/IWebhookPublisher.cs
+++ b/src/Abp/Webhooks/IWebhookPublisher.cs
@@ -16,7 +16,8 @@ namespace Abp.Webhooks
         /// False: It sends data in <see cref="WebhookPayload"/>. It is recommended way.
         /// </para>
         /// </param>
-        Task PublishAsync(string webhookName, object data, bool sendExactSameData = false);
+        /// <param name="headers">Headers to send. Publisher uses subscription defined webhook by default. You can add additional headers from here. If subscription already has given header, publisher uses the one you give here.</param>
+        Task PublishAsync(string webhookName, object data, bool sendExactSameData = false, WebhookHeader headers = null);
 
         /// <summary>
         /// Sends webhooks to current tenant subscriptions (<see cref="IAbpSession.TenantId"/>). with given data, (Checks permissions)
@@ -29,7 +30,8 @@ namespace Abp.Webhooks
         /// False: It sends data in <see cref="WebhookPayload"/>. It is recommended way.
         /// </para>
         /// </param>
-        void Publish(string webhookName, object data, bool sendExactSameData = false);
+        /// <param name="headers">Headers to send. Publisher uses subscription defined webhook by default. You can add additional headers from here. If subscription already has given header, publisher uses the one you give here.</param>
+        void Publish(string webhookName, object data, bool sendExactSameData = false, WebhookHeader headers = null);
 
         /// <summary>
         /// Sends webhooks to given tenant's subscriptions
@@ -45,7 +47,8 @@ namespace Abp.Webhooks
         /// False: It sends data in <see cref="WebhookPayload"/>. It is recommended way.
         /// </para>
         /// </param>
-        Task PublishAsync(string webhookName, object data, int? tenantId, bool sendExactSameData = false);
+        /// <param name="headers">Headers to send. Publisher uses subscription defined webhook by default. You can add additional headers from here. If subscription already has given header, publisher uses the one you give here.</param>
+        Task PublishAsync(string webhookName, object data, int? tenantId, bool sendExactSameData = false, WebhookHeader headers = null);
 
         /// <summary>
         /// Sends webhooks to given tenant's subscriptions
@@ -61,7 +64,8 @@ namespace Abp.Webhooks
         /// False: It sends data in <see cref="WebhookPayload"/>. It is recommended way.
         /// </para>
         /// </param>
-        void Publish(string webhookName, object data, int? tenantId, bool sendExactSameData = false);
+        /// <param name="headers">Headers to send. Publisher uses subscription defined webhook by default. You can add additional headers from here. If subscription already has given header, publisher uses the one you give here.</param>
+        void Publish(string webhookName, object data, int? tenantId, bool sendExactSameData = false, WebhookHeader headers = null);
 
         /// <summary>
         /// Sends webhooks to given tenant's subscriptions
@@ -77,7 +81,8 @@ namespace Abp.Webhooks
         /// False: It sends data in <see cref="WebhookPayload"/>. It is recommended way.
         /// </para>
         /// </param>
-        Task PublishAsync(int?[] tenantIds, string webhookName, object data, bool sendExactSameData = false);
+        /// <param name="headers">Headers to send. Publisher uses subscription defined webhook by default. You can add additional headers from here. If subscription already has given header, publisher uses the one you give here.</param>
+        Task PublishAsync(int?[] tenantIds, string webhookName, object data, bool sendExactSameData = false, WebhookHeader headers = null);
 
         /// <summary>
         /// Sends webhooks to given tenant's subscriptions
@@ -93,6 +98,7 @@ namespace Abp.Webhooks
         /// False: It sends data in <see cref="WebhookPayload"/>. It is recommended way.
         /// </para>
         /// </param>
-        void Publish(int?[] tenantIds, string webhookName, object data, bool sendExactSameData = false);
+        /// <param name="headers">Headers to send. Publisher uses subscription defined webhook by default. You can add additional headers from here. If subscription already has given header, publisher uses the one you give here.</param>
+        void Publish(int?[] tenantIds, string webhookName, object data, bool sendExactSameData = false, WebhookHeader headers = null);
     }
 }

--- a/src/Abp/Webhooks/WebhookHeader.cs
+++ b/src/Abp/Webhooks/WebhookHeader.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Abp.Webhooks
+{
+    public class WebhookHeader
+    {
+        /// <summary>
+        /// If true, webhook will only contain given headers. If false given headers will be added to predefined headers in subscription.
+        /// Default is false
+        /// </summary>
+        public bool UseOnlyGivenHeaders { get; set; }
+        
+        /// <summary>
+        /// That headers will be sent with the webhook.
+        /// </summary>
+        public IDictionary<string, string> Headers { get; set; }
+    }
+}


### PR DESCRIPTION
closes #6322

Example usage:
```csharp
await _webhookPublisher.PublishAsync(AppWebhookDefinitionNames.Users.Created, data, 
  headers: new WebhookHeader()
  {
      UseOnlyGivenHeaders = false,
      Headers = new Dictionary<string, string>()
      {
          {"Key1", "Value1"},
          {"Key3", "Value3"}
      }
  };
);
```
You can add additional headers from using it. If subscription already has given header, publisher uses the one you give.  If the **UseOnlyGivenHeaders** parameter is true, webhook will only contain given headers. Otherwise given headers will be added to predefined headers in subscription(default it false).