### PR TITLE
Async instead of sync methods in realtime classes

### DIFF
--- a/src/Abp.AspNetCore.SignalR/AspNetCore/SignalR/Hubs/OnlineClientHubBase.cs
+++ b/src/Abp.AspNetCore.SignalR/AspNetCore/SignalR/Hubs/OnlineClientHubBase.cs
@@ -36,7 +36,7 @@ namespace Abp.AspNetCore.SignalR.Hubs
 
             Logger.Debug("A client is connected: " + client);
 
-            OnlineClientManager.Add(client);
+            await OnlineClientManager.AddAsync(client);
         }
 
         public override async Task OnDisconnectedAsync(Exception exception)
@@ -47,7 +47,7 @@ namespace Abp.AspNetCore.SignalR.Hubs
 
             try
             {
-                OnlineClientManager.Remove(Context.ConnectionId);
+                await OnlineClientManager.RemoveAsync(Context.ConnectionId);
             }
             catch (Exception ex)
             {

--- a/src/Abp.AspNetCore.SignalR/AspNetCore/SignalR/Notifications/SignalRRealTimeNotifier.cs
+++ b/src/Abp.AspNetCore.SignalR/AspNetCore/SignalR/Notifications/SignalRRealTimeNotifier.cs
@@ -44,7 +44,7 @@ namespace Abp.AspNetCore.SignalR.Notifications
             {
                 try
                 {
-                    var onlineClients = _onlineClientManager.GetAllByUserId(userNotification);
+                    var onlineClients = await _onlineClientManager.GetAllByUserIdAsync(userNotification);
                     foreach (var onlineClient in onlineClients)
                     {
                         var signalRClient = _hubContext.Clients.Client(onlineClient.ConnectionId);

--- a/src/Abp.Web.SignalR/Web/SignalR/Hubs/AbpCommonHub.cs
+++ b/src/Abp.Web.SignalR/Web/SignalR/Hubs/AbpCommonHub.cs
@@ -42,18 +42,18 @@ namespace Abp.Web.SignalR.Hubs
 
             Logger.Debug("A client is connected: " + client);
 
-            _onlineClientManager.Add(client);
+            await _onlineClientManager.AddAsync(client);
         }
 
         public override async Task OnReconnected()
         {
             await base.OnReconnected();
 
-            var client = _onlineClientManager.GetByConnectionIdOrNull(Context.ConnectionId);
+            var client = await _onlineClientManager.GetByConnectionIdOrNullAsync(Context.ConnectionId);
             if (client == null)
             {
                 client = _onlineClientInfoProvider.CreateClientForCurrentConnection(Context);
-                _onlineClientManager.Add(client);
+                await _onlineClientManager.AddAsync(client);
                 Logger.Debug("A client is connected (on reconnected event): " + client);
             }
             else
@@ -70,7 +70,7 @@ namespace Abp.Web.SignalR.Hubs
 
             try
             {
-                _onlineClientManager.Remove(Context.ConnectionId);
+                await _onlineClientManager.RemoveAsync(Context.ConnectionId);
             }
             catch (Exception ex)
             {

--- a/src/Abp.Web.SignalR/Web/SignalR/Notifications/SignalRRealTimeNotifier.cs
+++ b/src/Abp.Web.SignalR/Web/SignalR/Notifications/SignalRRealTimeNotifier.cs
@@ -67,33 +67,5 @@ namespace Abp.Web.SignalR.Notifications
                 }
             }
         }
-
-        /// <inheritdoc/>
-        public void SendNotifications(UserNotification[] userNotifications)
-        {
-            foreach (var userNotification in userNotifications)
-            {
-                try
-                {
-                    var onlineClients = _onlineClientManager.GetAllByUserId(userNotification);
-                    foreach (var onlineClient in onlineClients)
-                    {
-                        var signalRClient = CommonHub.Clients.Client(onlineClient.ConnectionId);
-                        if (signalRClient == null)
-                        {
-                            Logger.Debug("Can not get user " + userNotification.ToUserIdentifier() + " with connectionId " + onlineClient.ConnectionId + " from SignalR hub!");
-                            continue;
-                        }
-
-                        signalRClient.getNotification(userNotification);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Warn("Could not send notification to user: " + userNotification.ToUserIdentifier());
-                    Logger.Warn(ex.ToString(), ex);
-                }
-            }
-        }
     }
 }

--- a/src/Abp.Web.SignalR/Web/SignalR/Notifications/SignalRRealTimeNotifier.cs
+++ b/src/Abp.Web.SignalR/Web/SignalR/Notifications/SignalRRealTimeNotifier.cs
@@ -47,7 +47,7 @@ namespace Abp.Web.SignalR.Notifications
             {
                 try
                 {
-                    var onlineClients = _onlineClientManager.GetAllByUserId(userNotification);
+                    var onlineClients = await _onlineClientManager.GetAllByUserIdAsync(userNotification);
                     foreach (var onlineClient in onlineClients)
                     {
                         var signalRClient = CommonHub.Clients.Client(onlineClient.ConnectionId);

--- a/src/Abp/RealTime/IOnlineClientManager.cs
+++ b/src/Abp/RealTime/IOnlineClientManager.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using JetBrains.Annotations;
+using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
+using System.Threading.Tasks;
 
 namespace Abp.RealTime
 {
@@ -26,21 +27,22 @@ namespace Abp.RealTime
         /// Adds a client.
         /// </summary>
         /// <param name="client">The client.</param>
-        void Add(IOnlineClient client);
+        /// <returns>The task to handle async operation</returns>
+        Task AddAsync(IOnlineClient client);
 
         /// <summary>
         /// Removes a client by connection id.
         /// </summary>
         /// <param name="connectionId">The connection id.</param>
         /// <returns>True, if a client is removed</returns>
-        bool Remove(string connectionId);
+        Task<bool> RemoveAsync(string connectionId);
 
         /// <summary>
         /// Tries to find a client by connection id.
         /// Returns null if not found.
         /// </summary>
         /// <param name="connectionId">connection id</param>
-        IOnlineClient GetByConnectionIdOrNull(string connectionId);
+        Task<IOnlineClient> GetByConnectionIdOrNullAsync(string connectionId);
 
         /// <summary>
         /// Gets all online clients.
@@ -52,5 +54,11 @@ namespace Abp.RealTime
         /// </summary>
         /// <param name="user">user identifier</param>
         IReadOnlyList<IOnlineClient> GetAllByUserId([NotNull] IUserIdentifier user);
+
+        /// <summary>
+        /// Gets all online clients by user id asynchronously .
+        /// </summary>
+        /// <param name="user">user identifier</param>
+        Task<IReadOnlyList<IOnlineClient>> GetAllByUserIdAsync([NotNull] IUserIdentifier user);
     }
 }

--- a/src/Abp/RealTime/IOnlineClientManager.cs
+++ b/src/Abp/RealTime/IOnlineClientManager.cs
@@ -50,12 +50,6 @@ namespace Abp.RealTime
         Task<IReadOnlyList<IOnlineClient>> GetAllClientsAsync();
 
         /// <summary>
-        /// Gets all online clients by user id.
-        /// </summary>
-        /// <param name="user">user identifier</param>
-        IReadOnlyList<IOnlineClient> GetAllByUserId([NotNull] IUserIdentifier user);
-
-        /// <summary>
         /// Gets all online clients by user id asynchronously.
         /// </summary>
         /// <param name="user">user identifier</param>

--- a/src/Abp/RealTime/IOnlineClientManager.cs
+++ b/src/Abp/RealTime/IOnlineClientManager.cs
@@ -45,9 +45,9 @@ namespace Abp.RealTime
         Task<IOnlineClient> GetByConnectionIdOrNullAsync(string connectionId);
 
         /// <summary>
-        /// Gets all online clients.
+        /// Gets all online clients asynchronously.
         /// </summary>
-        IReadOnlyList<IOnlineClient> GetAllClients();
+        Task<IReadOnlyList<IOnlineClient>> GetAllClientsAsync();
 
         /// <summary>
         /// Gets all online clients by user id.
@@ -56,7 +56,7 @@ namespace Abp.RealTime
         IReadOnlyList<IOnlineClient> GetAllByUserId([NotNull] IUserIdentifier user);
 
         /// <summary>
-        /// Gets all online clients by user id asynchronously .
+        /// Gets all online clients by user id asynchronously.
         /// </summary>
         /// <param name="user">user identifier</param>
         Task<IReadOnlyList<IOnlineClient>> GetAllByUserIdAsync([NotNull] IUserIdentifier user);

--- a/src/Abp/RealTime/IOnlineClientStore.cs
+++ b/src/Abp/RealTime/IOnlineClientStore.cs
@@ -44,21 +44,11 @@ namespace Abp.RealTime
         /// <summary>
         /// Gets all online clients.
         /// </summary>
-        IReadOnlyList<IOnlineClient> GetAll();
-
-        /// <summary>
-        /// Gets all online clients asynchronously.
-        /// </summary>
         Task<IReadOnlyList<IOnlineClient>> GetAllAsync();
+
 
         /// <summary>
         /// Gets all online clients by user identifier.
-        /// </summary>
-        /// <param name="userIdentifier">user identifier with tenant id and user id</param>
-        IReadOnlyList<IOnlineClient> GetAllByUserId(UserIdentifier userIdentifier);
-
-        /// <summary>
-        /// Gets all online clients by user identifier asynchronously.
         /// </summary>
         /// <param name="userIdentifier">user identifier with tenant id and user id</param>
         Task<IReadOnlyList<IOnlineClient>> GetAllByUserIdAsync(UserIdentifier userIdentifier);

--- a/src/Abp/RealTime/IOnlineClientStore.cs
+++ b/src/Abp/RealTime/IOnlineClientStore.cs
@@ -50,5 +50,17 @@ namespace Abp.RealTime
         /// Gets all online clients asynchronously.
         /// </summary>
         Task<IReadOnlyList<IOnlineClient>> GetAllAsync();
+
+        /// <summary>
+        /// Gets all online clients by user identifier.
+        /// </summary>
+        /// <param name="userIdentifier">user identifier with tenant id and user id</param>
+        IReadOnlyList<IOnlineClient> GetAllByUserId(UserIdentifier userIdentifier);
+
+        /// <summary>
+        /// Gets all online clients by user identifier asynchronously.
+        /// </summary>
+        /// <param name="userIdentifier">user identifier with tenant id and user id</param>
+        Task<IReadOnlyList<IOnlineClient>> GetAllByUserIdAsync(UserIdentifier userIdentifier);
     }
 }

--- a/src/Abp/RealTime/IOnlineClientStore.cs
+++ b/src/Abp/RealTime/IOnlineClientStore.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-using Abp.Data;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Abp.RealTime
 {
@@ -14,40 +15,40 @@ namespace Abp.RealTime
         /// Adds a client.
         /// </summary>
         /// <param name="client">The client.</param>
-        void Add(IOnlineClient client);
+        /// <returns>The task to handle async operation</returns>
+        Task AddAsync(IOnlineClient client);
 
         /// <summary>
         /// Removes a client by connection id.
         /// </summary>
         /// <param name="connectionId">The connection id.</param>
         /// <returns>true if the client is removed, otherwise, false</returns>
-        bool Remove(string connectionId);
+        Task<bool> RemoveAsync(string connectionId);
 
         /// <summary>
         /// Removes a client by connection id.
         /// </summary>
         /// <param name="connectionId">The connection id.</param>
-        /// <param name="client">The client.</param>
+        /// <param name="clientAction">The Action for setup value for client.</param>
         /// <returns>true if the client is removed, otherwise, false</returns>
-        bool TryRemove(string connectionId, out IOnlineClient client);
+        Task<bool> TryRemoveAsync(string connectionId, Action<IOnlineClient> clientAction);
 
         /// <summary>
         /// Gets a client by connection id.
         /// </summary>
         /// <param name="connectionId">The connection id.</param>
-        /// <param name="client">The client.</param>
+        /// <param name="clientAction">The Action for setup value for client.</param>
         /// <returns>true if the client exists, otherwise, false</returns>
-        bool TryGet(string connectionId, out IOnlineClient client);
-
-        /// <summary>
-        /// Determines if store contains client with connection id.
-        /// </summary>
-        /// <param name="connectionId">The connection id.</param>
-        bool Contains(string connectionId);
+        Task<bool> TryGetAsync(string connectionId, Action<IOnlineClient> clientAction);
 
         /// <summary>
         /// Gets all online clients.
         /// </summary>
         IReadOnlyList<IOnlineClient> GetAll();
+
+        /// <summary>
+        /// Gets all online clients asynchronously.
+        /// </summary>
+        Task<IReadOnlyList<IOnlineClient>> GetAllAsync();
     }
 }

