### PR TITLE
Add security stamp claim for two factor client

### DIFF
--- a/src/Abp.ZeroCore/Authorization/AbpSignInManager.cs
+++ b/src/Abp.ZeroCore/Authorization/AbpSignInManager.cs
@@ -101,7 +101,7 @@ namespace Abp.Authorization
         {
             await Context.SignInAsync(IdentityConstants.ApplicationScheme,
                 new ClaimsPrincipal(identity),
-                new Microsoft.AspNetCore.Authentication.AuthenticationProperties {IsPersistent = isPersistent}
+                new AuthenticationProperties { IsPersistent = isPersistent }
             );
         }
 
@@ -178,7 +178,7 @@ namespace Abp.Authorization
             var principal = await StoreRememberClient(user);
             await Context.SignInAsync(IdentityConstants.TwoFactorRememberMeScheme,
                 principal,
-                new Microsoft.AspNetCore.Authentication.AuthenticationProperties {IsPersistent = true});
+                new AuthenticationProperties { IsPersistent = true });
         }
 
         private bool IsTrue(string settingName, int? tenantId)

--- a/src/Abp.ZeroCore/Authorization/AbpSignInManager.cs
+++ b/src/Abp.ZeroCore/Authorization/AbpSignInManager.cs
@@ -164,6 +164,12 @@ namespace Abp.Authorization
                 rememberBrowserIdentity.AddClaim(new Claim(AbpClaimTypes.TenantId, user.TenantId.Value.ToString()));
             }
 
+            if (UserManager.SupportsUserSecurityStamp)
+            {
+                var stamp = await UserManager.GetSecurityStampAsync(user);
+                rememberBrowserIdentity.AddClaim(new Claim(Options.ClaimsIdentity.SecurityStampClaimType, stamp));
+            }
+
             await Context.SignInAsync(IdentityConstants.TwoFactorRememberMeScheme,
                 new ClaimsPrincipal(rememberBrowserIdentity),
                 new Microsoft.AspNetCore.Authentication.AuthenticationProperties {IsPersistent = true});


### PR DESCRIPTION
Fixes #6175 

Based on [https://github.com/dotnet/aspnetcore/blob/84c0baa/src/Identity/Core/src/SignInManager.cs#L762-L766](https://github.com/dotnet/aspnetcore/blob/84c0baa9a57bd6448cd1bf78b64d2c1658bf5ef6/src/Identity/Core/src/SignInManager.cs#L762-L766),
which was changed in [dotnet/aspnetcore@c6a82ad](https://github.com/dotnet/aspnetcore/commit/c6a82ad19a0bdb80b7358dc843b66664bbf33f96), so this has been broken in ABP likely since ASP.NET Core 2.1.7.