### PR TITLE
Allow changing HeaderName of AbpLocalizationHeaderRequestCultureProvider

### DIFF
--- a/src/Abp.AspNetCore/AspNetCore/Localization/AbpLocalizationHeaderRequestCultureProvider.cs
+++ b/src/Abp.AspNetCore/AspNetCore/Localization/AbpLocalizationHeaderRequestCultureProvider.cs
@@ -25,7 +25,7 @@ public class AbpLocalizationHeaderRequestCultureProvider : RequestCultureProvide
     /// The name of the header that contains the user's preferred culture information.
     /// Defaults to <see cref="CookieRequestCultureProvider.DefaultCookieName"/>.
     /// </summary>
-    public string HeaderName { get; set; } = CookieRequestCultureProvider.DefaultCookieName;
+    public static string HeaderName { get; set; } = ".AspNetCore.Culture";
 
     public AbpLocalizationHeaderRequestCultureProvider()
     {

--- a/test/Abp.AspNetCore.Tests/App/AppModule.cs
+++ b/test/Abp.AspNetCore.Tests/App/AppModule.cs
@@ -4,6 +4,7 @@ using Abp.AspNetCore.TestBase;
 using Abp.Configuration.Startup;
 using Abp.Modules;
 using Abp.AspNetCore.Configuration;
+using Abp.AspNetCore.Localization;
 using Abp.AspNetCore.Mocks;
 using Abp.Auditing;
 using Abp.Configuration;
@@ -43,6 +44,8 @@ public class AppModule : AbpModule
         });
 
         Configuration.Modules.AbpWebCommon().WrapResultFilters.Add(new CustomWrapResultFilter());
+        
+        AbpLocalizationHeaderRequestCultureProvider.HeaderName = "X-AspNetCore-Culture";
     }
 
     public override void Initialize()

--- a/test/Abp.AspNetCore.Tests/App/Controllers/LocalizationTestController.cs
+++ b/test/Abp.AspNetCore.Tests/App/Controllers/LocalizationTestController.cs
@@ -1,0 +1,12 @@
+using Abp.AspNetCore.Localization;
+using Abp.AspNetCore.Mvc.Controllers;
+
+namespace Abp.AspNetCore.App.Controllers;
+
+public class LocalizationTestController : AbpController
+{
+    public string GetAbpLocalizationHeaderRequestCultureProviderHeaderName()
+    {
+        return AbpLocalizationHeaderRequestCultureProvider.HeaderName;
+    }
+}

--- a/test/Abp.AspNetCore.Tests/Tests/AbpLocalizationController_Tests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/AbpLocalizationController_Tests.cs
@@ -1,7 +1,10 @@
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Abp.AspNetCore.App.Controllers;
+using Abp.AspNetCore.Localization;
 using Abp.AspNetCore.Mvc.Controllers;
+using Abp.Web.Models;
 using Shouldly;
 using Xunit;
 
@@ -95,5 +98,18 @@ public class AbpLocalizationControllerTests : AppTestBase
         // Assert
         response.Headers.Location.IsAbsoluteUri.ShouldBeFalse();
         response.Headers.Location.ToString().ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task Should_Change_AbpLocalizationHeaderRequestCultureProvider_HeaderName()
+    {
+        // Act
+        var response = await GetResponseAsObjectAsync<AjaxResponse<string>>(
+            GetUrl<LocalizationTestController>(
+                nameof(LocalizationTestController.GetAbpLocalizationHeaderRequestCultureProviderHeaderName)
+            )
+        );
+        
+        response.Result.ShouldBe("X-AspNetCore-Culture");
     }
 }

--- a/test/Abp.AspNetCore.Tests/Tests/SimpleTestControllerTests.cs
+++ b/test/Abp.AspNetCore.Tests/Tests/SimpleTestControllerTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Abp.AspNetCore.App.Controllers;
 using Abp.AspNetCore.App.Models;
+using Abp.AspNetCore.Localization;
 using Abp.Events.Bus;
 using Abp.Events.Bus.Exceptions;
 using Abp.UI;
@@ -202,7 +203,7 @@ public class SimpleTestControllerTests : AppTestBase
     public async Task AbpLocalizationHeaderRequestCultureProvider_Test()
     {
         //Arrange
-        Client.DefaultRequestHeaders.Add(CookieRequestCultureProvider.DefaultCookieName, "c=it|uic=it");
+        Client.DefaultRequestHeaders.Add(AbpLocalizationHeaderRequestCultureProvider.HeaderName, "c=it|uic=it");
 
         var culture = await GetResponseAsStringAsync(
                 GetUrl<SimpleTestController>(


### PR DESCRIPTION
resolves #7163 

Also, this is implemented on Angular side, see https://github.com/aspnetboilerplate/abp-ng2-module/commit/a4f4f684bfd240448c775c1fe9e0f05bcca753ae