### PR TITLE
remove Microsoft.VisualStudio.Web.CodeGeneration.Design's files

### DIFF
--- a/src/Abp/Abp.csproj
+++ b/src/Abp/Abp.csproj
@@ -26,7 +26,9 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
+	<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0">
+		<PrivateAssets>all</PrivateAssets>
+	</PackageReference>
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Abp/SequentialGuidGenerator.cs
+++ b/src/Abp/SequentialGuidGenerator.cs
@@ -150,7 +150,7 @@ namespace Abp
 
             /// <summary>
             /// The GUID should be sequential when formatted using the
-            /// <see cref="Guid.ToByteArray" /> method.
+            /// <see cref="Guid.ToByteArray()" /> method.
             /// </summary>
             SequentialAsBinary,
 


### PR DESCRIPTION
Starting from version 10.0, files from Microsoft.VisualStudio.Web.CodeGeneration.Design are being dumped into the output directory. These appear to be files that are not needed at runtime.
Additionally, the NuGet warning about problematic or deprecated libraries has disappeared.