### PR TITLE
Normalize Key added with KeyPrefix in Redis Cache and TenantKeyEnabled

### DIFF
--- a/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs
+++ b/src/Abp.AspNetCore.PerRequestRedisCache/Runtime/Caching/Redis/AbpPerRequestRedisCache.cs
@@ -1,4 +1,5 @@
-﻿using Abp.Data;
+﻿using Abp.Configuration.Startup;
+using Abp.Data;
 using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
@@ -17,8 +18,10 @@ namespace Abp.Runtime.Caching.Redis
             string name,
             IAbpRedisCacheDatabaseProvider redisCacheDatabaseProvider,
             IRedisCacheSerializer redisCacheSerializer,
-            IHttpContextAccessor httpContextAccessor)
-            : base(name, redisCacheDatabaseProvider, redisCacheSerializer)
+            IHttpContextAccessor httpContextAccessor,
+            IMultiTenancyConfig multiTenancyConfig,
+            IAbpRedisCacheKeyNormalizer abpRedisCacheKeyNormalizer)
+            : base(name, redisCacheDatabaseProvider, redisCacheSerializer, abpRedisCacheKeyNormalizer, multiTenancyConfig)
         {
             _httpContextAccessor = httpContextAccessor;
         }
@@ -326,7 +329,7 @@ namespace Abp.Runtime.Caching.Redis
         
         protected virtual string GetPerRequestRedisCacheKey(string key)
         {
-            return AbpPerRequestRedisCachePrefix + GetLocalizedRedisKey(key).ToString();
+            return AbpPerRequestRedisCachePrefix + NormalizeKey(key).ToString();
         }
     }
 }

--- a/src/Abp.RedisCache.ProtoBuf/Runtime/Caching/Redis/AbpRedisCacheOptionsExtensions.cs
+++ b/src/Abp.RedisCache.ProtoBuf/Runtime/Caching/Redis/AbpRedisCacheOptionsExtensions.cs
@@ -9,6 +9,7 @@ namespace Abp.Runtime.Caching.Redis
         {
             options.AbpStartupConfiguration
                 .ReplaceService<IRedisCacheSerializer, ProtoBufRedisCacheSerializer>(DependencyLifeStyle.Transient);
+
         }
     }
 }

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCache.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCache.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Abp.Configuration.Startup;
 using Abp.Data;
 using Abp.Domain.Entities;
+using Abp.MultiTenancy;
 using Abp.Reflection.Extensions;
 using StackExchange.Redis;
 
@@ -18,42 +20,60 @@ namespace Abp.Runtime.Caching.Redis
         private readonly IDatabase _database;
         private readonly IRedisCacheSerializer _serializer;
 
+        protected IAbpRedisCacheKeyNormalizer KeyNormalizer { get; }
+        protected IMultiTenancyConfig MultiTenancyConfig { get; }
+
         /// <summary>
         /// Constructor.
         /// </summary>
         public AbpRedisCache(
             string name,
             IAbpRedisCacheDatabaseProvider redisCacheDatabaseProvider,
-            IRedisCacheSerializer redisCacheSerializer)
+            IRedisCacheSerializer redisCacheSerializer,
+            IAbpRedisCacheKeyNormalizer keyNormalizer,
+            IMultiTenancyConfig multiTenancyConfig)
             : base(name)
         {
             _database = redisCacheDatabaseProvider.GetDatabase();
             _serializer = redisCacheSerializer;
+            KeyNormalizer = keyNormalizer;
+            MultiTenancyConfig = multiTenancyConfig;
+        }
+
+        protected virtual RedisKey NormalizeKey(string key)
+        {
+            return KeyNormalizer.NormalizeKey(
+                new AbpRedisCacheKeyNormalizeArgs(
+                    key.ToString(),
+                    Name,
+                    MultiTenancyConfig.IsEnabled
+                )
+            );
         }
 
         public override bool TryGetValue(string key, out object value)
         {
-            var redisValue = _database.StringGet(GetLocalizedRedisKey(key));
+            var redisValue = _database.StringGet(NormalizeKey(key));
             value = redisValue.HasValue ? Deserialize(redisValue) : null;
             return redisValue.HasValue;
         }
 
         public override ConditionalValue<object>[] TryGetValues(string[] keys)
         {
-            var redisKeys = keys.Select(GetLocalizedRedisKey);
+            var redisKeys = keys.Select(NormalizeKey);
             var redisValues = _database.StringGet(redisKeys.ToArray());
             return redisValues.Select(CreateConditionalValue).ToArray();
         }
 
         public override async Task<ConditionalValue<object>> TryGetValueAsync(string key)
         {
-            var redisValue = await _database.StringGetAsync(GetLocalizedRedisKey(key));
+            var redisValue = await _database.StringGetAsync(NormalizeKey(key));
             return CreateConditionalValue(redisValue);
         }
 
         public override async Task<ConditionalValue<object>[]> TryGetValuesAsync(string[] keys)
         {
-            var redisKeys = keys.Select(GetLocalizedRedisKey);
+            var redisKeys = keys.Select(NormalizeKey);
             var redisValues = await _database.StringGetAsync(redisKeys.ToArray());
             return redisValues.Select(CreateConditionalValue).ToArray();
         }