--- a/src/Abp/RealTime/InMemoryOnlineClientStore.cs
+++ b/src/Abp/RealTime/InMemoryOnlineClientStore.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Abp.RealTime
@@ -62,6 +63,20 @@ namespace Abp.RealTime
         public Task<IReadOnlyList<IOnlineClient>> GetAllAsync()
         {
             return Task.FromResult(GetAll());
+        }
+
+        public IReadOnlyList<IOnlineClient> GetAllByUserId(UserIdentifier userIdentifier)
+        {
+            return GetAll()
+                .Where(c => c.UserId == userIdentifier.UserId && c.TenantId == userIdentifier.TenantId)
+                .ToImmutableList();
+        }
+
+        public async Task<IReadOnlyList<IOnlineClient>> GetAllByUserIdAsync(UserIdentifier userIdentifier)
+        {
+            return (await GetAllAsync())
+                .Where(c => c.UserId == userIdentifier.UserId && c.TenantId == userIdentifier.TenantId)
+                .ToImmutableList();
         }
     }
 }

--- a/src/Abp/RealTime/InMemoryOnlineClientStore.cs
+++ b/src/Abp/RealTime/InMemoryOnlineClientStore.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Abp.RealTime
@@ -55,21 +56,9 @@ namespace Abp.RealTime
             return Task.FromResult(hasKey);
         }
 
