### PR TITLE
Update NLayer-Architecture.md

### DIFF
--- a/doc/WebSite/NLayer-Architecture.md
+++ b/doc/WebSite/NLayer-Architecture.md
@@ -2,12 +2,12 @@
 
 The layering of an application's codebase is a widely accepted technique to
 help reduce complexity and to improve code reusability. To achieve a layered
-architecture, ASP.NET Boilerplate follows the principles of **Domain
+architecture, ASP.NET Boilerplate follows the principles of the **Traditional "N-Layer" Architecture** with **Domain
 Driven Design**.
 
-### Domain Driven Design Layers
+### Traditional "N-Layer" Architecture Layers
 
-There are four fundamental layers in Domain Driven Design (DDD):
+There are four fundamental layers in the N-Layer Architecture:
 
 -   **Presentation Layer**: Provides an interface to the user. Uses the
     Application Layer to achieve user interactions.
@@ -15,7 +15,7 @@ There are four fundamental layers in Domain Driven Design (DDD):
     Layers. Orchestrates business objects to perform specific
     application tasks.
 -   **Domain Layer**: Includes business objects and their rules. This is the
-    heart of the application.
+    heart of the application and this is where DDD is applied.
 -   **Infrastructure Layer**: Provides generic technical capabilities
     that support higher layers mostly using 3rd-party libraries.
 


### PR DESCRIPTION
Hi,

I would like to suggest a little improvement to the docs.

In the [Domain Driven Design Layers](https://aspnetboilerplate.com/Pages/Documents/NLayer-Architecture) page at https://aspnetboilerplate.com/Pages/Documents/NLayer-Architecture the article says "_Domain Driven Design Layers_" and "_There are four fundamental layers in Domain Driven Design (DDD)_".

Despite the fact the community use DDD to refer to the N-Layer Architecture frequently, and vice versa, when we are in a formal context like in a documentation, the term "Domain Driven Design Layers" may not be precise and adequate.

The traditional Layered Architecture, also known as N-Layer Architecture, was proposed by Martin Fowler in 2002 at his book [Patterns of Enterprise Application Architecture](https://www.amazon.com/Patterns-Enterprise-Application-Architecture-Addison-Wesley-ebook/dp/B008OHVDFM/ref=tmm_kin_swatch_0?_encoding=UTF8&qid=&sr=). One year after the traditional Layered Architecture was introduced by Fowler, Erick Evans published its book [Domain-Driven Design: Tackling Complexity in the Heart of Software](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215).

In his blue book Erick Evans suggest the usage of a layered architecture in the Chapter 4. At the time of writing the DDD blue book, 20 years ago, the traditional layered architecture introduced by Fowler in 2002 was the only and the most popular layered architecture at its time.

Despite the fact Erick Evans suggests the usage of a layered architecture, the layered architecture itself was not created or introduced by Evans, nor DDD. It was introduced a year ago by Fowler. Evans so suggested the usage of the Fowler's layered architecture in its DDD blue book because of the various benefits it provides.

So, DDD and layered architecture, despite the fact it’s used together, are different things.

Here follows an excerpt from the Evans DDD blue book:

![image](https://github.com/aspnetboilerplate/aspnetboilerplate/assets/5115895/4c17b85b-d480-4e7d-a8a1-dcdaa4ff47d3)

Since the blue DDD book by Evans was published back in 2003 the time passed and other Layered Architectural Patterns emerged, like [Ports and Adapters](https://alistair.cockburn.us/hexagonal-architecture/) (aka Hexagonal Architecture) introduced by Dr. Alistair Cockburn at January 4th, 2005 and the [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) introduced by Robert C. Martin - Uncle Bob at August 13th, 2012 that’s very similar to the [Onion Architecture](https://dev.to/barrymcauley/onion-architecture-3fgl).

Nowadays DDD can be applied together with other Layered Architectural Patterns, not only in the traditional "N-Layer" Architecture from 2002¹. As all the other Layered Architectural Patterns have a Business logic layer (aka Domain or Model layer) DDD can be applied with all of those newer Layered Architectural Patterns.

> ¹Source: Chapter 8. Architectural Patterns - Khononov, Vlad. [Learning Domain-Driven Design](https://www.amazon.com/Learning-Domain-Driven-Design-Aligning-Architecture/dp/1098100131). O'Reilly Media. (2021)

It's a very controversial subject, but, as we noticed DDD and layered architecture are different things, despite the fact they are used together.

In this PR I made some small updates do the docs to make the terms "traditional N-Layer Layered Architecture" and "DDD" separated from each other.

Feel free to write your thoughts here as a comment. Feedbacks are welcome.