@@ -65,7 +85,7 @@ namespace Abp.Runtime.Caching.Redis
                 throw new AbpException("Can not insert null values to the cache!");
             }
 
-            var redisKey = GetLocalizedRedisKey(key);
+            var redisKey = NormalizeKey(key);
             var redisValue = Serialize(value, GetSerializableType(value));
             if (absoluteExpireTime.HasValue)
             {
@@ -123,7 +143,7 @@ namespace Abp.Runtime.Caching.Redis
                 throw new AbpException("Can not insert null values to the cache!");
             }
 
-            var redisKey = GetLocalizedRedisKey(key);
+            var redisKey = NormalizeKey(key);
             var redisValue = Serialize(value, GetSerializableType(value));
             if (absoluteExpireTime.HasValue)
             {
@@ -182,7 +202,7 @@ namespace Abp.Runtime.Caching.Redis
             }
 
             var redisPairs = pairs.Select(p => {
-                var redisKey = GetLocalizedRedisKey(p.Key);
+                var redisKey = NormalizeKey(p.Key);
                 var redisValue = Serialize(p.Value, GetSerializableType(p.Value));
                 return new KeyValuePair<RedisKey, RedisValue>(redisKey, redisValue);
             }).ToList();
@@ -257,7 +277,7 @@ namespace Abp.Runtime.Caching.Redis
             }
 
             var redisPairs = pairs.Select(p => {
-                var redisKey = GetLocalizedRedisKey(p.Key);
+                var redisKey = NormalizeKey(p.Key);
                 var redisValue = Serialize(p.Value, GetSerializableType(p.Value));
                 return new KeyValuePair<RedisKey, RedisValue>(redisKey, redisValue);
             });
@@ -326,23 +346,23 @@ namespace Abp.Runtime.Caching.Redis
 
         public override void Remove(string key)
         {
-            _database.KeyDelete(GetLocalizedRedisKey(key));
+            _database.KeyDelete(NormalizeKey(key));
         }
 
         public override async Task RemoveAsync(string key)
         {
-            await _database.KeyDeleteAsync(GetLocalizedRedisKey(key));
+            await _database.KeyDeleteAsync(NormalizeKey(key));
         }
 
         public override void Remove(string[] keys)
         {
-            var redisKeys = keys.Select(GetLocalizedRedisKey);
+            var redisKeys = keys.Select(NormalizeKey);
             _database.KeyDelete(redisKeys.ToArray());
         }
 
         public override async Task RemoveAsync(string[] keys)
         {
-            var redisKeys = keys.Select(GetLocalizedRedisKey);
+            var redisKeys = keys.Select(NormalizeKey);
             await _database.KeyDeleteAsync(redisKeys.ToArray());
         }
 
@@ -353,7 +373,7 @@ namespace Abp.Runtime.Caching.Redis
 
         protected virtual void ClearRedisCacheInternal()
         {
-            _database.KeyDeleteWithPrefix(GetLocalizedRedisKey("*"));
+            _database.KeyDeleteWithPrefix(NormalizeKey("*"));
         }
         
         protected virtual Type GetSerializableType(object value)
