### PR TITLE
Implement AbpODataDontWrapResultFilter

### DIFF
--- a/doc/WebSite/OData-AspNetCore-Integration.md
+++ b/doc/WebSite/OData-AspNetCore-Integration.md
@@ -218,6 +218,15 @@ configuration. If you need to, you can set
 `Configuration.Modules.AbpAspNetCoreOData().MapAction` to map OData routes
 yourself.
 
+#### Result Wrapping
+
+`Abp.AspNetCore.OData` implements `AbpODataDontWrapResultFilter` to disable result wrapping for paths that start with `"/odata"`.
+Add it to [`WrapResultFilters`](/Pages/Documents/AspNet-Core#wrapresultfilters) in the `PreInitialize` method of your module:
+
+```c#
+Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new AbpODataDontWrapResultFilter());
+```
+
 ### Examples
 
 Here are some requests made to the controller defined above. Assume that

--- a/doc/WebSite/OData-AspNetCore-Integration.md
+++ b/doc/WebSite/OData-AspNetCore-Integration.md
@@ -39,7 +39,7 @@ dependencies.
 OData requires us to declare entities which can be used as OData resources.
 We must do this in the Startup class:
 
-##### For asp net core 2.x
+##### For ASP.NET Core 2.x
 
 ```csharp
 public class Startup
@@ -96,7 +96,7 @@ public class Startup
 }
 ```
 
-##### For asp net core 3.x
+##### For ASP.NET Core 3.x
 
 ```csharp
 public class Startup
@@ -147,7 +147,7 @@ public class Startup
 }       
 ```
 
-##### For asp net core 5.x and above
+##### For ASP.NET Core 5.x and above
 
 ```csharp
 public class Startup

--- a/doc/WebSite/OData-AspNetCore-Integration.md
+++ b/doc/WebSite/OData-AspNetCore-Integration.md
@@ -129,11 +129,11 @@ public class Startup
         // Return IQueryable from controllers
         app.UseUnitOfWork(options =>
         {
-        	options.Filter = httpContext => httpContext.Request.Path.Value.StartsWith("/odata");
+            options.Filter = httpContext => httpContext.Request.Path.Value.StartsWith("/odata");
         });
         ...
-            
-		app.UseODataBatching();
+
+        app.UseODataBatching();
         app.UseEndpoints(endpoints =>
         {
             ...
@@ -155,14 +155,14 @@ public class Startup
     public IServiceProvider ConfigureServices(IServiceCollection services)
     {
         ...
-		services.AddMvc(/*...*/)
-			.AddOData(opts =>
-				{
-					var builder = new ODataConventionModelBuilder();
-					builder.EntitySet<Person>("Persons").EntityType.Expand().Filter().OrderBy().Page().Select();
-					opts.AddRouteComponents("odata", builder.GetEdmModel());
-				}
-			);
+        services.AddMvc(/*...*/)
+            .AddOData(opts =>
+                {
+                    var builder = new ODataConventionModelBuilder();
+                    builder.EntitySet<Person>("Persons").EntityType.Expand().Filter().OrderBy().Page().Select();
+                    opts.AddRouteComponents("odata", builder.GetEdmModel());
+                }
+            );
 
         return services.AddAbp<MyProjectWebHostModule>(...);
     }
@@ -170,19 +170,19 @@ public class Startup
     public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
     {
         app.UseAbp();
-		
-		// Return IQueryable from controllers
-		app.UseUnitOfWork(options =>
-		{
-			options.Filter = httpContext => httpContext.Request.Path.Value.StartsWith("/odata");
-		});
+
+        // Return IQueryable from controllers
+        app.UseUnitOfWork(options =>
+        {
+            options.Filter = httpContext => httpContext.Request.Path.Value.StartsWith("/odata");
+        });
         ...
-	}
+    }
 }
 ```
 
 
-   
+
 
 Here, we got the ODataModelBuilder reference and set the Person entity.
 You can use EntitySet to add other entities in a similar way. See the [OData
@@ -197,7 +197,7 @@ controllers easier. An example to create an OData endpoint for the Person
 entity:
 
 ```csharp
-public class PersonsController : AbpODataEntityController<Person>, ITransientDependency 
+public class PersonsController : AbpODataEntityController<Person>, ITransientDependency
 {
     public PersonsController(IRepository<Person> repository)
         : base(repository)
@@ -480,7 +480,7 @@ Metadata is used to investigate the service.
 Note: If you want to use `ODataQueryOptions` in the controller methods, you need to ignore validation for `ODataQueryOptions` and `ODataQueryOptions<>` as shown below;
 
 ````csharp
-Configuration.Validation.IgnoredTypes.AddIfNotContains(typeof(ODataQueryOptions)); 
+Configuration.Validation.IgnoredTypes.AddIfNotContains(typeof(ODataQueryOptions));
 Configuration.Validation.IgnoredTypes.AddIfNotContains(typeof(ODataQueryOptions<>));
 ````
 

--- a/src/Abp.AspNetCore.OData/AspNetCore/OData/ResultWrapping/AbpODataDontWrapResultFilter.cs
+++ b/src/Abp.AspNetCore.OData/AspNetCore/OData/ResultWrapping/AbpODataDontWrapResultFilter.cs
@@ -1,0 +1,20 @@
+﻿using Abp.Web.Results.Filters;
+using System;
+
+namespace Abp.AspNetCore.OData.ResultWrapping
+{
+    public class AbpODataDontWrapResultFilter : IWrapResultFilter
+    {
+        public bool HasFilterForWrapOnError(string url, out bool wrapOnError)
+        {
+            wrapOnError = false;
+            return new Uri(url).AbsolutePath.StartsWith("/odata", StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public bool HasFilterForWrapOnSuccess(string url, out bool wrapOnSuccess)
+        {
+            wrapOnSuccess = false;
+            return new Uri(url).AbsolutePath.StartsWith("/odata", StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/AbpODataEntityControllerTests.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/AbpODataEntityControllerTests.cs
@@ -44,6 +44,24 @@ namespace AbpAspNetCoreDemo.IntegrationTests.Tests
         }
 
         [Fact]
+        public async Task AbpODataEntityController_DontWrapResult_Test()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/odata");
+            var response2 = await client.GetAsync("/odata/$metadata");
+
+            // Assert
+            response.StatusCode.ShouldBe(Enum.Parse<HttpStatusCode>("200"));
+            (await response.Content.ReadAsStringAsync()).ShouldNotContain("__abp");
+
+            response2.StatusCode.ShouldBe(Enum.Parse<HttpStatusCode>("200"));
+            (await response2.Content.ReadAsStringAsync()).ShouldNotContain("__abp");
+        }
+
+        [Fact]
         public async Task AbpODataEntityController_GetAll_Permission_Test()
         {
             // Arrange

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo/AbpAspNetCoreDemoModule.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo/AbpAspNetCoreDemoModule.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Abp.AspNetCore;
 using Abp.AspNetCore.Configuration;
 using Abp.AspNetCore.OData;
+using Abp.AspNetCore.OData.ResultWrapping;
 using Abp.Castle.Logging.Log4Net;
 using Abp.Configuration.Startup;
 using Abp.Dependency;
@@ -40,6 +41,7 @@ namespace AbpAspNetCoreDemo
                     typeof(AbpAspNetCoreDemoCoreModule).GetAssembly()
                 );
 
+            Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new AbpODataDontWrapResultFilter());
 
             Configuration.IocManager.Resolve<IAbpAspNetCoreConfiguration>().EndpointConfiguration.Add(endpoints =>
             {


### PR DESCRIPTION
Based on #6199 and aspnetboilerplate/sample-odata#20.
Related: #5856

Let's provide `AbpODataDontWrapResultFilter` in the `Abp.AspNetCore.OData` library since it's a common requirement:
1. [https://stackoverflow.com/questions/70947461/how-to-control-response-wrapping-in-abp-on-a-per-route-basis](https://stackoverflow.com/q/70947461/8601760)
2. [https://stackoverflow.com/questions/49535921/abp-aspnetcore-odata-self-referencing-loop-when-accessing-odata-metadata](https://stackoverflow.com/q/49535921/8601760)
3. [https://stackoverflow.com/questions/47888802/disable-wrapping-of-controller-results](https://stackoverflow.com/q/47888802/8601760)

Notably, `/odata/$metadata` is broken if result wrapping is not disabled (see link 2 above).

Usage, in `PreInitialize` method of a module:

```c#
Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new AbpODataDontWrapResultFilter());
```

*We could do this by default in the `PreInitialize` method of `AbpAspNetCoreODataModule`, but there is also value in letting library users configure this explicitly — to highlight this interaction between the default result wrapping and OData use case.*

This PR includes:
- a test in test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/AbpODataEntityControllerTests.cs.
- a section in doc/WebSite/OData-AspNetCore-Integration.md.

This PR also:
- standardized `asp net core` → `ASP.NET Core` in headings in doc/WebSite/OData-AspNetCore-Integration.md.
- fixed whitespace (converted tabs, removed trailing spaces) in doc/WebSite/OData-AspNetCore-Integration.md.