### PR TITLE
Added null check for remoteIpAdress in HttpContextClientInfoProvider.GetComputerName

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Mvc/Auditing/HttpContextClientInfoProvider.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using Abp.Auditing;
+﻿using Abp.Auditing;
 using Castle.Core.Logging;
 using Microsoft.AspNetCore.Http;
-using Abp.Extensions;
+using System;
 using System.Net;
 
 namespace Abp.AspNetCore.Mvc.Auditing
@@ -56,8 +55,11 @@ namespace Abp.AspNetCore.Mvc.Auditing
             try
             {
                 var httpContext = _httpContextAccessor.HttpContext;
-                return Dns.GetHostEntry(httpContext?.Connection?.RemoteIpAddress).HostName;
+                var remoteIpAddress = httpContext?.Connection?.RemoteIpAddress;
 
+                if (remoteIpAddress is null) return null;
+
+                return Dns.GetHostEntry(remoteIpAddress).HostName;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
After an upgrade to 7.2 my app was really slow. The reason is the implementation in #6400.
`remoteIpAdress` can be null, but null isn't a valid input for `Dns.GetHostEntry`.
My log was full with this error message:
```
INFO  2022-06-09 15:46:20,519 [63   ] osoft.EntityFrameworkCore.Infrastructure - Entity Framework Core 6.0.5 initialized 'DbContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer:6.0.5' with options: None
WARN  2022-06-09 15:46:20,524 [63   ] c.Auditing.HttpContextClientInfoProvider - System.ArgumentNullException: Value cannot be null. (Parameter 'address')
   at System.Net.Dns.GetHostEntry(IPAddress address)
   at Abp.AspNetCore.Mvc.Auditing.HttpContextClientInfoProvider.GetComputerName()
```