### PR TITLE
Added FailedForOtherReason login result type and custom fail reason message

### DIFF
--- a/src/Abp.Zero.Common/Authorization/AbpLoginResultType.cs
+++ b/src/Abp.Zero.Common/Authorization/AbpLoginResultType.cs
@@ -21,5 +21,7 @@ namespace Abp.Authorization
         LockedOut,
 
         UserPhoneNumberIsNotConfirmed,
+        
+        FailedForOtherReason
     }
 }

--- a/src/Abp.ZeroCore/Authorization/Users/AbpLoginResult.cs
+++ b/src/Abp.ZeroCore/Authorization/Users/AbpLoginResult.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Security.Claims;
+using Abp.Localization;
 using Abp.MultiTenancy;
 
 namespace Abp.Authorization.Users
@@ -9,6 +11,8 @@ namespace Abp.Authorization.Users
     {
         public AbpLoginResultType Result { get; private set; }
 
+        public ILocalizableString FailReason { get; private set; }
+        
         public TTenant Tenant { get; private set; }
 
         public TUser User { get; private set; }
@@ -27,6 +31,20 @@ namespace Abp.Authorization.Users
         {
             User = user;
             Identity = identity;
+        }
+
+        /// <summary>
+        /// This method can be used only when <see cref="Result"/> is <see cref="AbpLoginResultType.FailedForOtherReason"/>.
+        /// </summary>
+        /// <param name="failReason">Localizable fail reason message</param>
+        public void SetFailReason(ILocalizableString failReason)
+        {
+            if (Result != AbpLoginResultType.FailedForOtherReason)
+            {
+                throw new Exception($"Can not set fail reason for result type {Result}, use this method only for AbpLoginResultType.FailedForOtherReason result type!");
+            }
+            
+            FailReason = failReason;
         }
     }
 }


### PR DESCRIPTION
- This PR adds `FailedForOtherReason` to `AbpLoginResultType` and also allows to set `FailReason` of `AbpLoginResult` when result is `FailedForOtherReason`

resolves #6691 