### PR TITLE
#6560 - EFRepositoryBase - Unnecessary call to Update or UpdateAsync causes whole entity to be marked dirty

### DIFF
--- a/src/Abp.EntityFramework/EntityFramework/Repositories/EfRepositoryBaseOfTEntityAndTPrimaryKey.cs
+++ b/src/Abp.EntityFramework/EntityFramework/Repositories/EfRepositoryBaseOfTEntityAndTPrimaryKey.cs
@@ -191,15 +191,23 @@ namespace Abp.EntityFramework.Repositories
 
         public override TEntity Update(TEntity entity)
         {
-            AttachIfNot(entity);
-            Context.Entry(entity).State = EntityState.Modified;
+            // only if entity had to be attached, we do set its state to "Modified"
+            // this ensures, that unnecessary calls to "Update" result in the whole entity being set "dirty"
+            // as opposed to just the properties that changed!
+            if(AttachIfNot(entity))
+                Context.Entry(entity).State = EntityState.Modified;
+            
             return entity;
         }
-
+        
         public override Task<TEntity> UpdateAsync(TEntity entity)
         {
-            AttachIfNot(entity);
-            Context.Entry(entity).State = EntityState.Modified;
+            // only if entity had to be attached, we do set its state to "Modified"
+            // this ensures, that unnecessary calls to "UpdateAsync" result in the whole entity being set "dirty"
+            // as opposed to just the properties that changed!
+            if(AttachIfNot(entity))
+                Context.Entry(entity).State = EntityState.Modified;
+
             return Task.FromResult(entity);
         }
 
@@ -248,12 +256,15 @@ namespace Abp.EntityFramework.Repositories
             return await query.Where(predicate).LongCountAsync(CancellationTokenProvider.Token);
         }
 
-        protected virtual void AttachIfNot(TEntity entity)
+        protected virtual bool AttachIfNot(TEntity entity)
         {
             if (!Table.Local.Contains(entity))
             {
                 Table.Attach(entity);
+                return true;
             }
+
+            return false;
         }
 
         public DbContext GetDbContext()

--- a/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
+++ b/src/Abp.Zero.EntityFramework/EntityHistory/EntityHistoryHelper.cs
@@ -102,6 +102,12 @@ namespace Abp.EntityHistory
                 changeSet.EntityChanges.Add(entityChange);
             }
 
+            // in case no entity was changed, but only a relationship between entities...
+            foreach(var relationshipOnlyChange in relationshipChanges.Where(rc => context.ChangeTracker.Entries().All(ent => ent.Entity != rc.Entity)))
+            {
+               // TODO: implement this
+            }
+
             return changeSet;
         }
 
@@ -154,7 +160,7 @@ namespace Abp.EntityHistory
             var property = entityEntry.Property(primaryKey.Name);
             return (property.GetNewValue() ?? property.GetOriginalValue())?.ToJsonString();
         }
-
+        
         [CanBeNull]
         private EntityChange CreateEntityChange(DbEntityEntry entityEntry, EntityType entityType)
         {

--- a/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
+++ b/test/Abp.Zero.SampleApp.Tests/EntityHistory/SimpleEntityHistory_Test.cs
@@ -514,7 +514,7 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
 
             Predicate<EntityChangeSet> predicate = s =>
             {
-                s.EntityChanges.Count.ShouldBe(2);
+                s.EntityChanges.Count.ShouldBe(1, "only the FK on post10 was set, so blog1 should not be modified");
 
                 /* Post is not in Configuration.Selectors */
                 /* Post.Blog has Audited attribute */
@@ -528,9 +528,8 @@ namespace Abp.Zero.SampleApp.Tests.EntityHistory
                 propertyChange1.NewValue.ShouldNotBeNull();
 
                 /* Blog has Audited attribute. */
-                var entityChangeBlog = s.EntityChanges.Single(ec => ec.EntityTypeFullName == typeof(Blog).FullName);
-                entityChangeBlog.ChangeType.ShouldBe(EntityChangeType.Updated);
-                entityChangeBlog.PropertyChanges.Count.ShouldBe(0);
+                var entityChangeBlog = s.EntityChanges.SingleOrDefault(ec => ec.EntityTypeFullName == typeof(Blog).FullName);
+                entityChangeBlog.ShouldBeNull("only the FK on post10 was set, so blog1 should not be modified");
 
                 return true;
             };


### PR DESCRIPTION
#6560 - EFRepositoryonlyBase - if entity had to be attached, we do set its state to "Modified"

this ensures, that unnecessary calls to "UpdateAsync" result in the whole entity being set "dirty" as opposed to just the properties that changed!

