### PR TITLE
Update PermissionManager.cs

### DIFF
--- a/src/Abp/Authorization/PermissionManager.cs
+++ b/src/Abp/Authorization/PermissionManager.cs
@@ -91,7 +91,6 @@ namespace Abp.Authorization
 
                 var permissions = Permissions.Values
                     .WhereIf(tenancyFilter, p => p.MultiTenancySides.HasFlag(GetCurrentMultiTenancySide()))
-                    .Where(p => p.FeatureDependency == null || GetCurrentMultiTenancySide() == MultiTenancySides.Host)
                     .ToList();
 
                 var result = await FilterSatisfiedPermissionsAsync(featureDependencyContextObject, permissions);


### PR DESCRIPTION
With this condition, you can't actually see permissions that have feature dependencies if they are not Host Permissions. This allows non-host permissions that have feature dependencies to be pulled.