### PR TITLE
GetCacheItemFromDataSourceAsync method called fixed.

### DIFF
--- a/src/Abp/Domain/Entities/Caching/MultiTenancyEntityCache.cs
+++ b/src/Abp/Domain/Entities/Caching/MultiTenancyEntityCache.cs
@@ -43,7 +43,7 @@ namespace Abp.Domain.Entities.Caching
 
         public override Task<TCacheItem> GetAsync(TPrimaryKey id)
         {
-            return InternalCache.GetAsync(GetCacheKey(id), () => GetCacheItemFromDataSourceAsync(id));
+            return InternalCache.GetAsync(GetCacheKey(id), async () => await GetCacheItemFromDataSourceAsync(id));
         }
 
         public virtual void HandleEvent(EntityChangedEventData<TEntity> eventData)


### PR DESCRIPTION
resolves #6850 

GetCacheItemFromDataSourceAsync method called in MultiTenancyEntityCache has been fixed.