### PR TITLE
Allow manual cross tenant LastModifierUserId assignment

### DIFF
--- a/src/Abp/Domain/Entities/Auditing/EntityAuditingHelper.cs
+++ b/src/Abp/Domain/Entities/Auditing/EntityAuditingHelper.cs
@@ -103,6 +103,11 @@ namespace Abp.Domain.Entities.Auditing
             }
 
             var entity = entityAsObj.As<IModificationAudited>();
+            if (entity.LastModifierUserId != null)
+            {
+                // LastModifierUserId is already set
+                return;
+            }
 
             if (multiTenancyConfig?.IsEnabled == true)
             {


### PR DESCRIPTION
Resolves #7058 

Modified SetModificationAuditProperties to include an early return if LastModifierUserId is already populated. This ensures the manually set value is preserved, bypassing the multi-tenancy logic that would previously nullify it.