### PR TITLE
remove [Obsolete("ISystemClock is obsolete, use TimeProvider on SecurityStampValidatorOptions instead.")] from AbpSecurityStampValidator and service_override

### DIFF
--- a/src/Abp.ZeroCore/Authorization/AbpSecurityStampValidator.cs
+++ b/src/Abp.ZeroCore/Authorization/AbpSecurityStampValidator.cs
@@ -3,7 +3,6 @@ using Abp.Authorization.Roles;
 using Abp.Authorization.Users;
 using Abp.Domain.Uow;
 using Abp.MultiTenancy;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
@@ -21,13 +20,11 @@ namespace Abp.Authorization
         public AbpSecurityStampValidator(
             IOptions<SecurityStampValidatorOptions> options,
             AbpSignInManager<TTenant, TRole, TUser> signInManager,
-            ISystemClock systemClock,
             ILoggerFactory loggerFactory,
             IUnitOfWorkManager unitOfWorkManager)
             : base(
                 options,
                 signInManager,
-                systemClock,
                 loggerFactory)
         {
             _unitOfWorkManager = unitOfWorkManager;

--- a/test/Abp.ZeroCore.SampleApp/Core/_Service_Overrides.cs
+++ b/test/Abp.ZeroCore.SampleApp/Core/_Service_Overrides.cs
@@ -12,7 +12,6 @@ using Abp.Configuration.Startup;
 using Abp.Dependency;
 using Abp.Domain.Repositories;
 using Abp.Domain.Uow;
-using Abp.Linq;
 using Abp.MultiTenancy;
 using Abp.Organizations;
 using Abp.Runtime.Caching;
@@ -208,10 +207,9 @@ namespace Abp.ZeroCore.SampleApp.Core
         public SecurityStampValidator(
             IOptions<SecurityStampValidatorOptions> options,
             SignInManager signInManager,
-            ISystemClock systemClock,
             ILoggerFactory loggerFactory,
             IUnitOfWorkManager unitOfWorkManager)
-            : base(options, signInManager, systemClock, loggerFactory, unitOfWorkManager)
+            : base(options, signInManager, loggerFactory, unitOfWorkManager)
         {
         }
     }


### PR DESCRIPTION
remove [Obsolete("ISystemClock is obsolete, use TimeProvider on SecurityStampValidatorOptions instead.")] from AbpSecurityStampValidator and service_override