### PR TITLE
Allow overwriting Redis cache clear methods

### DIFF
--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs
@@ -299,6 +299,11 @@ namespace Abp.Runtime.Caching.Redis
 
         public override void Clear()
         {
+            ClearPerRequestRedisCacheInternal();
+        }
+
+        protected virtual void ClearPerRequestRedisCacheInternal()
+        {
             base.Clear();
 
             var httpContext = _httpContextAccessor.HttpContext;
@@ -318,7 +323,7 @@ namespace Abp.Runtime.Caching.Redis
                 }
             }
         }
-
+        
         protected virtual string GetPerRequestRedisCacheKey(string key)
         {
             return AbpPerRequestRedisCachePrefix + GetLocalizedRedisKey(key).ToString();

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCache.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCache.cs
@@ -348,9 +348,14 @@ namespace Abp.Runtime.Caching.Redis
 
         public override void Clear()
         {
-            _database.KeyDeleteWithPrefix(GetLocalizedRedisKey("*"));
+            ClearRedisCacheInternal();
         }
 
+        protected virtual void ClearRedisCacheInternal()
+        {
+            _database.KeyDeleteWithPrefix(GetLocalizedRedisKey("*"));
+        }
+        
         protected virtual Type GetSerializableType(object value)
         {
             //TODO: This is a workaround for serialization problems of entities.


### PR DESCRIPTION
resolves #6744 

Now you can create your own implementation of AbpRedisCache and overwrite `ClearRedisCacheInternal` method to change behaviour of Clearing redis cache.

We will work on clustered Redis usage in below issue
https://github.com/aspnetboilerplate/aspnetboilerplate/issues/6820