### PR TITLE
create RegisterForEntity method for registering a single entity for generic repositories

### DIFF
--- a/src/Abp.EntityFramework.Common/Repositories/IEfGenericRepositoryRegistrar.cs
+++ b/src/Abp.EntityFramework.Common/Repositories/IEfGenericRepositoryRegistrar.cs
@@ -6,6 +6,17 @@ namespace Abp.EntityFramework.Repositories
 {
     public interface IEfGenericRepositoryRegistrar
     {
-        void RegisterForDbContext(Type dbContextType, IIocManager iocManager, AutoRepositoryTypesAttribute defaultAutoRepositoryTypesAttribute);
+        void RegisterForDbContext(
+            Type dbContextType,
+            IIocManager iocManager,
+            AutoRepositoryTypesAttribute defaultAutoRepositoryTypesAttribute
+        );
+
+        void RegisterForEntity(
+            Type dbContextType,
+            Type entityType,
+            IIocManager iocManager,
+            AutoRepositoryTypesAttribute defaultAutoRepositoryTypesAttribute
+        );
     }
 }

--- a/src/Abp.EntityFrameworkCore/EntityFrameworkCore/Configuration/AbpDbContextConfiguration.cs
+++ b/src/Abp.EntityFrameworkCore/EntityFrameworkCore/Configuration/AbpDbContextConfiguration.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
 using System.Data.Common;
