### PR TITLE
Changed `API Reference` title url

### DIFF
--- a/doc/WebSite/Document-Index.md
+++ b/doc/WebSite/Document-Index.md
@@ -10,7 +10,7 @@ Overall
 -   [Multi Tenancy](Multi-Tenancy.md)
 -   [OWIN Integration](OWIN.md)
 -   [Debugging](Debugging.md)
--   [API Reference](/api-docs/index.html)
+-   [API Reference](https://aspnetboilerplate.com/api-docs/api/index.html)
 
 Common Structures
 

--- a/doc/WebSite/Documents.md
+++ b/doc/WebSite/Documents.md
@@ -10,7 +10,7 @@ Overall
 -   [Multi-Tenancy](Multi-Tenancy.md)
 -   [OWIN Integration](OWIN.md)
 -   [Debugging](Debugging.md)
--   [API Reference](/api-docs/index.html)
+-   [API Reference](https://aspnetboilerplate.com/api-docs/api/index.html)
 
 Common Structures
 


### PR DESCRIPTION
Resolves [vs-internal/issues/3981](https://github.com/volosoft/vs-internal/issues/3981)

The "API Reference" title url has been replaced with the current url in the Documents.md and Documents-Index.md files located in the Website folder.