### PR TITLE
Introducing ABP Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Packages integrated into <a href="https://docs.microsoft.com/en-us/aspnet/identi
 |Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore|[![NuGet version](https://badge.fury.io/nu/Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore.svg)](https://badge.fury.io/nu/Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore)|
 
 ### Shared Packages
-Shared packages between the Abp.ZeroCore.* and Abp.Zero.* packages.
+
 Shared packages between the Abp.ZeroCore.\* and Abp.Zero.\* packages.
 
 |Package|Status|

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![NuGet](https://img.shields.io/nuget/v/Abp.svg?style=flat-square)](https://www.nuget.org/packages/Abp)
 [![MyGet (with prereleases)](https://img.shields.io/myget/abp-nightly/vpre/Abp.svg?style=flat-square)](https://aspnetboilerplate.com/Pages/Documents/Nightly-Builds)
 [![NuGet Download](https://img.shields.io/nuget/dt/Abp.svg?style=flat-square)](https://www.nuget.org/packages/Abp)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20ABP%20Guru-006BFF?style=flat-square)](https://gurubase.io/g/abp)
 
 ## What is ABP?
 
@@ -109,7 +110,7 @@ Packages integrated into <a href="https://docs.microsoft.com/en-us/aspnet/identi
 |Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore|[![NuGet version](https://badge.fury.io/nu/Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore.svg)](https://badge.fury.io/nu/Abp.ZeroCore.IdentityServer4.vNext.EntityFrameworkCore)|
 
 ### Shared Packages
-
+Shared packages between the Abp.ZeroCore.* and Abp.Zero.* packages.
 Shared packages between the Abp.ZeroCore.\* and Abp.Zero.\* packages.
 
 |Package|Status|


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [ABP Guru](https://gurubase.io/g/abp) to Gurubase. ABP Guru uses the data from this repo and data from the [docs](https://aspnetboilerplate.com/Pages/Documents) to answer questions by leveraging the LLM.

In this PR, I showcased the "ABP Guru", which highlights that ABP now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable ABP Guru in Gurubase, just let me know that's totally fine.
