### PR TITLE
Use SqlFragmentExpression instead of SqlConstantExpression in ModelBuilderExtensions

### DIFF
--- a/src/Abp.EntityFrameworkCore/EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Abp.EntityFrameworkCore/EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -12,7 +12,6 @@ public static class ModelBuilderExtensions
         modelBuilder.HasDbFunction(methodInfo)
             .HasTranslation(args =>
             {
-                // (bool isDeleted, bool boolParam)
                 var isDeleted = args[0];
                 var boolParam = args[1];
 
@@ -22,13 +21,18 @@ public static class ModelBuilderExtensions
                     return new SqlBinaryExpression(
                         ExpressionType.Equal,
                         isDeleted,
-                        new SqlFragmentExpression("0"),
-                        boolParam.Type,
-                        boolParam.TypeMapping);
+                        new SqlConstantExpression(false, isDeleted.TypeMapping),
+                        isDeleted.Type,
+                        isDeleted.TypeMapping);
                 }
 
                 // empty where sql
-                return new SqlFragmentExpression("1=1");
+                return new SqlBinaryExpression(
+                    ExpressionType.Equal,
+                    new SqlConstantExpression(true, boolParam.TypeMapping),
+                    new SqlConstantExpression(true, boolParam.TypeMapping),
+                    boolParam.Type,
+                    boolParam.TypeMapping);
             });
 
         return modelBuilder;
@@ -39,24 +43,26 @@ public static class ModelBuilderExtensions
         modelBuilder.HasDbFunction(methodInfo)
             .HasTranslation(args =>
             {
-                // (int? tenantId, int? currentTenantId, bool boolParam)
                 var tenantId = args[0];
                 var currentTenantId = args[1];
                 var boolParam = args[2];
 
                 if (abpEfCoreCurrentDbContext.Context?.IsMayHaveTenantFilterEnabled == true)
                 {
-                    // TenantId == CurrentTenantId
                     return new SqlBinaryExpression(
                         ExpressionType.Equal,
                         tenantId,
                         currentTenantId,
-                        boolParam.Type,
-                        boolParam.TypeMapping);
+                        tenantId.Type,
+                        tenantId.TypeMapping);
                 }
 
-                // empty where sql
-                return new SqlFragmentExpression("1=1");
+                return new SqlBinaryExpression(
+                    ExpressionType.Equal,
+                    new SqlConstantExpression(true, boolParam.TypeMapping),
+                    new SqlConstantExpression(true, boolParam.TypeMapping),
+                    boolParam.Type,
+                    boolParam.TypeMapping);
             });
 
         return modelBuilder;
@@ -67,24 +73,26 @@ public static class ModelBuilderExtensions
         modelBuilder.HasDbFunction(methodInfo)
             .HasTranslation(args =>
             {
-                // (int tenantId, int? currentTenantId, bool boolParam)
                 var tenantId = args[0];
                 var currentTenantId = args[1];
                 var boolParam = args[2];
 
                 if (abpEfCoreCurrentDbContext.Context?.IsMustHaveTenantFilterEnabled == true)
                 {
-                    // TenantId == CurrentTenantId
                     return new SqlBinaryExpression(
                         ExpressionType.Equal,
                         tenantId,
                         currentTenantId,
-                        boolParam.Type,
-                        boolParam.TypeMapping);
+                        tenantId.Type,
+                        tenantId.TypeMapping);
                 }
 
-                // empty where sql
-                return new SqlFragmentExpression("1=1");
+                return new SqlBinaryExpression(
+                    ExpressionType.Equal,
+                    new SqlConstantExpression(true, boolParam.TypeMapping),
+                    new SqlConstantExpression(true, boolParam.TypeMapping),
+                    boolParam.Type,
+                    boolParam.TypeMapping);
             });
 
         return modelBuilder;

--- a/src/Abp.EntityFrameworkCore/EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Abp.EntityFrameworkCore/EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -22,13 +22,13 @@ public static class ModelBuilderExtensions
                     return new SqlBinaryExpression(
                         ExpressionType.Equal,
                         isDeleted,
-                        new SqlConstantExpression(Expression.Constant(false), boolParam.TypeMapping),
+                        new SqlFragmentExpression("0"),
                         boolParam.Type,
                         boolParam.TypeMapping);
                 }
 
                 // empty where sql
-                return new SqlConstantExpression(Expression.Constant(true), boolParam.TypeMapping);
+                return new SqlFragmentExpression("1=1");
             });
 
         return modelBuilder;
@@ -56,7 +56,7 @@ public static class ModelBuilderExtensions
                 }
 
                 // empty where sql
-                return new SqlConstantExpression(Expression.Constant(true), boolParam.TypeMapping);
+                return new SqlFragmentExpression("1=1");
             });
 
         return modelBuilder;
@@ -84,7 +84,7 @@ public static class ModelBuilderExtensions
                 }
 
                 // empty where sql
-                return new SqlConstantExpression(Expression.Constant(true), boolParam.TypeMapping);
+                return new SqlFragmentExpression("1=1");
             });
 
         return modelBuilder;


### PR DESCRIPTION
resolves https://github.com/aspnetzero/aspnet-zero-core/issues/5651

Sometimes EF Core wrongly optimizes generated query when `Configuration.Modules.AbpEfCore().UseAbpQueryCompiler` is set to true. So, this PR fixes that problem.

For example, if we create a new project on https://aspnetboilerplate.com/Templates and set `Configuration.Modules.AbpEfCore().UseAbpQueryCompiler = true`, app throws an exception "No Language defined" because a query similar to one below is generated;

```SQL
SELECT * FROM AbpLanguages
WHERE 0 = 1
```

This happens becasue below statement is translated to `0 = 1` which is defined in ModelBuilderExtensions.cs.

````csharp
return new SqlBinaryExpression(
                        ExpressionType.Equal,
                        isDeleted,
                        new SqlFragmentExpression("0"),
                        boolParam.Type,
                        boolParam.TypeMapping);
````