-        public IReadOnlyList<IOnlineClient> GetAll()
-        {
-            return Clients.Values.ToImmutableList();
-        }
-
         public Task<IReadOnlyList<IOnlineClient>> GetAllAsync()
         {
-            return Task.FromResult(GetAll());
-        }
-
-        public IReadOnlyList<IOnlineClient> GetAllByUserId(UserIdentifier userIdentifier)
-        {
-            return GetAll()
-                .Where(c => c.UserId == userIdentifier.UserId && c.TenantId == userIdentifier.TenantId)
-                .ToImmutableList();
+            return Task.FromResult<IReadOnlyList<IOnlineClient>>(Clients.Values.ToImmutableList());
         }
 
         public async Task<IReadOnlyList<IOnlineClient>> GetAllByUserIdAsync(UserIdentifier userIdentifier)

--- a/src/Abp/RealTime/InMemoryOnlineClientStore.cs
+++ b/src/Abp/RealTime/InMemoryOnlineClientStore.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Concurrent;
+﻿using Abp.Dependency;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Abp.Dependency;
+using System.Threading.Tasks;
 
 namespace Abp.RealTime
 {
@@ -21,34 +23,45 @@ namespace Abp.RealTime
             Clients = new ConcurrentDictionary<string, IOnlineClient>();
         }
 
