### PR TITLE
Fixed a null reference exception in Abp.HtmlSanitizer.

### DIFF
--- a/src/Abp.HtmlSanitizer/HtmlSanitizer/HtmlSanitizerHelper.cs
+++ b/src/Abp.HtmlSanitizer/HtmlSanitizer/HtmlSanitizerHelper.cs
@@ -103,6 +103,11 @@ namespace Abp.HtmlSanitizer
 
         private void SanitizeObject(object item)
         {
+            if (item is null)
+            {
+                return;
+            }
+
             var classType = item.GetType();
 
             if (classType.GetTypeInfo().IsDefined(typeof(DisableHtmlSanitizerAttribute), true))
@@ -113,40 +118,40 @@ namespace Abp.HtmlSanitizer
             switch (item)
             {
                 case IDictionary dictionary:
-                {
-                    foreach (var value in dictionary.Values)
                     {
-                        SanitizeObject(value);
-                    }
+                        foreach (var value in dictionary.Values)
+                        {
+                            SanitizeObject(value);
+                        }
 
-                    break;
-                }
+                        break;
+                    }
                 case IEnumerable enumerable:
-                {
-                    foreach (var listItem in enumerable)
                     {
-                        SanitizeObject(listItem);
-                    }
+                        foreach (var listItem in enumerable)
+                        {
+                            SanitizeObject(listItem);
+                        }
 
-                    break;
-                }
+                        break;
+                    }
 
                 case DateTime _:
-                {
-                    break;
-                }
-
-                default:
-                {
-                    var properties = classType.GetProperties();
-
-                    foreach (var property in properties)
                     {
-                        SanitizeProperty(item, property);
+                        break;
                     }
 
-                    break;
-                }
+                default:
+                    {
+                        var properties = classType.GetProperties();
+
+                        foreach (var property in properties)
+                        {
+                            SanitizeProperty(item, property);
+                        }
+
+                        break;
+                    }
             }
         }
 

--- a/src/Abp.HtmlSanitizer/HtmlSanitizer/HtmlSanitizerHelper.cs
+++ b/src/Abp.HtmlSanitizer/HtmlSanitizer/HtmlSanitizerHelper.cs
@@ -118,40 +118,38 @@ namespace Abp.HtmlSanitizer
             switch (item)
             {
                 case IDictionary dictionary:
+                {
+                    foreach (var value in dictionary.Values)
                     {
-                        foreach (var value in dictionary.Values)
-                        {
-                            SanitizeObject(value);
-                        }
-
-                        break;
+                        SanitizeObject(value);
                     }
+
+                    break;
+                }
                 case IEnumerable enumerable:
+                {
+                    foreach (var listItem in enumerable)
                     {
-                        foreach (var listItem in enumerable)
-                        {
-                            SanitizeObject(listItem);
-                        }
-
-                        break;
+                        SanitizeObject(listItem);
                     }
 
+                    break;
+                }
                 case DateTime _:
-                    {
-                        break;
-                    }
-
+                {
+                    break;
+                }
                 default:
+                {
+                    var properties = classType.GetProperties();
+
+                    foreach (var property in properties)
                     {
-                        var properties = classType.GetProperties();
-
-                        foreach (var property in properties)
-                        {
-                            SanitizeProperty(item, property);
-                        }
-
-                        break;
+                        SanitizeProperty(item, property);
                     }
+
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
When passing null to the SanitizeObject method, it would cause `var classType = item.GetType()` to throw a NullReferenceException since `item` is null.

Passing null to the SanitizeObject method can occur, for example, by accident when iterating over an IEnumerable or IDictionary, since entries could be null.

To prevent code duplication, I've added a null check to the start of the SanitizeObject method.