+using Abp.Domain.Entities;
 
 namespace Abp.EntityFrameworkCore.Configuration
 {
@@ -11,7 +13,7 @@ namespace Abp.EntityFrameworkCore.Configuration
         public DbConnection ExistingConnection { get; internal set; }
 
         public DbContextOptionsBuilder<TDbContext> DbContextOptions { get; }
-        
+
         public AbpDbContextConfiguration(string connectionString, DbConnection existingConnection)
         {
             ConnectionString = connectionString;

--- a/test/Abp.ZeroCore.SampleApp/AbpZeroCoreSampleAppModule.cs
+++ b/test/Abp.ZeroCore.SampleApp/AbpZeroCoreSampleAppModule.cs
@@ -1,15 +1,21 @@
-﻿using Abp.AutoMapper;
+﻿using System;
+using Abp.AutoMapper;
 using Abp.Configuration;
+using Abp.Domain.Repositories;
+using Abp.EntityFramework.Repositories;
 using Abp.EntityFrameworkCore.Configuration;
+using Abp.EntityFrameworkCore.Repositories;
 using Abp.Modules;
 using Abp.Reflection.Extensions;
 using Abp.Zero.EntityFrameworkCore;
 using Abp.ZeroCore.SampleApp.Application;
 using Abp.ZeroCore.SampleApp.Application.Shop;
+using Abp.ZeroCore.SampleApp.Core.EntityHistory;
 using Abp.ZeroCore.SampleApp.Core.Shop;
 using Abp.ZeroCore.SampleApp.EntityFramework;
 using Abp.ZeroCore.SampleApp.EntityFramework.Seed;
 using AutoMapper;
+using Castle.MicroKernel.Registration;
 
 namespace Abp.ZeroCore.SampleApp
 {
@@ -25,7 +31,8 @@ namespace Abp.ZeroCore.SampleApp
             {
                 Configuration.Modules.AbpEfCore().AddDbContext<SampleAppDbContext>(configuration =>
                 {
-                    AbpZeroTemplateDbContextConfigurer.Configure(configuration.DbContextOptions, configuration.ConnectionString);
+                    AbpZeroTemplateDbContextConfigurer.Configure(configuration.DbContextOptions,
+                        configuration.ConnectionString);
                 });
             }
 
@@ -41,6 +48,22 @@ namespace Abp.ZeroCore.SampleApp
         {
             IocManager.RegisterAssemblyByConvention(typeof(AbpZeroCoreSampleAppModule).GetAssembly());
 
+            var genericRepositoryRegistarar = IocManager.Resolve<EfGenericRepositoryRegistrar>();
+            
+            genericRepositoryRegistarar.RegisterForEntity(
+                typeof(SampleAppDbContext),
+                typeof(CustomEntity),
+                IocManager,
+                EfCoreAutoRepositoryTypes.Default
+            );
+            
+            genericRepositoryRegistarar.RegisterForEntity(
+                typeof(SampleAppDbContext),
+                typeof(CustomEntityWithGuidId),
+                IocManager,
+                EfCoreAutoRepositoryTypes.Default
+            );
+            
             Configuration.Modules.AbpAutoMapper().Configurators.Add(configuration =>
             {
                 CustomDtoMapper.CreateMappings(configuration, new MultiLingualMapContext(

--- a/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/CustomEntity.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/EntityHistory/CustomEntity.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Abp.Domain.Entities;
+
+namespace Abp.ZeroCore.SampleApp.Core.EntityHistory
+{
+    public class CustomEntity : Entity
+    {
+        public string Name { get; set; }
+    }
+    
+    public class CustomEntityWithGuidId : Entity<Guid>
+    {
+        public string Name { get; set; }
+    }
+}

--- a/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
+++ b/test/Abp.ZeroCore.SampleApp/EntityFramework/SampleAppDbContext.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Abp.ZeroCore.SampleApp.EntityFramework
 {
-    //TODO: Re-enable when IdentityServer ready
     public class SampleAppDbContext : AbpZeroDbContext<Tenant, Role, User, SampleAppDbContext>, IAbpPersistedGrantDbContext
     {
         public DbSet<PersistedGrantEntity> PersistedGrants { get; set; }
@@ -85,6 +84,10 @@ namespace Abp.ZeroCore.SampleApp.EntityFramework
             modelBuilder.Entity<Book>().Property(e => e.Id).ValueGeneratedNever();
 
             modelBuilder.Entity<Store>().Property(e => e.Id).HasColumnName("StoreId");
+            
+            // Register custom entity which is not in DbContext
+            modelBuilder.Entity(typeof(CustomEntity));
+            modelBuilder.Entity(typeof(CustomEntityWithGuidId));
         }
     }
 }

--- a/test/Abp.ZeroCore.Tests/Zero/Repository/Repository_Dynamic_Entity_Registration_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Repository/Repository_Dynamic_Entity_Registration_Tests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading.Tasks;
+using Abp.Domain.Repositories;
+using Abp.ZeroCore.SampleApp.Core.EntityHistory;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Zero.Repository
+{
+    public class Generic_Repository_Registration_Tests: AbpZeroTestBase
+    {
+        private readonly IRepository<CustomEntity> _customEntityRepository;
+        private readonly IRepository<CustomEntityWithGuidId, Guid> _customEntityWithGuidRepository;
+        
+        public Generic_Repository_Registration_Tests()
+        {
+            _customEntityRepository = LocalIocManager.Resolve<IRepository<CustomEntity>>();
+            _customEntityWithGuidRepository= LocalIocManager.Resolve<IRepository<CustomEntityWithGuidId, Guid>>();
+        }
+
+        [Fact]
+        public async Task Generic_Repository_Registration_Test_For_Entity_With_Int_Id()
+        {
+            var items = await _customEntityRepository.GetAllListAsync();
+            items.Count.ShouldBe(0);
+        }
+        
+        [Fact]
+        public async Task Generic_Repository_Registration_Test_For_Entity_With_Guid_Id()
+        {
+            var items = await _customEntityWithGuidRepository.GetAllListAsync();
+            items.Count.ShouldBe(0);
+        }
+    }
+}


### PR DESCRIPTION
resolves #6272 

With this PR, it will be possible to register entities registered in OnModelCreating of a DbContext for generic IRepository<> as shown below;

```c#
var genericRepositoryRegistarar = IocManager.Resolve<EfGenericRepositoryRegistrar>();
            
genericRepositoryRegistarar.RegisterForEntity(
    typeof(SampleAppDbContext),
    typeof(CustomEntity),
    IocManager,
    EfCoreAutoRepositoryTypes.Default
);
```