-        public void Add(IOnlineClient client)
+        public Task AddAsync(IOnlineClient client)
         {
             Clients.AddOrUpdate(client.ConnectionId, client, (s, o) => client);
+            return Task.CompletedTask;
         }
 
-        public bool Remove(string connectionId)
+        public Task<bool> RemoveAsync(string connectionId)
         {
-            return TryRemove(connectionId, out IOnlineClient removed);
+            return TryRemoveAsync(connectionId, value => _ = value);
         }
 
-        public bool TryRemove(string connectionId, out IOnlineClient client)
+        public Task<bool> TryRemoveAsync(string connectionId, Action<IOnlineClient> clientAction)
         {
-            return Clients.TryRemove(connectionId, out client);
+            var hasRemoved = Clients.TryRemove(connectionId, out IOnlineClient client);
+            clientAction(client);
+            return Task.FromResult(hasRemoved);
         }
 
-        public bool TryGet(string connectionId, out IOnlineClient client)
+        public Task<bool> TryGetAsync(string connectionId, Action<IOnlineClient> clientAction)
         {
-            return Clients.TryGetValue(connectionId, out client);
+            var hasValue = Clients.TryGetValue(connectionId, out IOnlineClient client);
+            clientAction(client);
+            return Task.FromResult(hasValue);
         }
 
