### PR TITLE
Refactored LastModifierUserId handling in EntityAuditingHelper

### DIFF
--- a/src/Abp/Domain/Entities/Auditing/EntityAuditingHelper.cs
+++ b/src/Abp/Domain/Entities/Auditing/EntityAuditingHelper.cs
@@ -96,14 +96,13 @@ namespace Abp.Domain.Entities.Auditing
                 return;
             }
 
-            var entity = entityAsObj.As<IModificationAudited>();
-
-            if (userId == null)
+            var lastModifierUserIdFilter = auditFields?.FirstOrDefault(e => e.FieldName == AbpAuditFields.LastModifierUserId);
+            if (lastModifierUserIdFilter != null && !lastModifierUserIdFilter.IsSavingEnabled)
             {
-                //Unknown user
-                entity.LastModifierUserId = null;
                 return;
             }
+
+            var entity = entityAsObj.As<IModificationAudited>();
 
             if (multiTenancyConfig?.IsEnabled == true)
             {
@@ -121,12 +120,6 @@ namespace Abp.Domain.Entities.Auditing
                     entity.LastModifierUserId = null;
                     return;
                 }
-            }
-
-            var lastModifierUserIdFilter = auditFields?.FirstOrDefault(e => e.FieldName == AbpAuditFields.LastModifierUserId);
-            if (lastModifierUserIdFilter != null && !lastModifierUserIdFilter.IsSavingEnabled)
-            {
-                return;
             }
 
             //Finally, set LastModifierUserId!


### PR DESCRIPTION
Resolves #7111 

In the SetModificationAuditProperties method of EntityAuditingHelper, setting LastModifierUserId to null if UserId is null has been removed because it is set based on unconditional userId. Here, LastModifierUserId filter control was given priority because when the LastModifierUserId filter was disabled, LastModifierUserId was set to null. Thus, when the filter is disabled, this property will not change.