### PR TITLE
Added asynchronous cancel mode in EfCoreAsyncQueryableExecuter

### DIFF
--- a/src/Abp.EntityFramework/EntityFramework/Linq/EfAsyncQueryableExecuter.cs
+++ b/src/Abp.EntityFramework/EntityFramework/Linq/EfAsyncQueryableExecuter.cs
@@ -2,32 +2,49 @@
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Abp.Dependency;
 using Abp.Linq;
+using Abp.Threading;
 
 namespace Abp.EntityFramework.Linq
 {
     public class EfAsyncQueryableExecuter : IAsyncQueryableExecuter, ISingletonDependency
     {
-        public Task<int> CountAsync<T>(IQueryable<T> queryable)
+        private readonly ICancellationTokenProvider _cancellationTokenProvider;
+
+        public EfAsyncQueryableExecuter(ICancellationTokenProvider cancellationTokenProvider)
         {
-            return queryable.CountAsync();
+            _cancellationTokenProvider = cancellationTokenProvider;
         }
 
-        public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable)
+        public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
-            return queryable.ToListAsync();
+            return ExecuteAsync(queryable, (q, token) => q.CountAsync(token), cancellationToken);
         }
 
-        public Task<T> FirstOrDefaultAsync<T>(IQueryable<T> queryable)
+        public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
-            return queryable.FirstOrDefaultAsync();
+            return ExecuteAsync(queryable, (q, token) => q.ToListAsync(token), cancellationToken);
         }
 
-        public Task<bool> AnyAsync<T>(IQueryable<T> queryable)
+        public Task<T> FirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
-            return queryable.AnyAsync();
+            return ExecuteAsync(queryable, (q, token) => q.FirstOrDefaultAsync(token), cancellationToken);
+        }
+
+        public Task<bool> AnyAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
+        {
+            return ExecuteAsync(queryable, (q, token) => q.AnyAsync(token), cancellationToken);
+        }
+
+        private async Task<TResult> ExecuteAsync<T, TResult>(IQueryable<T> queryable,
+            Func<IQueryable<T>, CancellationToken, Task<TResult>> executeMethod,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken = _cancellationTokenProvider.FallbackToProvider(cancellationToken);
+            return await executeMethod(queryable, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Abp/Linq/IAsyncQueryableExecuter.cs
+++ b/src/Abp/Linq/IAsyncQueryableExecuter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Abp.Linq
@@ -10,12 +11,12 @@ namespace Abp.Linq
     /// </summary>
     public interface IAsyncQueryableExecuter
     {
-        Task<int> CountAsync<T>(IQueryable<T> queryable);
+        Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default);
 
-        Task<List<T>> ToListAsync<T>(IQueryable<T> queryable);
+        Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default);
 
-        Task<T> FirstOrDefaultAsync<T>(IQueryable<T> queryable);
+        Task<T> FirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default);
 
-        Task<bool> AnyAsync<T>(IQueryable<T> queryable);
+        Task<bool> AnyAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Abp/Linq/NullAsyncQueryableExecuter.cs
+++ b/src/Abp/Linq/NullAsyncQueryableExecuter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Abp.Linq
@@ -8,22 +9,22 @@ namespace Abp.Linq
     {
         public static NullAsyncQueryableExecuter Instance { get; } = new NullAsyncQueryableExecuter();
 
-        public Task<int> CountAsync<T>(IQueryable<T> queryable)
+        public Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(queryable.Count());
         }
 
-        public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable)
+        public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(queryable.ToList());
         }
 
-        public Task<T> FirstOrDefaultAsync<T>(IQueryable<T> queryable)
+        public Task<T> FirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(queryable.FirstOrDefault());
         }
 
-        public Task<bool> AnyAsync<T>(IQueryable<T> queryable)
+        public Task<bool> AnyAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(queryable.Any());
         }

--- a/test/Abp.Zero.SampleApp.Tests/DynamicEntityProperties/DynamicEntityPropertiesTestModule.cs
+++ b/test/Abp.Zero.SampleApp.Tests/DynamicEntityProperties/DynamicEntityPropertiesTestModule.cs
@@ -1,4 +1,6 @@
 ﻿using Abp.Modules;
+using Abp.Threading;
+using Castle.MicroKernel.Registration;
 
 namespace Abp.Zero.SampleApp.Tests.DynamicEntityProperties
 {
@@ -8,6 +10,11 @@ namespace Abp.Zero.SampleApp.Tests.DynamicEntityProperties
         public override void PreInitialize()
         {
             IocManager.RegisterAssemblyByConvention(typeof(DynamicEntityPropertiesTestModule).Assembly);
+
+            IocManager.IocContainer.Register(
+                Component.For<ICancellationTokenProvider>().Instance(NullCancellationTokenProvider.Instance)
+                    .LifestyleSingleton()
+            );
 
             Configuration.Authorization.Providers.Add<DynamicEntityPropertiesTestAuthorizationProvider>();
             Configuration.DynamicEntityProperties.Providers.Add<MyDynamicEntityPropertyDefinitionProvider>();

--- a/test/Abp.Zero.SampleApp/Linq/FakeAsyncQueryableExecuter.cs
+++ b/test/Abp.Zero.SampleApp/Linq/FakeAsyncQueryableExecuter.cs
@@ -1,6 +1,7 @@
 ﻿using Abp.Linq;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Abp.Zero.SampleApp.Linq
@@ -12,7 +13,7 @@ namespace Abp.Zero.SampleApp.Linq
     /// </summary>
     public class FakeAsyncQueryableExecuter : IAsyncQueryableExecuter
     {
-        public async Task<bool> AnyAsync<T>(IQueryable<T> queryable)
+        public async Task<bool> AnyAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
             await AsyncTask();
             return queryable.Any();
@@ -23,7 +24,7 @@ namespace Abp.Zero.SampleApp.Linq
             throw new System.NotImplementedException();
         }
 
-        public async Task<int> CountAsync<T>(IQueryable<T> queryable)
+        public async Task<int> CountAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
             await AsyncTask();
             return queryable.Count();
@@ -34,7 +35,7 @@ namespace Abp.Zero.SampleApp.Linq
             throw new System.NotImplementedException();
         }
 
-        public async Task<T> FirstOrDefaultAsync<T>(IQueryable<T> queryable)
+        public async Task<T> FirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
             await AsyncTask();
             return queryable.FirstOrDefault();
@@ -45,7 +46,7 @@ namespace Abp.Zero.SampleApp.Linq
             throw new System.NotImplementedException();
         }
 
-        public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable)
+        public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
         {
             await AsyncTask();
             return queryable.ToList();


### PR DESCRIPTION
Resolves #6920 

ICancellationTokenProvider was implemented in the EfCoreAsyncQueryableExecuter and EfAsyncQueryableExecuter classes.