-        public bool Contains(string connectionId)
+        public Task<bool> ContainsAsync(string connectionId)
         {
-            return Clients.ContainsKey(connectionId);
+            var hasKey = Clients.ContainsKey(connectionId);
+            return Task.FromResult(hasKey);
         }
 
         public IReadOnlyList<IOnlineClient> GetAll()
         {
             return Clients.Values.ToImmutableList();
+        }
+
+        public Task<IReadOnlyList<IOnlineClient>> GetAllAsync()
+        {
+            return Task.FromResult(GetAll());
         }
     }
 }

--- a/src/Abp/RealTime/OnlineClientManager.cs
+++ b/src/Abp/RealTime/OnlineClientManager.cs
@@ -93,21 +93,11 @@ namespace Abp.RealTime
             return null;
         }
 
-        public async Task<IReadOnlyList<IOnlineClient>> GetAllClientsAsync()
+        public Task<IReadOnlyList<IOnlineClient>> GetAllClientsAsync()
         {
-            return await Store.GetAllAsync();
+            return Store.GetAllAsync();
         }
 
-        [NotNull]
-        public virtual IReadOnlyList<IOnlineClient> GetAllByUserId([NotNull] IUserIdentifier user)
-        {
-            Check.NotNull(user, nameof(user));
-
-            var userIdentifier = new UserIdentifier(user.TenantId, user.UserId);
-            var clients = Store.GetAllByUserId(userIdentifier);
-
-            return clients;
-        }
 
         [NotNull]
         public virtual async Task<IReadOnlyList<IOnlineClient>> GetAllByUserIdAsync([NotNull] IUserIdentifier user)

--- a/src/Abp/RealTime/OnlineClientManager.cs
+++ b/src/Abp/RealTime/OnlineClientManager.cs
@@ -3,8 +3,6 @@ using Abp.Extensions;
 using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Abp.RealTime
@@ -95,12 +93,7 @@ namespace Abp.RealTime
             return null;
         }
 
-        public IReadOnlyList<IOnlineClient> GetAllClients()
-        {
-            return Store.GetAll();
-        }
-
-        private async Task<IReadOnlyList<IOnlineClient>> GetAllClientsAsync()
+        public async Task<IReadOnlyList<IOnlineClient>> GetAllClientsAsync()
         {
             return await Store.GetAllAsync();
         }
@@ -110,9 +103,10 @@ namespace Abp.RealTime
         {
             Check.NotNull(user, nameof(user));
 
-            return GetAllClients()
-                 .Where(c => c.UserId == user.UserId && c.TenantId == user.TenantId)
-                 .ToImmutableList();
+            var userIdentifier = new UserIdentifier(user.TenantId, user.UserId);
+            var clients = Store.GetAllByUserId(userIdentifier);
+
+            return clients;
         }
 
         [NotNull]
@@ -120,9 +114,11 @@ namespace Abp.RealTime
         {
             Check.NotNull(user, nameof(user));
 
-            return (await GetAllClientsAsync())
-                .Where(c => c.UserId == user.UserId && c.TenantId == user.TenantId)
-                .ToImmutableList();
+            var userIdentifier = new UserIdentifier(user.TenantId, user.UserId);
+            var clients = await Store.GetAllByUserIdAsync(userIdentifier);
+
+            return clients;
         }
+
     }
 }

--- a/src/Abp/RealTime/OnlineClientManager.cs
+++ b/src/Abp/RealTime/OnlineClientManager.cs
@@ -1,9 +1,11 @@
+using Abp.Dependency;
+using Abp.Extensions;
+using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Abp.Dependency;
-using JetBrains.Annotations;
+using System.Threading.Tasks;
 
 namespace Abp.RealTime
 {
@@ -38,29 +40,30 @@ namespace Abp.RealTime
             Store = store;
         }
 
