### PR TITLE
Honour column max length during UserLoginAttempt insertion

### DIFF
--- a/src/Abp.Zero/Authorization/AbpLoginManager.cs
+++ b/src/Abp.Zero/Authorization/AbpLoginManager.cs
@@ -241,16 +241,16 @@ namespace Abp.Authorization
                     var loginAttempt = new UserLoginAttempt
                     {
                         TenantId = tenantId,
-                        TenancyName = tenancyName,
+                        TenancyName = tenancyName.TruncateWithPostfix(UserLoginAttempt.MaxTenancyNameLength),
 
                         UserId = loginResult.User != null ? loginResult.User.Id : (long?)null,
-                        UserNameOrEmailAddress = userNameOrEmailAddress,
+                        UserNameOrEmailAddress = userNameOrEmailAddress.TruncateWithPostfix(UserLoginAttempt.MaxUserNameOrEmailAddressLength),
 
                         Result = loginResult.Result,
 
-                        BrowserInfo = ClientInfoProvider.BrowserInfo,
-                        ClientIpAddress = ClientInfoProvider.ClientIpAddress,
-                        ClientName = ClientInfoProvider.ComputerName,
+                        BrowserInfo = ClientInfoProvider.BrowserInfo.TruncateWithPostfix(UserLoginAttempt.MaxBrowserInfoLength),
+                        ClientIpAddress = ClientInfoProvider.ClientIpAddress.TruncateWithPostfix(UserLoginAttempt.MaxClientIpAddressLength),
+                        ClientName = ClientInfoProvider.ComputerName.TruncateWithPostfix(UserLoginAttempt.MaxClientNameLength),
                     };
 
                     await UserLoginAttemptRepository.InsertAsync(loginAttempt);

--- a/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
+++ b/src/Abp.ZeroCore/Authorization/AbpLoginManager.cs
@@ -262,16 +262,16 @@ namespace Abp.Authorization
                     var loginAttempt = new UserLoginAttempt
                     {
                         TenantId = tenantId,
-                        TenancyName = tenancyName,
+                        TenancyName = tenancyName.TruncateWithPostfix(UserLoginAttempt.MaxTenancyNameLength),
 
                         UserId = loginResult.User != null ? loginResult.User.Id : (long?) null,
-                        UserNameOrEmailAddress = userNameOrEmailAddress,
+                        UserNameOrEmailAddress = userNameOrEmailAddress.TruncateWithPostfix(UserLoginAttempt.MaxUserNameOrEmailAddressLength),
 
                         Result = loginResult.Result,
 
-                        BrowserInfo = ClientInfoProvider.BrowserInfo,
-                        ClientIpAddress = ClientInfoProvider.ClientIpAddress,
-                        ClientName = ClientInfoProvider.ComputerName,
+                        BrowserInfo = ClientInfoProvider.BrowserInfo.TruncateWithPostfix(UserLoginAttempt.MaxBrowserInfoLength),
+                        ClientIpAddress = ClientInfoProvider.ClientIpAddress.TruncateWithPostfix(UserLoginAttempt.MaxClientIpAddressLength),
+                        ClientName = ClientInfoProvider.ComputerName.TruncateWithPostfix(UserLoginAttempt.MaxClientNameLength),
                     };
 
                     await UserLoginAttemptRepository.InsertAsync(loginAttempt);
@@ -293,16 +293,16 @@ namespace Abp.Authorization
                     var loginAttempt = new UserLoginAttempt
                     {
                         TenantId = tenantId,
-                        TenancyName = tenancyName,
+                        TenancyName = tenancyName.TruncateWithPostfix(UserLoginAttempt.MaxTenancyNameLength),
 
                         UserId = loginResult.User != null ? loginResult.User.Id : (long?) null,
-                        UserNameOrEmailAddress = userNameOrEmailAddress,
+                        UserNameOrEmailAddress = userNameOrEmailAddress.TruncateWithPostfix(UserLoginAttempt.MaxUserNameOrEmailAddressLength),
 
                         Result = loginResult.Result,
 
-                        BrowserInfo = ClientInfoProvider.BrowserInfo,
-                        ClientIpAddress = ClientInfoProvider.ClientIpAddress,
-                        ClientName = ClientInfoProvider.ComputerName,
+                        BrowserInfo = ClientInfoProvider.BrowserInfo.TruncateWithPostfix(UserLoginAttempt.MaxBrowserInfoLength),
+                        ClientIpAddress = ClientInfoProvider.ClientIpAddress.TruncateWithPostfix(UserLoginAttempt.MaxClientIpAddressLength),
+                        ClientName = ClientInfoProvider.ComputerName.TruncateWithPostfix(UserLoginAttempt.MaxClientNameLength),
                     };
 
                     UserLoginAttemptRepository.Insert(loginAttempt);


### PR DESCRIPTION
Resolves https://github.com/aspnetboilerplate/aspnetboilerplate/issues/6862

SaveLoginAttempt fails due to exceeded max length of Client IP Address in UserLoginAttempt table. This PR fixes this issue by truncating string to max allowed length.