@@ -381,11 +401,6 @@ namespace Abp.Runtime.Caching.Redis
         protected virtual object Deserialize(RedisValue objbyte)
         {
             return _serializer.Deserialize(objbyte);
-        }
-
-        protected virtual RedisKey GetLocalizedRedisKey(string key)
-        {
-            return "n:" + Name + ",c:" + key;
         }
     }
 }

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheKeyNormalizeArgs.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheKeyNormalizeArgs.cs
@@ -1,0 +1,21 @@
+﻿namespace Abp.Runtime.Caching.Redis
+{
+    public class AbpRedisCacheKeyNormalizeArgs
+    {
+        public string Key { get; }
+
+        public string CacheName { get; }
+
+        public bool MultiTenancyEnabled { get; }
+
+        public AbpRedisCacheKeyNormalizeArgs(
+            string key,
+            string cacheName,
+            bool multiTenancyEnabled)
+        {
+            Key = key;
+            CacheName = cacheName;
+            MultiTenancyEnabled = multiTenancyEnabled;
+        }
+    }
+}

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheKeyNormalizer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheKeyNormalizer.cs
@@ -20,7 +20,7 @@ namespace Abp.Runtime.Caching.Redis
         {
             var normalizedKey = $"n:{args.CacheName},c:{RedisCacheOptions.KeyPrefix}{args.Key}";
 
-            if (args.MultiTenancyEnabled && AbpSession.TenantId != null)
+            if (args.MultiTenancyEnabled && AbpSession.TenantId != null && RedisCacheOptions.TenantKeyEnabled)
             {
                 normalizedKey = $"t:{AbpSession.TenantId},{normalizedKey}";
             }

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheKeyNormalizer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheKeyNormalizer.cs
@@ -1,0 +1,31 @@
+﻿using Abp.Dependency;
+using Abp.Runtime.Session;
+using Microsoft.Extensions.Options;
+
+namespace Abp.Runtime.Caching.Redis
+{
+    public class AbpRedisCacheKeyNormalizer : IAbpRedisCacheKeyNormalizer, ITransientDependency
+    {
+        public IAbpSession AbpSession { get; set; }
+        protected AbpRedisCacheOptions RedisCacheOptions { get; }
+
+        public AbpRedisCacheKeyNormalizer(
+        IOptions<AbpRedisCacheOptions> redisCacheOptions)
+        {
+            AbpSession = NullAbpSession.Instance;
+            RedisCacheOptions = redisCacheOptions.Value;
+        }
+
+        public string NormalizeKey(AbpRedisCacheKeyNormalizeArgs args)
+        {
+            var normalizedKey = $"n:{args.CacheName},c:{RedisCacheOptions.KeyPrefix}{args.Key}";
+
+            if (args.MultiTenancyEnabled && AbpSession.TenantId != null)
+            {
+                normalizedKey = $"t:{AbpSession.TenantId},{normalizedKey}";
+            }
+
+            return normalizedKey;
+        }
+    }
+}

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheOptions.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheOptions.cs
@@ -17,13 +17,16 @@ namespace Abp.Runtime.Caching.Redis
         public int DatabaseId { get; set; }
 
         public string OnlineClientsStoreKey = "Abp.RealTime.OnlineClients";
-        
+
+        public string KeyPrefix { get; set; }
+
         public AbpRedisCacheOptions(IAbpStartupConfiguration abpStartupConfiguration)
         {
             AbpStartupConfiguration = abpStartupConfiguration;
 
             ConnectionString = GetDefaultConnectionString();
             DatabaseId = GetDefaultDatabaseId();
+            KeyPrefix = "";
         }
 
         private static int GetDefaultDatabaseId()
@@ -53,5 +56,7 @@ namespace Abp.Runtime.Caching.Redis
 
             return connStr.ConnectionString;
         }
+
+        
     }
 }

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheOptions.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/AbpRedisCacheOptions.cs
@@ -20,6 +20,8 @@ namespace Abp.Runtime.Caching.Redis
 
         public string KeyPrefix { get; set; }
 
+        public bool TenantKeyEnabled { get; set; }
+
         public AbpRedisCacheOptions(IAbpStartupConfiguration abpStartupConfiguration)
         {
             AbpStartupConfiguration = abpStartupConfiguration;
@@ -27,6 +29,7 @@ namespace Abp.Runtime.Caching.Redis
             ConnectionString = GetDefaultConnectionString();
             DatabaseId = GetDefaultDatabaseId();
             KeyPrefix = "";
+            TenantKeyEnabled = false;
         }
 
         private static int GetDefaultDatabaseId()

--- a/src/Abp.RedisCache/Runtime/Caching/Redis/IAbpRedisCacheKeyNormalizer.cs
+++ b/src/Abp.RedisCache/Runtime/Caching/Redis/IAbpRedisCacheKeyNormalizer.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Abp.Runtime.Caching.Redis
+{
+    public interface IAbpRedisCacheKeyNormalizer
+    {
+        string NormalizeKey(AbpRedisCacheKeyNormalizeArgs args);
+    }
+}

