### PR TITLE
Call ToList while getting event handlers during event trigger process

### DIFF
--- a/src/Abp/Events/Bus/EventBus.cs
+++ b/src/Abp/Events/Bus/EventBus.cs
@@ -310,9 +310,9 @@ namespace Abp.Events.Bus
 
             await new SynchronizationContextRemover();
 
-            foreach (var handlerFactories in GetHandlerFactories(eventType))
+            foreach (var handlerFactories in GetHandlerFactories(eventType).ToList())
             {
-                foreach (var handlerFactory in handlerFactories.EventHandlerFactories)
+                foreach (var handlerFactory in handlerFactories.EventHandlerFactories.ToList())
                 {
                     var handlerType = handlerFactory.GetHandlerType();
 

--- a/test/Abp.Tests/Events/Bus/EventRegisterUnregisterTest.cs
+++ b/test/Abp.Tests/Events/Bus/EventRegisterUnregisterTest.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Abp.Events.Bus;
+using Shouldly;
+using Xunit;
+
+namespace Abp.Tests.Events.Bus
+{
+    public class EventRegisterUnregisterTest
+    {
+        IEventBus eventBus;
+
+        public EventRegisterUnregisterTest()
+        {
+            eventBus = new EventBus();
+        }
+
+        [Fact]
+        public void EventBustTest_UnregisterWhileHandlingEvent_ShouldNotThrow()
+        {
+            // Arrange
+            Func<MyEvent, Task> eventHandler = async (axel) => await axel.Semaphore.WaitAsync();
+            eventBus.AsyncRegister(eventHandler);
+            var myEvent = new MyEvent();
+
+            // Act
+            var triggerTask = eventBus.TriggerAsync(myEvent);
+            eventBus.AsyncUnregister(eventHandler);
+            myEvent.Semaphore.Release();
+
+            // Assert
+            Should.NotThrow(async () => await triggerTask);
+        }
+        
+        class MyEvent : EventData
+        {
+            public SemaphoreSlim Semaphore { get; set; } = new SemaphoreSlim(0);
+        }
+    }
+}


### PR DESCRIPTION
resolves #6726 
resolves #6737 

Call ToList while getting event handlers during event trigger process. We decided not to use `lock` because of performance and it requires big refactoring on the existing code because we are using async/await in the current code block.