### PR TITLE
Changed the type of withUrlOptions from string to object to accommodate missing properties.

### DIFF
--- a/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr.d.ts
+++ b/src/Abp.Web.Resources/Abp/Framework/scripts/libs/abp.signalr.d.ts
@@ -10,7 +10,7 @@
 
         let url: string;
 
-        let withUrlOptions: string;
+        let withUrlOptions: object;
         
         function connect(): any;
 


### PR DESCRIPTION
Currently, withUrlOptions  is defined as of type string, however, as this documentation from Microsoft shows, we could define quite a few properties there: https://learn.microsoft.com/en-us/aspnet/core/signalr/configuration?view=aspnetcore-7.0&tabs=javascript#configure-additional-options

- Inside the .withUrl method it is expected to pass object as a second parameter:

`let connection = new signalR.HubConnectionBuilder().withUrl("/chathub", { `
       `      // "Foo: Bar" will not be sent with WebSockets or Server-Sent Events requests`
       `      headers: { "Foo": "Bar" },`
       `       transport: signalR.HttpTransportType.LongPolling `
   ` })
    .build();`

- Also inside the abp.signalr-client.js **start** method we are using the withUrlOptions  as object:

`abp.signalr.withUrlOptions.transport = transport;
`

In case withUrlOptions is defined as string this causes transport to be returned as undefined.

- Also, if we are deploying in web farm environment we are not able to set the skipNegotiation property if withUrlOptions is defined as string which in turn breaks the signalR connection.