### PR TITLE
Replaced static HangfireBackgroundJob methods with DI-injected IBackgroundJobClient

### DIFF
--- a/src/Abp.HangFire.AspNetCore/Hangfire/HangfireBackgroundJobManager.cs
+++ b/src/Abp.HangFire.AspNetCore/Hangfire/HangfireBackgroundJobManager.cs
@@ -3,12 +3,19 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Abp.BackgroundJobs;
 using Abp.Threading.BackgroundWorkers;
-using HangfireBackgroundJob = Hangfire.BackgroundJob;
+using Hangfire;
 
 namespace Abp.Hangfire
 {
     public class HangfireBackgroundJobManager : BackgroundWorkerBase, IBackgroundJobManager
     {
+        private readonly IBackgroundJobClient _backgroundJobClient;
+
+        public HangfireBackgroundJobManager(IBackgroundJobClient backgroundJobClient)
+        {
+            _backgroundJobClient = backgroundJobClient;
+        }
+
         public virtual Task<string> EnqueueAsync<TJob, TArgs>(TArgs args, BackgroundJobPriority priority = BackgroundJobPriority.Normal,
             TimeSpan? delay = null) where TJob : IBackgroundJobBase<TArgs>
         {
@@ -18,22 +25,22 @@ namespace Abp.Hangfire
             {
                 if (typeof(IBackgroundJob<TArgs>).IsAssignableFrom(typeof(TJob)))
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args));
+                    jobUniqueIdentifier = _backgroundJobClient.Enqueue<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args));
                 }
                 else
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args));
+                    jobUniqueIdentifier = _backgroundJobClient.Enqueue<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args));
                 }
             }
             else
             {
                 if (typeof(IBackgroundJob<TArgs>).IsAssignableFrom(typeof(TJob)))
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args), delay.Value);
+                    jobUniqueIdentifier = _backgroundJobClient.Schedule<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args), delay.Value);
                 }
                 else
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args), delay.Value);
+                    jobUniqueIdentifier = _backgroundJobClient.Schedule<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args), delay.Value);
                 }
             }
 
@@ -49,22 +56,22 @@ namespace Abp.Hangfire
             {
                 if (typeof(IBackgroundJob<TArgs>).IsAssignableFrom(typeof(TJob)))
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args));
+                    jobUniqueIdentifier = _backgroundJobClient.Enqueue<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args));
                 }
                 else
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args));
+                    jobUniqueIdentifier = _backgroundJobClient.Enqueue<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args));
                 }
             }
             else
             {
                 if (typeof(IBackgroundJob<TArgs>).IsAssignableFrom(typeof(TJob)))
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args), delay.Value);
+                    jobUniqueIdentifier = _backgroundJobClient.Schedule<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args), delay.Value);
                 }
                 else
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args), delay.Value);
+                    jobUniqueIdentifier = _backgroundJobClient.Schedule<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args), delay.Value);
                 }
             }
 
@@ -78,7 +85,7 @@ namespace Abp.Hangfire
                 throw new ArgumentNullException(nameof(jobId));
             }
 
-            bool successfulDeletion = HangfireBackgroundJob.Delete(jobId);
+            bool successfulDeletion = _backgroundJobClient.Delete(jobId);
             return Task.FromResult(successfulDeletion);
         }
 
@@ -89,7 +96,7 @@ namespace Abp.Hangfire
                 throw new ArgumentNullException(nameof(jobId));
             }
 
-            bool successfulDeletion = HangfireBackgroundJob.Delete(jobId);
+            bool successfulDeletion = _backgroundJobClient.Delete(jobId);
             return successfulDeletion;
         }
     }

--- a/src/Abp.HangFire/Hangfire/HangfireBackgroundJobManager.cs
+++ b/src/Abp.HangFire/Hangfire/HangfireBackgroundJobManager.cs
@@ -4,7 +4,6 @@ using Abp.BackgroundJobs;
 using Abp.Hangfire.Configuration;
 using Abp.Threading.BackgroundWorkers;
 using Hangfire;