-        public virtual void Add(IOnlineClient client)
+        public virtual async Task AddAsync(IOnlineClient client)
         {
             var userWasAlreadyOnline = false;
             var user = client.ToUserIdentifierOrNull();
 
             if (user != null)
             {
-                userWasAlreadyOnline = this.IsOnline(user);
+                userWasAlreadyOnline = await this.IsOnlineAsync(user);
             }
 
-            Store.Add(client);
+            await Store.AddAsync(client);
 
-            ClientConnected?.Invoke(this, new OnlineClientEventArgs(client));
+            ClientConnected.InvokeSafely(this, new OnlineClientEventArgs(client));
 
             if (user != null && !userWasAlreadyOnline)
             {
-                UserConnected?.Invoke(this, new OnlineUserEventArgs(user, client));
+                UserConnected.InvokeSafely(this, new OnlineUserEventArgs(user, client));
             }
         }
 
-        public virtual bool Remove(string connectionId)
+        public virtual async Task<bool> RemoveAsync(string connectionId)
         {
-            var result = Store.TryRemove(connectionId, out IOnlineClient client);
+            IOnlineClient client = default;
+            var result = await Store.TryRemoveAsync(connectionId, value => client = value);
             if (!result)
             {
                 return false;
@@ -70,30 +73,36 @@ namespace Abp.RealTime
             {
                 var user = client.ToUserIdentifierOrNull();
 
-                if (user != null && !this.IsOnline(user))
+                if (user != null && !await this.IsOnlineAsync(user))
                 {
-                    UserDisconnected.Invoke(this, new OnlineUserEventArgs(user, client));
+                    UserDisconnected.InvokeSafely(this, new OnlineUserEventArgs(user, client));
                 }
             }
 
-            ClientDisconnected?.Invoke(this, new OnlineClientEventArgs(client));
+            ClientDisconnected?.InvokeSafely(this, new OnlineClientEventArgs(client));
 
             return true;
         }
 
-        public virtual IOnlineClient GetByConnectionIdOrNull(string connectionId)
+        public virtual async Task<IOnlineClient> GetByConnectionIdOrNullAsync(string connectionId)
         {
-            if (Store.TryGet(connectionId, out IOnlineClient client))
+            IOnlineClient client = default;
+            if (await Store.TryGetAsync(connectionId, value => client = value))
             {
                 return client;
             }
 
             return null;
         }
-        
-        public virtual IReadOnlyList<IOnlineClient> GetAllClients()
+
+        public IReadOnlyList<IOnlineClient> GetAllClients()
         {
             return Store.GetAll();
+        }
+
+        private async Task<IReadOnlyList<IOnlineClient>> GetAllClientsAsync()
+        {
+            return await Store.GetAllAsync();
         }
 
         [NotNull]
@@ -104,6 +113,16 @@ namespace Abp.RealTime
             return GetAllClients()
                  .Where(c => c.UserId == user.UserId && c.TenantId == user.TenantId)
                  .ToImmutableList();
+        }
+
+        [NotNull]
+        public virtual async Task<IReadOnlyList<IOnlineClient>> GetAllByUserIdAsync([NotNull] IUserIdentifier user)
+        {
+            Check.NotNull(user, nameof(user));
+
+            return (await GetAllClientsAsync())
+                .Where(c => c.UserId == user.UserId && c.TenantId == user.TenantId)
+                .ToImmutableList();
         }
     }
 }

