### PR TITLE
DisposeAction should revert to initial state of the filters if the parameter does not have old value.

### DIFF
--- a/src/Abp/Domain/Uow/UnitOfWorkBase.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkBase.cs
@@ -246,6 +246,10 @@ namespace Abp.Domain.Uow
                 {
                     SetFilterParameter(filterName, parameterName, oldValue);
                 }
+                else
+                {
+                    _filters.RemoveAt(filterIndex);
+                }
             });
         }
 


### PR DESCRIPTION
Hello, 
The problem arises when the filter does not have old value. When disposing a filter that is set with SetFilterParameter method the new parameter should be deleted because it does not exist in the first place. The logical correction should be to make the filters array intact exactly like when it was before calling the SetFilterParameter method.