-using HangfireBackgroundJob = Hangfire.BackgroundJob;
 
 namespace Abp.Hangfire
 {
@@ -12,13 +11,16 @@ namespace Abp.Hangfire
     {
         private readonly IBackgroundJobConfiguration _backgroundJobConfiguration;
         private readonly IAbpHangfireConfiguration _hangfireConfiguration;
+        private readonly IBackgroundJobClient _backgroundJobClient;
 
         public HangfireBackgroundJobManager(
             IBackgroundJobConfiguration backgroundJobConfiguration,
-            IAbpHangfireConfiguration hangfireConfiguration)
+            IAbpHangfireConfiguration hangfireConfiguration,
+            IBackgroundJobClient backgroundJobClient)
         {
             _backgroundJobConfiguration = backgroundJobConfiguration;
             _hangfireConfiguration = hangfireConfiguration;
+            _backgroundJobClient = backgroundJobClient;
         }
 
         public override void Start()
@@ -57,22 +59,22 @@ namespace Abp.Hangfire
             {
                 if (typeof(IBackgroundJob<TArgs>).IsAssignableFrom(typeof(TJob)))
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args));
+                    jobUniqueIdentifier = _backgroundJobClient.Enqueue<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args));
                 }
                 else
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args));
+                    jobUniqueIdentifier = _backgroundJobClient.Enqueue<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args));
                 }
             }
             else
             {
                 if (typeof(IBackgroundJob<TArgs>).IsAssignableFrom(typeof(TJob)))
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args), delay.Value);
+                    jobUniqueIdentifier = _backgroundJobClient.Schedule<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args), delay.Value);
                 }
                 else
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args), delay.Value);
+                    jobUniqueIdentifier = _backgroundJobClient.Schedule<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args), delay.Value);
                 }
             }
 
@@ -88,22 +90,22 @@ namespace Abp.Hangfire
             {
                 if (typeof(IBackgroundJob<TArgs>).IsAssignableFrom(typeof(TJob)))
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args));
+                    jobUniqueIdentifier = _backgroundJobClient.Enqueue<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args));
                 }
                 else
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Enqueue<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args));
+                    jobUniqueIdentifier = _backgroundJobClient.Enqueue<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args));
                 }
             }
             else
             {
                 if (typeof(IBackgroundJob<TArgs>).IsAssignableFrom(typeof(TJob)))
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args), delay.Value);
+                    jobUniqueIdentifier = _backgroundJobClient.Schedule<TJob>(job => ((IBackgroundJob<TArgs>)job).Execute(args), delay.Value);
                 }
                 else
                 {
-                    jobUniqueIdentifier = HangfireBackgroundJob.Schedule<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args), delay.Value);
+                    jobUniqueIdentifier = _backgroundJobClient.Schedule<TJob>(job => ((IAsyncBackgroundJob<TArgs>)job).ExecuteAsync(args), delay.Value);
                 }
             }
 
@@ -117,7 +119,7 @@ namespace Abp.Hangfire
                 throw new ArgumentNullException(nameof(jobId));
             }
 
-            bool successfulDeletion = HangfireBackgroundJob.Delete(jobId);
+            bool successfulDeletion = _backgroundJobClient.Delete(jobId);
             return Task.FromResult(successfulDeletion);
         }
 
@@ -128,7 +130,7 @@ namespace Abp.Hangfire
                 throw new ArgumentNullException(nameof(jobId));
             }
 
-            bool successfulDeletion = HangfireBackgroundJob.Delete(jobId);
+            bool successfulDeletion = _backgroundJobClient.Delete(jobId);
             return successfulDeletion;
         }
     }


### PR DESCRIPTION
Resolves #7082 

The HangfireBackgroundJobManager class has been refactored to use HangfireBackgroundJob through dependency injection instead of utilizing it as a static class.