--- a/src/Abp/RealTime/OnlineClientManagerExtensions.cs
+++ b/src/Abp/RealTime/OnlineClientManagerExtensions.cs
@@ -1,5 +1,6 @@
-﻿using System.Linq;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Abp.RealTime
 {
@@ -13,21 +14,21 @@ namespace Abp.RealTime
         /// </summary>
         /// <param name="onlineClientManager">The online client manager.</param>
         /// <param name="user">User.</param>
-        public static bool IsOnline(
+        public static async Task<bool> IsOnlineAsync(
             [NotNull] this IOnlineClientManager onlineClientManager,
             [NotNull] UserIdentifier user)
         {
-            return onlineClientManager.GetAllByUserId(user).Any();
+            return (await onlineClientManager.GetAllByUserIdAsync(user)).Any();
         }
 
-        public static bool Remove(
+        public static async Task<bool> RemoveAsync(
             [NotNull] this IOnlineClientManager onlineClientManager,
             [NotNull] IOnlineClient client)
         {
             Check.NotNull(onlineClientManager, nameof(onlineClientManager));
             Check.NotNull(client, nameof(client));
 
-            return onlineClientManager.Remove(client.ConnectionId);
+            return await onlineClientManager.RemoveAsync(client.ConnectionId);
         }
     }
 }

--- a/test/Abp.Tests/RealTime/InMemoryOnlineClientManager_Tests.cs
+++ b/test/Abp.Tests/RealTime/InMemoryOnlineClientManager_Tests.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using Abp.RealTime;
+using Shouldly;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
-using Abp.RealTime;
-using Shouldly;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Abp.Tests.RealTime
@@ -20,7 +21,7 @@ namespace Abp.Tests.RealTime
         }
 
         [Fact]
-        public void Test_All()
+        public async Task Test_All()
         {
             int tenantId = 1;
 
@@ -33,18 +34,18 @@ namespace Abp.Tests.RealTime
 
             foreach (var pair in connections)
             {
-                _clientManager.Add(new OnlineClient(pair.Key, "127.0.0.1", tenantId, pair.Value));
+                await _clientManager.AddAsync(new OnlineClient(pair.Key, "127.0.0.1", tenantId, pair.Value));
             }
 
             var testId = connections.Keys.ToList()[5];
 
             _clientManager.GetAllClients().Count.ShouldBe(connections.Count);
-            _clientManager.GetAllByUserId(new UserIdentifier(tenantId, connections[testId])).Count.ShouldBe(1);
-            _clientManager.GetByConnectionIdOrNull(testId).ShouldNotBeNull();
-            _clientManager.Remove(testId).ShouldBeTrue();
+            (await _clientManager.GetAllByUserIdAsync(new UserIdentifier(tenantId, connections[testId]))).Count.ShouldBe(1);
+            await _clientManager.GetByConnectionIdOrNullAsync(testId).ShouldNotBeNull();
+            (await _clientManager.RemoveAsync(testId)).ShouldBeTrue();
             _clientManager.GetAllClients().Count.ShouldBe(connections.Count - 1);
-            _clientManager.GetByConnectionIdOrNull(testId).ShouldBeNull();
-            _clientManager.GetAllByUserId(new UserIdentifier(tenantId, connections[testId])).Count.ShouldBe(0);
+            (await _clientManager.GetByConnectionIdOrNullAsync(testId)).ShouldBeNull();
+            (await _clientManager.GetAllByUserIdAsync(new UserIdentifier(tenantId, connections[testId]))).Count.ShouldBe(0);
         }
 
         private static string MakeNewConnectionId()

--- a/test/Abp.Tests/RealTime/InMemoryOnlineClientManager_Tests.cs
+++ b/test/Abp.Tests/RealTime/InMemoryOnlineClientManager_Tests.cs
@@ -39,11 +39,11 @@ namespace Abp.Tests.RealTime
 
             var testId = connections.Keys.ToList()[5];
 
-            _clientManager.GetAllClients().Count.ShouldBe(connections.Count);
+            (await _clientManager.GetAllClientsAsync()).Count.ShouldBe(connections.Count);
             (await _clientManager.GetAllByUserIdAsync(new UserIdentifier(tenantId, connections[testId]))).Count.ShouldBe(1);
-            await _clientManager.GetByConnectionIdOrNullAsync(testId).ShouldNotBeNull();
+            (await _clientManager.GetByConnectionIdOrNullAsync(testId)).ShouldNotBeNull();
             (await _clientManager.RemoveAsync(testId)).ShouldBeTrue();
-            _clientManager.GetAllClients().Count.ShouldBe(connections.Count - 1);
+            (await _clientManager.GetAllClientsAsync()).Count.ShouldBe(connections.Count - 1);
             (await _clientManager.GetByConnectionIdOrNullAsync(testId)).ShouldBeNull();
             (await _clientManager.GetAllByUserIdAsync(new UserIdentifier(tenantId, connections[testId]))).Count.ShouldBe(0);
         }

