### PR TITLE
Add TryGetKey method to ILocalizationDictionary

### DIFF
--- a/src/Abp.Zero.Common/Localization/EmptyDictionary.cs
+++ b/src/Abp.Zero.Common/Localization/EmptyDictionary.cs
@@ -13,6 +13,11 @@ namespace Abp.Localization
             CultureInfo = cultureInfo;
         }
 
+        public string TryGetKey(string value)
+        {
+            return null;
+        }
+
         public LocalizedString GetOrNull(string name)
         {
             return null;

--- a/src/Abp.Zero.Common/Localization/IMultiTenantLocalizationDictionary.cs
+++ b/src/Abp.Zero.Common/Localization/IMultiTenantLocalizationDictionary.cs
@@ -9,6 +9,14 @@ namespace Abp.Localization
     public interface IMultiTenantLocalizationDictionary : ILocalizationDictionary
     {
         /// <summary>
+        /// Gets a <see cref="string"/> for given <paramref name="value"/>.
+        /// </summary>
+        /// <param name="tenantId">TenantId or null for host.</param>
+        /// <param name="value">Value to get key</param>
+        /// <returns>The key or null</returns>
+        string TryGetKey(int? tenantId, string value);
+
+        /// <summary>
         /// Gets a <see cref="LocalizedString"/>.
         /// </summary>
         /// <param name="tenantId">TenantId or null for host.</param>

--- a/src/Abp.Zero.Common/Localization/IMultiTenantLocalizationSource.cs
+++ b/src/Abp.Zero.Common/Localization/IMultiTenantLocalizationSource.cs
@@ -10,6 +10,18 @@ namespace Abp.Localization
     public interface IMultiTenantLocalizationSource : ILocalizationSource
     {
         /// <summary>
+        /// Gets key for given value.
+        /// </summary>
+        /// <param name="tenantId">TenantId or null for host.</param>
+        /// <param name="value">Value</param>
+        /// <param name="culture">culture information</param>
+        /// <param name="tryDefaults">
+        /// True: Fallbacks to default language if not found in current culture.
+        /// </param>
+        /// <returns>Key</returns>
+        string FindKeyOrNull(int? tenantId, string value, CultureInfo culture, bool tryDefaults = true);
+
+        /// <summary>
         /// Gets a <see cref="LocalizedString"/>.
         /// </summary>
         /// <param name="tenantId">TenantId or null for host.</param>

--- a/src/Abp/Localization/Dictionaries/ILocalizationDictionary.cs
+++ b/src/Abp/Localization/Dictionaries/ILocalizationDictionary.cs
@@ -20,6 +20,13 @@ namespace Abp.Localization.Dictionaries
         string this[string name] { get; set; }
 
         /// <summary>
+        /// Gets a <see cref="string"/> for given <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">Value to get key</param>
+        /// <returns>The key or null</returns>
+        string TryGetKey(string value);
+
+        /// <summary>
         /// Gets a <see cref="LocalizedString"/> for given <paramref name="name"/>.
         /// </summary>
         /// <param name="name">Name (key) to get localized string</param>

--- a/src/Abp/Localization/Dictionaries/LocalizationDictionary.cs
+++ b/src/Abp/Localization/Dictionaries/LocalizationDictionary.cs
@@ -38,6 +38,13 @@ namespace Abp.Localization.Dictionaries
         }
 
         /// <inheritdoc/>
+        public virtual string TryGetKey(string value)
+        {
+            var found = _dictionary.Values.FirstOrDefault(x => x.Value == value);
+            return found?.Name;
+        }
+
+        /// <inheritdoc/>
         public virtual LocalizedString GetOrNull(string name)
         {
             return _dictionary.TryGetValue(name, out var localizedString) ? localizedString : null;

--- a/src/Abp/Localization/Sources/ILocalizationSource.cs
+++ b/src/Abp/Localization/Sources/ILocalizationSource.cs
@@ -21,6 +21,17 @@ namespace Abp.Localization.Sources
         void Initialize(ILocalizationConfiguration configuration, IIocResolver iocResolver);
 
         /// <summary>
+        /// Gets key for given value.
+        /// </summary>
+        /// <param name="value">Value</param>
+        /// <param name="culture">culture information</param>
+        /// <param name="tryDefaults">
+        /// True: Fallbacks to default language if not found in current culture.
+        /// </param>
+        /// <returns>Key</returns>
+        string FindKeyOrNull(string value, CultureInfo culture, bool tryDefaults = true);
+
+        /// <summary>
         /// Gets localized string for given name in current language.
         /// Fallbacks to default language if not found in current culture.
         /// </summary>

--- a/src/Abp/Localization/Sources/NullLocalizationSource.cs
+++ b/src/Abp/Localization/Sources/NullLocalizationSource.cs
@@ -29,6 +29,11 @@ namespace Abp.Localization.Sources
 
         }
 
+        public string FindKeyOrNull(string value, CultureInfo culture, bool tryDefaults = true)
+        {
+            return null;
+        }
+
         public string GetString(string name)
         {
             return name;

--- a/src/Abp/Localization/Sources/Resource/ResourceFileLocalizationSource.cs
+++ b/src/Abp/Localization/Sources/Resource/ResourceFileLocalizationSource.cs
@@ -49,6 +49,11 @@ namespace Abp.Localization.Sources.Resource
                 : NullLogger.Instance;
         }
 
+        public string FindKeyOrNull(string value, CultureInfo culture, bool tryDefaults = true)
+        {
+            return null;
+        }
+
         public virtual string GetString(string name)
         {
             var value = GetStringOrNull(name);

--- a/src/Abp/Localization/Sources/Resource/ResourceFileLocalizationSource.cs
+++ b/src/Abp/Localization/Sources/Resource/ResourceFileLocalizationSource.cs
@@ -51,7 +51,11 @@ namespace Abp.Localization.Sources.Resource
 
         public string FindKeyOrNull(string value, CultureInfo culture, bool tryDefaults = true)
         {
-            return null;
+            var resource = ResourceManager.GetResourceSet(culture, true, tryDefaults)
+                .Cast<DictionaryEntry>()
+                .FirstOrDefault(x => x.Value.ToString() == value);
+
+            return resource.Key?.ToString();
         }
 
         public virtual string GetString(string name)
@@ -94,7 +98,8 @@ namespace Abp.Localization.Sources.Resource
             var nullValues = values.Where(x => x.Value == null).ToList();
             if (nullValues.Any())
             {
-                return ReturnGivenNamesOrThrowException(nullValues.Select(x => x.Name).ToList(), CultureInfo.CurrentUICulture);
+                return ReturnGivenNamesOrThrowException(nullValues.Select(x => x.Name).ToList(),
+                    CultureInfo.CurrentUICulture);
             }
 
             return values.Select(x => x.Value).ToList();

--- a/test/Abp.Tests/Localization/ResourceFileLocalizationSource_Tests.cs
+++ b/test/Abp.Tests/Localization/ResourceFileLocalizationSource_Tests.cs
@@ -137,6 +137,13 @@ namespace Abp.Tests.Localization
             enStrings.ShouldContain(x => x == null);
             enStrings[2].ShouldBeNull(); //NotExist
         }
+        
+        [Fact]
+        public void Should_Get_Correct_Localization_Key()
+        {
+            _resourceFileLocalizationSource.FindKeyOrNull("Hello!", new CultureInfo("en")).ShouldBe("Hello");
+            _resourceFileLocalizationSource.FindKeyOrNull("Merhaba!", new CultureInfo("tr")).ShouldBe("Hello");
+        }
 
         [Fact(Skip = "Waiting for https://github.com/aspnetboilerplate/aspnetboilerplate/issues/1995")]
         public void Test_GetAllStrings()

--- a/test/Abp.Tests/Localization/Test_DictionaryBasedLocalizationSource.cs
+++ b/test/Abp.Tests/Localization/Test_DictionaryBasedLocalizationSource.cs
@@ -83,6 +83,13 @@ namespace Abp.Tests.Localization
             _localizationSource.GetString("An undefined text").ShouldBe("[An undefined text]");
         }
 
+        [Fact]
+        public void Should_Get_Correct_Localization_Key()
+        {
+            _localizationSource.FindKeyOrNull("Yeryüzü", new CultureInfo("tr-TR")).ShouldBe("world");
+            _localizationSource.FindKeyOrNull("Fourty Two (42)", new CultureInfo("fr-FR")).ShouldBe("fourtyTwo");
+        }
+        
         private class FakeLocalizationDictionary : LocalizationDictionaryProviderBase
         {
             public FakeLocalizationDictionary()


### PR DESCRIPTION
Hello,
Find the key to a localized string, this is needed when you try to import or convert back the localized strings to corresponding type or enum.
ResourceFileLocalizationSource does not provide any method to find key properly, so returning null.