--- a/test/Abp.RedisCache.Tests/RedisCacheManager_Test.cs
+++ b/test/Abp.RedisCache.Tests/RedisCacheManager_Test.cs
@@ -9,6 +9,7 @@ using NSubstitute;
 using Xunit;
 using Shouldly;
 using StackExchange.Redis;
+using Microsoft.Extensions.Options;
 
 namespace Abp.RedisCache.Tests
 {
@@ -34,6 +35,11 @@ namespace Abp.RedisCache.Tests
             _redisSerializer = LocalIocManager.Resolve<IRedisCacheSerializer>();
 
             LocalIocManager.IocContainer.Register(Component.For<IAbpStartupConfiguration>().Instance(Substitute.For<IAbpStartupConfiguration>()));
+
+            LocalIocManager.Register<IAbpRedisCacheKeyNormalizer, AbpRedisCacheKeyNormalizer>();
+            LocalIocManager.Register<IOptions<AbpRedisCacheOptions>,OptionsWrapper<AbpRedisCacheOptions>>();
+            LocalIocManager.Register<IMultiTenancyConfig, MultiTenancyConfig>();
+
 
             LocalIocManager.Resolve<ICachingConfiguration>().Configure("MyTestCacheItems", cache =>
             {

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCacheReplacement_Tests.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCacheReplacement_Tests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Abp.Runtime.Caching;
+using Abp.Runtime.Caching.Redis;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using StackExchange.Redis;
@@ -16,6 +18,7 @@ namespace Abp.Zero.Redis.PerRequestRedisCache
 
         public AbpPerRequestRedisCacheReplacement_Tests()
         {
+            LocalIocManager.Register<IOptions<AbpRedisCacheOptions>, OptionsWrapper<AbpRedisCacheOptions>>();
             _typedCache = LocalIocManager.Resolve<ICacheManager>().GetCache<string, TestCacheItem>("TestCacheItems");
         }
 

--- a/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCache_Test.cs
+++ b/test/Abp.ZeroCore.Tests/Zero/Redis/PerRequestRedisCache/AbpPerRequestRedisCache_Test.cs
@@ -3,11 +3,13 @@ using System.Threading.Tasks;
 using Abp.Application.Editions;
 using Abp.Authorization.Roles;
 using Abp.Authorization.Users;
+using Abp.Configuration.Startup;
 using Abp.Json;
 using Abp.MultiTenancy;
 using Abp.Runtime.Caching;
 using Abp.Runtime.Caching.Configuration;
 using Abp.Runtime.Caching.Redis;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using StackExchange.Redis;
@@ -24,7 +26,9 @@ namespace Abp.Zero.Redis.PerRequestRedisCache
         {
             LocalIocManager.Resolve<ICachingConfiguration>().Configure("MyTestCacheItems", cache => { cache.DefaultSlidingExpireTime = TimeSpan.FromHours(12); });
             LocalIocManager.Resolve<ICachingConfiguration>().Configure("MyPerRequestRedisTestCacheItems", cache => { cache.DefaultSlidingExpireTime = TimeSpan.FromHours(24); });
-            
+
+            LocalIocManager.Register<IOptions<AbpRedisCacheOptions>, OptionsWrapper<AbpRedisCacheOptions>>();
+
             _perRequestRedisCache = LocalIocManager.Resolve<IAbpPerRequestRedisCacheManager>().GetCache<string, MyCacheItem>("MyPerRequestRedisTestCacheItems");
             _normalRedisCache = LocalIocManager.Resolve<ICacheManager>().GetCache<string, MyCacheItem>("MyTestCacheItems");
         }

--- a/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/AbpODataDtoControllerPermissionTests.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo.Tests/Tests/AbpODataDtoControllerPermissionTests.cs
@@ -8,6 +8,7 @@ using Abp.Dependency;
 using AbpAspNetCoreDemo.Core.Domain;
 using Castle.MicroKernel.Registration;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using NSubstitute;
 using Shouldly;
@@ -35,6 +36,7 @@ namespace AbpAspNetCoreDemo.IntegrationTests.Tests
             _permissionChecker = Substitute.For<IPermissionChecker>();
             _permissionChecker.IsGrantedAsync(Arg.Any<string>()).Returns(false);
             _permissionChecker.IsGranted(Arg.Any<string>()).Returns(false);
+
 
             Startup.IocManager.Value.IocContainer.Register(
                 Component.For<IPermissionChecker>().Instance(


### PR DESCRIPTION
Resolves #6877 

Normalize Key operation with KeyPrefix addition has been added to Redis Cache. Additionally, the ability to include tenant-specific keys can be activated in the options if desired.