--- a/test/Abp.Tests/RealTime/InMemoryOnlineClientStore_Tests.cs
+++ b/test/Abp.Tests/RealTime/InMemoryOnlineClientStore_Tests.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using Abp.RealTime;
+﻿using Abp.RealTime;
 using Shouldly;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Abp.Tests.RealTime
@@ -17,23 +18,23 @@ namespace Abp.Tests.RealTime
         }
 
         [Fact]
-        public void Test_All()
+        public async Task Test_All()
         {
             var connectionId = Guid.NewGuid().ToString("N");
 
-            _store.Add(new OnlineClient(connectionId, "127.0.0.1", 1, 2));
-            _store.TryGet(connectionId, out IOnlineClient client).ShouldBeTrue();
+            await _store.AddAsync(new OnlineClient(connectionId, "127.0.0.1", 1, 2));
+            (await _store.TryGetAsync(connectionId, value => _ = value)).ShouldBeTrue();
 
-            _store.Contains(connectionId).ShouldBeTrue();
-            _store.GetAll().Count.ShouldBe(1);
-            _store.Remove(connectionId).ShouldBeTrue();
-            _store.GetAll().Count.ShouldBe(0);
+            (await _store.ContainsAsync(connectionId)).ShouldBeTrue();
+            (await _store.GetAllAsync()).Count.ShouldBe(1);
+            (await _store.RemoveAsync(connectionId)).ShouldBeTrue();
+            (await _store.GetAllAsync()).Count.ShouldBe(0);
 
-            _chatStore.GetAll().Count.ShouldBe(0);
+            (await _chatStore.GetAllAsync()).Count.ShouldBe(0);
             connectionId = Guid.NewGuid().ToString("N");
 
-            _chatStore.Add(new OnlineClient(connectionId, "127.0.0.1", 1, 2));
-            _chatStore.GetAll().Count.ShouldBe(1);
+            await _chatStore.AddAsync(new OnlineClient(connectionId, "127.0.0.1", 1, 2));
+            (await _chatStore.GetAllAsync()).Count.ShouldBe(1);
         }
 
         internal class ChatChannel


### PR DESCRIPTION
# Changes
I changed all synchronous calls to asynchronous calls in interfaces/classes: 
* IOnlineClientStore
* IOnlineClientManager / OnlineClientManager
* OnlineClientManagerExtensions
* InMemoryOnlineClientStore
* RedisOnlineClientStore.cs
And in all places where they are called (including tests).

Removed:
 * SignalRRealTimeNotifier.SendNotifications() method and depends: 


I also changed the logic of **IOnlineClientManager.GetAllByUserId**, 
namely optimized this by storing a separate hash set of users with references to the connection hash set in Redis.
Added GetAllByUserId / GetAllByUserIdAsync to IOnlineClientStore and RedisOnlineClientStore.

# Reasoning
When using the latest version of a project, I noticed that the number of threads in the thread pool grows about x3 times the usual value since synchronous calls create **thread pool starvation issues**.

First, you can see the graphs from Application Insights, which clearly show the increase in ThreadPool:

![general chart](https://github.com/aspnetboilerplate/aspnetboilerplate/assets/28319749/93525888-39d7-417f-a38b-146b91efc187)

![chart with max thread count](https://github.com/aspnetboilerplate/aspnetboilerplate/assets/28319749/923fae72-a1e2-4b94-93e9-c942e17f9433)

The following screenshots are an accurate description of what blocks the application the most, and it turned out to be synchronous methods: 

![blocked time functions](https://github.com/aspnetboilerplate/aspnetboilerplate/assets/28319749/ea6a200e-dd6f-4943-ba09-a673f3068d4a)

![blocked time functions 2](https://github.com/aspnetboilerplate/aspnetboilerplate/assets/28319749/64f11cca-ba64-4182-b3d3-cf8ed2a8093e)

This all means that synchronous calls block and should be replaced with asynchronous calls

**About Redis**
In the current implementation, all online clients are retrieved from the Redis cache, which is very expensive. For instance in production env, this means transferring ~3 MB of data. 

**After local changes and testing, the situation has improved, so I would like to see these changes in the framework itself.**
