### PR TITLE
Implement GetComputerName of HttpContextClientInfoProvider

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
@@ -40,7 +40,6 @@ namespace Abp.AspNetCore.Mvc.Auditing
             try
             {
                 var httpContext = _httpContextAccessor.HttpContext;
-
                 return httpContext?.Connection?.RemoteIpAddress?.ToString();
 
             }
@@ -57,8 +56,7 @@ namespace Abp.AspNetCore.Mvc.Auditing
             try
             {
                 var httpContext = _httpContextAccessor.HttpContext;
-
-                return Dns.GetHostEntry(_httpContextAccessor?.HttpContext?.Connection?.RemoteIpAddress).HostName;
+                return Dns.GetHostEntry(httpContext?.Connection?.RemoteIpAddress).HostName;
 
             }
             catch (Exception ex)

--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
@@ -3,6 +3,7 @@ using Abp.Auditing;
 using Castle.Core.Logging;
 using Microsoft.AspNetCore.Http;
 using Abp.Extensions;
+using System.Net;
 
 namespace Abp.AspNetCore.Mvc.Auditing
 {
@@ -53,7 +54,19 @@ namespace Abp.AspNetCore.Mvc.Auditing
 
         protected virtual string GetComputerName()
         {
-            return null; //TODO: Implement!
+            try
+            {
+                var httpContext = _httpContextAccessor.HttpContext;
+
+                return Dns.GetHostEntry(_httpContextAccessor?.HttpContext?.Connection?.RemoteIpAddress).HostName;
+
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex.ToString());
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Implement GetComputerName of HttpContextClientInfoProvider, which is being used to populate the ClientName property of the AuditInfo Class
resolves #6399 