### PR TITLE
Fixes the bug created by code change in #6854 && Formatter-based serialization is obsolete and should not be used

### DIFF
--- a/src/Abp.HtmlSanitizer/HtmlSanitizer/HtmlSanitizerBuilder.cs
+++ b/src/Abp.HtmlSanitizer/HtmlSanitizer/HtmlSanitizerBuilder.cs
@@ -27,7 +27,7 @@ namespace Abp.HtmlSanitizer
 
                 if (!typeof(T).IsAssignableFrom(type) || !type.IsClass) return false;
 
-                var instance = (T) FormatterServices.GetUninitializedObject(type);
+                var instance = (T) default;
 
                 var param = selector(instance);
 

--- a/src/Abp/Domain/Uow/UnitOfWorkBase.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkBase.cs
@@ -248,7 +248,7 @@ namespace Abp.Domain.Uow
                 }
                 else
                 {
-                    _filters.RemoveAt(filterIndex);
+                    _filters[filterIndex].FilterParameters[parameterName] = default;
                 }
             });
         }


### PR DESCRIPTION
The commit at #6854 has a logical divergence, which removes filter, but it should default (empty dictionary) the FilterParameters.