### PR TITLE
Extend UnitOfWorkAuditingConfiguration to disable LastModificationTime and DeletionTime

### DIFF
--- a/src/Abp/AbpKernelModule.cs
+++ b/src/Abp/AbpKernelModule.cs
@@ -132,7 +132,9 @@ namespace Abp
         {
             Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.CreationUserId, true);
             Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.LastModifierUserId, true);
+            Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.LastModificationTime, true);
             Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.DeleterUserId, true);
+            Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.DeletionTime, true);
         }
 
         private void AddSettingProviders()

--- a/src/Abp/AbpKernelModule.cs
+++ b/src/Abp/AbpKernelModule.cs
@@ -130,7 +130,7 @@ namespace Abp
 
         private void AddUnitOfWorkAuditFieldConfiguration()
         {
-            Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.CreationUserId, true);
+            Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.CreatorUserId, true);
             Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.LastModifierUserId, true);
             Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.LastModificationTime, true);
             Configuration.UnitOfWork.RegisterAuditFieldConfiguration(AbpAuditFields.DeleterUserId, true);

--- a/src/Abp/Domain/Entities/Auditing/EntityAuditingHelper.cs
+++ b/src/Abp/Domain/Entities/Auditing/EntityAuditingHelper.cs
@@ -1,5 +1,4 @@
 ﻿using Abp.Timing;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Abp.Configuration.Startup;
@@ -13,7 +12,7 @@ namespace Abp.Domain.Entities.Auditing
     {
         public static void SetCreationAuditProperties(
             IMultiTenancyConfig multiTenancyConfig,
-            object entityAsObj, 
+            object entityAsObj,
             int? tenantId,
             long? userId,
             IReadOnlyList<AuditFieldConfiguration> auditFields)
@@ -70,7 +69,7 @@ namespace Abp.Domain.Entities.Auditing
             {
                 return;
             }
-            
+
             //Finally, set CreatorUserId!
             entity.CreatorUserId = userId;
         }
@@ -84,7 +83,11 @@ namespace Abp.Domain.Entities.Auditing
         {
             if (entityAsObj is IHasModificationTime)
             {
-                entityAsObj.As<IHasModificationTime>().LastModificationTime = Clock.Now;
+                var lastModificationTimeFilter = auditFields?.FirstOrDefault(e => e.FieldName == AbpAuditFields.LastModificationTime);
+                if (lastModificationTimeFilter == null || lastModificationTimeFilter.IsSavingEnabled)
+                {
+                    entityAsObj.As<IHasModificationTime>().LastModificationTime = Clock.Now;
+                }
             }
 
             if (!(entityAsObj is IModificationAudited))
@@ -107,7 +110,7 @@ namespace Abp.Domain.Entities.Auditing
                 if (MultiTenancyHelper.IsMultiTenantEntity(entity) &&
                     !MultiTenancyHelper.IsTenantEntity(entity, tenantId))
                 {
-                    //A tenant entitiy is modified by host or a different tenant
+                    //A tenant entity is modified by host or a different tenant
                     entity.LastModifierUserId = null;
                     return;
                 }
@@ -125,15 +128,15 @@ namespace Abp.Domain.Entities.Auditing
             {
                 return;
             }
-            
+
             //Finally, set LastModifierUserId!
             entity.LastModifierUserId = userId;
         }
 
         public static void SetDeletionAuditProperties(
-            IMultiTenancyConfig multiTenancyConfig, 
-            object entityAsObj, 
-            int? tenantId, 
+            IMultiTenancyConfig multiTenancyConfig,
+            object entityAsObj,
+            int? tenantId,
             long? userId,
             IReadOnlyList<AuditFieldConfiguration> auditFields)
         {
@@ -143,7 +146,11 @@ namespace Abp.Domain.Entities.Auditing
 
                 if (entity.DeletionTime == null)
                 {
-                    entity.DeletionTime = Clock.Now;
+                    var deletionTimeFilter = auditFields?.FirstOrDefault(e => e.FieldName == AbpAuditFields.DeletionTime);
+                    if (deletionTimeFilter == null || deletionTimeFilter.IsSavingEnabled)
+                    {
+                        entityAsObj.As<IHasDeletionTime>().DeletionTime = Clock.Now;
+                    }
                 }
             }
 
