### PR TITLE
In this code:

### DIFF
--- a/test/aspnet-core-demo/AbpAspNetCoreDemo.Core/Application/ProductAppService.cs
+++ b/test/aspnet-core-demo/AbpAspNetCoreDemo.Core/Application/ProductAppService.cs
@@ -9,59 +9,68 @@ using AbpAspNetCoreDemo.Core.Domain;
 using Abp.Domain.Repositories;
 using Abp.Domain.Uow;
 using Abp.UI;
+using Microsoft.Extensions.DependencyInjection;
+using AbpAspNetCoreDemo;
+using System;
 
-namespace AbpAspNetCoreDemo.Core.Application;
-
-public class ProductAppService : ApplicationService
+namespace AbpAspNetCoreDemo.Core.Application
 {
-    private readonly IRepository<Product> _productRepository;
-
-    public ProductAppService(IRepository<Product> productRepository)
+    public class ProductAppService : ApplicationService
     {
-        _productRepository = productRepository;
-    }
+        private readonly IRepository<Product> _productRepository;
+        private readonly IServiceProvider _serviceProvider;
 
-    public async Task<List<ProductDto>> GetAllAsync()
-    {
-        return ObjectMapper.Map<List<ProductDto>>(await _productRepository.GetAllListAsync());
-    }
-
-    public int CreateProduct(ProductCreateInput input)
-    {
-        var product = ObjectMapper.Map<Product>(input);
-        return _productRepository.InsertAndGetId(product);
-    }
-
-    public void CreateProductAndRollback(ProductCreateInput input)
-    {
-        _productRepository.Insert(ObjectMapper.Map<Product>(input));
-        CurrentUnitOfWork.SaveChanges();
-        throw new UserFriendlyException("This exception is thrown to rollback the transaction!");
-    }
-
-    //TODO: This method crashes!
-    public async Task GetAllParallel()
-    {
-        const int threadCount = 32;
-
-        var tasks = new List<Task<int>>();
-
-        for (int i = 0; i < threadCount; i++)
+        public ProductAppService(IRepository<Product> productRepository, IServiceProvider serviceProvider)
         {
-            tasks.Add(GetAllParallelMethod());
+            _productRepository = productRepository;
+            _serviceProvider = serviceProvider;
         }
 
-        await Task.WhenAll(tasks.Cast<Task>().ToArray());
-
-        foreach (var task in tasks)
+        public async Task<List<ProductDto>> GetAllAsync()
         {
-            Debug.Assert(task.Result > 0);
+            return ObjectMapper.Map<List<ProductDto>>(await _productRepository.GetAllListAsync());
         }
-    }
 
-    [UnitOfWork(TransactionScopeOption.RequiresNew)]
-    protected virtual async Task<int> GetAllParallelMethod()
-    {
-        return await _productRepository.CountAsync();
+        public int CreateProduct(ProductCreateInput input)
+        {
+            var product = ObjectMapper.Map<Product>(input);
+            return _productRepository.InsertAndGetId(product);
+        }
+
+        public void CreateProductAndRollback(ProductCreateInput input)
+        {
+            _productRepository.Insert(ObjectMapper.Map<Product>(input));
+            CurrentUnitOfWork.SaveChanges();
+            throw new UserFriendlyException("This exception is thrown to rollback the transaction!");
+        }
+
+        public async Task GetAllParallel()
+        {
+            const int threadCount = 32;
+
+            var tasks = new List<Task<int>>();
+
+            for (int i = 0; i < threadCount; i++)
+            {
+                tasks.Add(Task.Run(() => GetAllParallelMethod()));
+            }
+
+            await Task.WhenAll(tasks.Cast<Task>().ToArray());
+
+            foreach (var task in tasks)
+            {
+                Debug.Assert(task.Result > 0);
+            }
+        }
+
+        [UnitOfWork(TransactionScopeOption.RequiresNew)]
+        protected virtual async Task<int> GetAllParallelMethod()
+        {
+            using (var scope = _serviceProvider.CreateScope())
+            {
+                var productRepository = scope.ServiceProvider.GetRequiredService<IRepository<Product>>();
+                return await productRepository.CountAsync();
+            }
+        }
     }
 }


### PR DESCRIPTION
Each task is run in a new scope using Task.Run.
A new IServiceScope is created for each task to ensure that each task gets its own DbContext instance. The IProductRepository is resolved from the new scope to ensure it uses the new DbContext instance.

fixes #7090

@dotnet-policy-service agree