### PR TITLE
Added missing repository methods and implementation.

### DIFF
--- a/src/Abp.EntityFramework/EntityFramework/Repositories/EfRepositoryBaseOfTEntityAndTPrimaryKey.cs
+++ b/src/Abp.EntityFramework/EntityFramework/Repositories/EfRepositoryBaseOfTEntityAndTPrimaryKey.cs
@@ -101,6 +101,23 @@ namespace Abp.EntityFramework.Repositories
             return query;
         }
 
+        public override async Task<IQueryable<TEntity>> GetAllIncludingAsync(params Expression<Func<TEntity, object>>[] propertySelectors)
+        {
+            if (propertySelectors.IsNullOrEmpty())
+            {
+                return await GetAllAsync();
+            }
+
+            var query = await GetAllAsync();
+
+            foreach (var propertySelector in propertySelectors)
+            {
+                query = query.Include(propertySelector);
+            }
+
+            return query;
+        }
+
         public override async Task<List<TEntity>> GetAllListAsync()
         {
             var query = await GetAllAsync();

--- a/src/Abp/Domain/Repositories/IRepositoryOfTEntityAndTPrimaryKey.cs
+++ b/src/Abp/Domain/Repositories/IRepositoryOfTEntityAndTPrimaryKey.cs
@@ -25,11 +25,25 @@ namespace Abp.Domain.Repositories
 
         /// <summary>
         /// Used to get a IQueryable that is used to retrieve entities from entire table.
+        /// </summary>
+        /// <returns>IQueryable to be used to select entities from database</returns>
+        Task<IQueryable<TEntity>> GetAllAsync();
+
+        /// <summary>
+        /// Used to get a IQueryable that is used to retrieve entities from entire table.
         /// One or more 
         /// </summary>
         /// <param name="propertySelectors">A list of include expressions.</param>
         /// <returns>IQueryable to be used to select entities from database</returns>
         IQueryable<TEntity> GetAllIncluding(params Expression<Func<TEntity, object>>[] propertySelectors);
+
+        /// <summary>
+        /// Used to get a IQueryable that is used to retrieve entities from entire table.
+        /// One or more 
+        /// </summary>
+        /// <param name="propertySelectors">A list of include expressions.</param>
+        /// <returns>IQueryable to be used to select entities from database</returns>
+        Task<IQueryable<TEntity>> GetAllIncludingAsync(params Expression<Func<TEntity, object>>[] propertySelectors);
 
         /// <summary>
         /// Used to get all entities.


### PR DESCRIPTION
- Added GetAllAsync method to the IRepository interface. (#6922)
- Added GetAllIncludingAsync method to the IRepository interface (#6923)
- Implemented GetAllIncludingAsync in the EfRepositoryBase class, as it previously was not implemented, which meant that the AbpRepositoryBase class implementation was used, which just returns the result of GetAllAsync, which does not use the filters.