@@ -167,7 +174,7 @@ namespace Abp.Domain.Entities.Auditing
                 {
                     return;
                 }
-                
+
                 //Special check for multi-tenant entities
                 if (entity is IMayHaveTenant || entity is IMustHaveTenant)
                 {

--- a/src/Abp/Domain/Entities/Auditing/EntityAuditingHelper.cs
+++ b/src/Abp/Domain/Entities/Auditing/EntityAuditingHelper.cs
@@ -64,7 +64,7 @@ namespace Abp.Domain.Entities.Auditing
                 }
             }
 
-            var creationUserIdFilter = auditFields?.FirstOrDefault(e => e.FieldName == AbpAuditFields.CreationUserId);
+            var creationUserIdFilter = auditFields?.FirstOrDefault(e => e.FieldName == AbpAuditFields.CreatorUserId);
             if (creationUserIdFilter != null && !creationUserIdFilter.IsSavingEnabled)
             {
                 return;

--- a/src/Abp/Domain/Uow/AbpDataFilters.cs
+++ b/src/Abp/Domain/Uow/AbpDataFilters.cs
@@ -51,7 +51,7 @@ namespace Abp.Domain.Uow
     /// </summary>
     public static class AbpAuditFields
     {
-        public const string CreationUserId = "CreationUserId";
+        public const string CreatorUserId = "CreatorUserId";
 
         public const string LastModifierUserId = "LastModifierUserId";
 

--- a/src/Abp/Domain/Uow/AbpDataFilters.cs
+++ b/src/Abp/Domain/Uow/AbpDataFilters.cs
@@ -45,17 +45,20 @@ namespace Abp.Domain.Uow
             public const string IsDeleted = "isDeleted";
         }
     }
-    
+
     /// <summary>
     /// Standard filters of ABP.
     /// </summary>
     public static class AbpAuditFields
     {
         public const string CreationUserId = "CreationUserId";
-        
+
         public const string LastModifierUserId = "LastModifierUserId";
-        
+
         public const string DeleterUserId = "DeleterUserId";
-        
+
+        public const string LastModificationTime = "LastModificationTime";
+
+        public const string DeletionTime = "DeletionTime";
     }
 }

--- a/test/Abp.TestBase.SampleApplication.Tests/Auditing/AuditedEntity_Tests.cs
+++ b/test/Abp.TestBase.SampleApplication.Tests/Auditing/AuditedEntity_Tests.cs
@@ -125,7 +125,7 @@ namespace Abp.TestBase.SampleApplication.Tests.Auditing
             {
                 using (var uow = uowManager.Object.Begin())
                 {
-                    using (uowManager.Object.Current.DisableAuditing(AbpAuditFields.CreationUserId))
+                    using (uowManager.Object.Current.DisableAuditing(AbpAuditFields.CreatorUserId))
                     {
                         var message = _messageRepository.Insert(new Message(AbpSession.TenantId, "test message 1"));
                         message.CreatorUserId.ShouldBeNull();
@@ -245,9 +245,9 @@ namespace Abp.TestBase.SampleApplication.Tests.Auditing
             {
                 using (var uow = uowManager.Object.Begin())
                 {
-                    using (uowManager.Object.Current.DisableAuditing(AbpAuditFields.CreationUserId))
+                    using (uowManager.Object.Current.DisableAuditing(AbpAuditFields.CreatorUserId))
                     {
-                        using (uowManager.Object.Current.EnableAuditing(AbpAuditFields.CreationUserId))
+                        using (uowManager.Object.Current.EnableAuditing(AbpAuditFields.CreatorUserId))
                         {
                             var message = _messageRepository.Insert(new Message(AbpSession.TenantId, "test message 1"));
                             message.CreatorUserId.ShouldNotBeNull();

--- a/test/Abp.TestBase.SampleApplication.Tests/Auditing/AuditedEntity_Tests.cs
+++ b/test/Abp.TestBase.SampleApplication.Tests/Auditing/AuditedEntity_Tests.cs
@@ -189,6 +189,51 @@ namespace Abp.TestBase.SampleApplication.Tests.Auditing
         }
 
         [Fact]
+        public void Should_Not_Set_LastModificationTime_When_DisableLastModificationTime_Configuration_Is_Disabled()
+        {
+            //Act: Create a new entity
+            var message = _messageRepository.Insert(new Message(null, "test message 1"));
+
+            //Act: CreatorUserId
+            using (var uowManager = LocalIocManager.ResolveAsDisposable<IUnitOfWorkManager>())
+            {
+                using (var uow = uowManager.Object.Begin())
+                {
+                    using (uowManager.Object.Current.DisableAuditing(AbpAuditFields.LastModificationTime))
+                    {
+                        message.Text = "edited test message 1";
+                        _messageRepository.Update(message);
+                        uow.Complete();
+                    }
+                }
+            }
+
+            message.LastModificationTime.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_Not_Set_DeletionTime_When_DisableDeletionTime_Configuration_Is_Disabled()
+        {
+            //Act: Create a new entity
+            var message = _messageRepository.Insert(new Message(null, "test message 1"));
+
+            //Act: CreatorUserId
+            using (var uowManager = LocalIocManager.ResolveAsDisposable<IUnitOfWorkManager>())
+            {
+                using (var uow = uowManager.Object.Begin())
+                {
+                    using (uowManager.Object.Current.DisableAuditing(AbpAuditFields.DeletionTime))
+                    {
+                        _messageRepository.Delete(message);
+                        uow.Complete();
+                    }
+                }
+            }
+
+            message.DeletionTime.ShouldBeNull();
+        }
+
+        [Fact]
         public void Should_Set_CreatorUserId_When_DisableCreatorUserId_Configuration_Is_Enabled()
         {
             //Arrange
@@ -270,6 +315,57 @@ namespace Abp.TestBase.SampleApplication.Tests.Auditing
             }
 
             message.DeleterUserId.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Should_Set_LastModificationTime_When_DisableLastModificationTime_Configuration_Is_Enabled()
+        {
+            //Act: Create a new entity
+            var message = _messageRepository.Insert(new Message(null, "test message 1"));
+
+            //Act: CreatorUserId
+            using (var uowManager = LocalIocManager.ResolveAsDisposable<IUnitOfWorkManager>())
+            {
+                using (var uow = uowManager.Object.Begin())
+                {
+                    using (uowManager.Object.Current.DisableAuditing(AbpAuditFields.LastModificationTime))
+                    {
+                        using (uowManager.Object.Current.EnableAuditing(AbpAuditFields.LastModificationTime))
+                        {
+                            message.Text = "edited test message 1";
+                            _messageRepository.Update(message);
+                            uow.Complete();
+                        }
+                    }
+                }
+            }
+
+            message.LastModificationTime.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Should_Set_DeletionTime_When_DisableDeletionTime_Configuration_Is_Enabled()
+        {
+            //Act: Create a new entity
+            var message = _messageRepository.Insert(new Message(null, "test message 1"));
+
+            //Act: CreatorUserId
+            using (var uowManager = LocalIocManager.ResolveAsDisposable<IUnitOfWorkManager>())
+            {
+                using (var uow = uowManager.Object.Begin())
+                {
+                    using (uowManager.Object.Current.DisableAuditing(AbpAuditFields.DeletionTime))
+                    {
+                        using (uowManager.Object.Current.EnableAuditing(AbpAuditFields.DeletionTime))
+                        {
+                            _messageRepository.Delete(message);
+                            uow.Complete();
+                        }
+                    }
+                }
+            }
+
+            message.DeletionTime.ShouldNotBeNull();
         }
     }
 }


### PR DESCRIPTION
Similiar to #6028 I added filters to disable updates for LastModificationTime and DeletionTime.

I didn't add a filter for CreationTime because CreationTime is not nullable.